### PR TITLE
docs: credit rtk as inspiration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ tokf gain --json       # machine-readable output
 
 ---
 
+## Acknowledgements
+
+tokf was heavily inspired by [rtk](https://github.com/rtk-ai/rtk) ([rtk-ai.app](https://www.rtk-ai.app/)) — a CLI proxy that compresses command output before it reaches an AI agent's context window. rtk pioneered the idea and demonstrated that 60–90% context reduction is achievable across common dev tools. tokf takes a different approach (TOML-driven filters, user-overridable library, Claude Code hook integration) but the core insight is theirs.
+
+---
+
 ## License
 
 MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Adds an Acknowledgements section to the README crediting [rtk](https://github.com/rtk-ai/rtk) ([rtk-ai.app](https://www.rtk-ai.app/)) as the project that inspired tokf. Briefly describes what rtk does and how tokf's approach differs.

## Test plan

- [ ] Verify links render correctly in the GitHub README preview