### PR TITLE
docs: add tokf.net website reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Config-driven CLI tool that compresses command output before it reaches an LLM context"
 license = "MIT"
 repository = "https://github.com/mpecan/tokf"
-homepage = "https://github.com/mpecan/tokf"
+homepage = "https://tokf.net"
 keywords = ["llm", "cli", "filter", "output", "tokens"]
 categories = ["command-line-utilities", "development-tools"]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tokf
 
-**Token filter** — a config-driven CLI that compresses command output before it reaches an LLM context.
+**[tokf.net](https://tokf.net)** — a config-driven CLI that compresses command output before it reaches an LLM context.
 
 Commands like `git push`, `cargo test`, or `docker build` produce verbose output full of progress bars, compile noise, and boilerplate. tokf intercepts that output, applies a TOML filter, and emits only what matters. Less context consumed, cleaner signal for the model.
 


### PR DESCRIPTION
## Summary

- Updates `Cargo.toml` `homepage` from the GitHub repo URL to `https://tokf.net`
- Updates the README header to link to `https://tokf.net`
- GitHub repo website field already updated via API

## Test plan

- [ ] Verify `cargo metadata` shows the correct homepage
- [ ] Verify README renders the link correctly