### PR TITLE
fix(ci): use macos-14 runner for x86_64-apple-darwin cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           - target: aarch64-apple-darwin
             runner: macos-14
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-14
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Replaces the retired `macos-13` runner with `macos-14` (Apple Silicon) for the `x86_64-apple-darwin` build target
- The Xcode toolchain on Apple Silicon natively supports cross-compilation to x86_64, so no extra tooling is needed

## Test plan

- [ ] Verify the `Build x86_64-apple-darwin` job completes successfully on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)