### PR TITLE
fix(ci): explicitly add rustup target before cross-compiling x86_64-apple-darwin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
+
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
 


### PR DESCRIPTION
## Summary

Both macOS build jobs now share the `macos-14` runner. The `aarch64-apple-darwin` job can prime the Rust cache without the `x86_64-apple-darwin` target installed. When the x86_64 job restores that cache, `rustup` skips target installation and the build fails with `can't find crate for std`.

Adding an explicit `rustup target add` step after cache restore ensures the target is always present regardless of cache state.

## Test plan

- [ ] Verify `Build x86_64-apple-darwin` completes successfully on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)