### PR TITLE
chore: add Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "schedule": ["before 6am on monday"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Group all GitHub Actions updates together",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "description": "Automerge Cargo patch updates",
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "description": "Group Cargo minor updates into one PR",
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["minor"],
+      "groupName": "Cargo dependencies (minor)"
+    },
+    {
+      "description": "Major updates always get individual PRs",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ],
+  "rust": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.github/renovate.json` to enable automated dependency updates.

**Schedule**: Monday before 6am (one batch per week, not constant noise).

**Update strategy**:
| Type | Behaviour |
|---|---|
| Cargo patch | Automerge when CI passes |
| Cargo minor | Grouped into one PR for review |
| Cargo major | Individual PR, no automerge |
| GitHub Actions | Grouped, automerge when CI passes |

**Next step**: install the [Renovate GitHub App](https://github.com/apps/renovate) on the `mpecan/tokf` repository to activate it. The config will be picked up automatically on first run.

## Test plan

- [ ] Install Renovate app on the repo
- [ ] Confirm Renovate opens its onboarding PR (or skips straight to dependency PRs since config already exists)