### PR TITLE
feat(filter): add docker build and compose filters

### DIFF
--- a/filters/docker/build.toml
+++ b/filters/docker/build.toml
@@ -1,0 +1,17 @@
+command = ["docker build", "docker buildx build"]
+skip = [
+  "^ +=> +=> [a-z]",      # Skip transferring, fetching, extracting
+  "^ +=> +\\[internal\\]", # Skip metadata loading (noise)
+  "^Sending build context",
+]
+
+[on_success]
+skip = [
+  "^ +=> +\\[[0-9/]+\\]", # Skip routine steps like [1/5]
+  "^Step [0-9/]+ : ",      # Skip legacy step headers
+  "^ ---> [0-9a-f]+",      # Skip legacy hash markers
+  "^ ---> Using cache",   # Skip legacy cache messages
+]
+
+[on_failure]
+tail = 50

--- a/filters/docker/compose.toml
+++ b/filters/docker/compose.toml
@@ -1,0 +1,22 @@
+command = ["docker compose", "docker-compose"]
+skip = [
+  "^ +⠿ (Network|Container|Volume|Config|Secret) .* (Created|Starting|Started|Healthy)",
+  "^Attaching to ",
+]
+keep = [
+  "(?i)error",
+  "(?i)fatal",
+  "(?i)warn",
+  "(?i)panic",
+  "(?i)health check",
+  "(?i)ready",
+  "(?i)started",
+  "(?i)listening",
+  "(?i)failed",
+  "(?i)critical",
+  "(?i)exception",
+  "\\[\\+\\] Running",
+]
+
+[on_failure]
+tail = 100

--- a/tests/config_resolution.rs
+++ b/tests/config_resolution.rs
@@ -27,13 +27,13 @@ fn test_discover_git_push_from_stdlib() {
 fn test_all_stdlib_filters_load() {
     let dirs = vec![stdlib_dir()];
     let filters = config::discover_all_filters(&dirs).unwrap();
-    // 27 stdlib filters: git/(add,commit,diff,log,push,show,status), cargo/(build,check,clippy,install,test),
+    // 29 stdlib filters: git/(add,commit,diff,log,push,show,status), cargo/(build,check,clippy,install,test),
     // ls, npm/run, pnpm/(add,install), go/(build,vet), pytest, tsc,
-    // docker/(images,ps), kubectl/get, gh/(issue,pr), next/build, prisma/generate
+    // docker/(build,compose,images,ps), kubectl/get, gh/(issue,pr), next/build, prisma/generate
     assert_eq!(
         filters.len(),
-        27,
-        "expected 27 stdlib filters, got {}",
+        29,
+        "expected 29 stdlib filters, got {}",
         filters.len()
     );
 }

--- a/tests/filter_docker_build.rs
+++ b/tests/filter_docker_build.rs
@@ -1,0 +1,56 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use tokf::config::types::FilterConfig;
+use tokf::filter;
+use tokf::runner::CommandResult;
+
+fn load_config() -> FilterConfig {
+    let path = format!("{}/filters/docker/build.toml", env!("CARGO_MANIFEST_DIR"));
+    let content = std::fs::read_to_string(&path).unwrap();
+    toml::from_str(&content).unwrap()
+}
+
+fn load_fixture(name: &str) -> String {
+    let path = format!(
+        "{}/tests/fixtures/docker/{name}",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    std::fs::read_to_string(&path)
+        .unwrap()
+        .trim_end()
+        .to_string()
+}
+
+fn make_result(fixture: &str, exit_code: i32) -> CommandResult {
+    CommandResult {
+        stdout: String::new(),
+        stderr: String::new(),
+        exit_code,
+        combined: fixture.to_string(),
+    }
+}
+
+#[test]
+fn docker_build_success_shows_cached_and_finished() {
+    let config = load_config();
+    let fixture = load_fixture("build-success.txt");
+    let result = make_result(&fixture, 0);
+    let filtered = filter::apply(&config, &result, &[]);
+
+    assert!(filtered.output.contains("FINISHED"));
+    assert!(filtered.output.contains("CACHED"));
+    assert!(!filtered.output.contains("transferring"));
+    assert!(!filtered.output.contains("[internal]"));
+}
+
+#[test]
+fn docker_build_failure_shows_error() {
+    let config = load_config();
+    let fixture = load_fixture("build-failure.txt");
+    let result = make_result(&fixture, 1);
+    let filtered = filter::apply(&config, &result, &[]);
+
+    assert!(filtered.output.contains("ERROR"));
+    assert!(filtered.output.contains("Unable to locate package nodejss"));
+    assert!(!filtered.output.contains("transferring"));
+}

--- a/tests/filter_docker_compose.rs
+++ b/tests/filter_docker_compose.rs
@@ -1,0 +1,49 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use tokf::config::types::FilterConfig;
+use tokf::filter;
+use tokf::runner::CommandResult;
+
+fn load_config() -> FilterConfig {
+    let path = format!("{}/filters/docker/compose.toml", env!("CARGO_MANIFEST_DIR"));
+    let content = std::fs::read_to_string(&path).unwrap();
+    toml::from_str(&content).unwrap()
+}
+
+fn load_fixture(name: &str) -> String {
+    let path = format!(
+        "{}/tests/fixtures/docker/{name}",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    std::fs::read_to_string(&path)
+        .unwrap()
+        .trim_end()
+        .to_string()
+}
+
+fn make_result(fixture: &str, exit_code: i32) -> CommandResult {
+    CommandResult {
+        stdout: String::new(),
+        stderr: String::new(),
+        exit_code,
+        combined: fixture.to_string(),
+    }
+}
+
+#[test]
+fn docker_compose_startup_shows_errors_and_ready() {
+    let config = load_config();
+    let fixture = load_fixture("compose-startup.txt");
+    let result = make_result(&fixture, 0);
+    let filtered = filter::apply(&config, &result, &[]);
+
+    assert!(filtered.output.contains("ERROR"));
+    assert!(
+        filtered
+            .output
+            .contains("database system is ready to accept connections")
+    );
+    assert!(filtered.output.contains("Ready on http://localhost:3000"));
+    assert!(!filtered.output.contains("⠿ Network"));
+    assert!(!filtered.output.contains("⠿ Container"));
+}

--- a/tests/fixtures/docker/build-failure.txt
+++ b/tests/fixtures/docker/build-failure.txt
@@ -1,0 +1,32 @@
+[+] Building 4.5s (8/12)
+ => [internal] load build definition from Dockerfile                       0.0s
+ => => transferring dockerfile: 37B                                        0.0s
+ => [internal] load .dockerignore                                          0.0s
+ => => transferring context: 2B                                            0.0s
+ => [internal] load metadata for docker.io/library/ubuntu:22.04            0.4s
+ => [1/5] FROM docker.io/library/ubuntu:22.04@sha256:ed15...              0.0s
+ => CACHED [2/5] RUN apt-get update                                        0.0s
+ => [3/5] RUN apt-get install -y --no-install-recommends curl git         4.1s
+ => => # Get:1 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
+ => => # Get:2 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]
+ => => # Get:3 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [109 kB]
+ => => # Get:4 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]
+ => => # Fetching...
+ => => # Extracting...
+ => [4/5] RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -      0.2s
+ => ERROR [5/5] RUN apt-get install -y nodejss                             0.1s
+------
+ > [5/5] RUN apt-get install -y nodejss:
+#0 0.123 Reading package lists...
+#0 0.456 Building dependency tree...
+#0 0.789 Reading state information...
+#0 0.901 E: Unable to locate package nodejss
+------
+Dockerfile:12
+--------------------
+  10 |     RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
+  11 |     
+  12 | >>> RUN apt-get install -y nodejss
+  13 |     
+--------------------
+ERROR: failed to solve: process "/bin/sh -c apt-get install -y nodejss" did not complete successfully: exit code: 100

--- a/tests/fixtures/docker/build-success.txt
+++ b/tests/fixtures/docker/build-success.txt
@@ -1,0 +1,34 @@
+[+] Building 1.2s (12/12) FINISHED
+ => [internal] load build definition from Dockerfile                       0.0s
+ => => transferring dockerfile: 37B                                        0.0s
+ => [internal] load .dockerignore                                          0.0s
+ => => transferring context: 2B                                            0.0s
+ => [internal] load metadata for docker.io/library/node:18-alpine          0.5s
+ => [base 1/2] FROM docker.io/library/node:18-alpine@sha256:c7c2...        0.0s
+ => CACHED [base 2/2] WORKDIR /app                                         0.0s
+ => CACHED [deps 1/2] COPY package.json package-lock.json ./               0.0s
+ => CACHED [deps 2/2] RUN npm ci                                           0.0s
+ => CACHED [build 1/2] COPY . .                                            0.0s
+ => CACHED [build 2/2] RUN npm run build                                   0.0s
+ => [final 1/2] COPY --from=build /app/dist /usr/share/nginx/html          0.1s
+ => [final 2/2] EXPOSE 80                                                  0.0s
+ => exporting to image                                                     0.1s
+ => => exporting layers                                                    0.1s
+ => => writing image sha256:d5f...                                         0.0s
+ => => naming to docker.io/library/myapp:latest                            0.0s
+
+# Legacy (non-BuildKit) output
+Sending build context to Docker daemon  2.048kB
+Step 1/10 : FROM node:18-alpine
+ ---> c7c2...
+Step 2/10 : WORKDIR /app
+ ---> Using cache
+ ---> d5f...
+Step 3/10 : COPY package.json package-lock.json ./
+ ---> Using cache
+ ---> a1b...
+Step 4/10 : RUN npm ci
+ ---> Using cache
+ ---> f2e...
+Successfully built f2e...
+Successfully tagged myapp:latest

--- a/tests/fixtures/docker/compose-startup.txt
+++ b/tests/fixtures/docker/compose-startup.txt
@@ -1,0 +1,20 @@
+[+] Running 4/4
+ ⠿ Network app_default        Created                                      0.1s
+ ⠿ Container app-db-1         Created                                      0.1s
+ ⠿ Container app-api-1        Created                                      0.1s
+ ⠿ Container app-web-1        Created                                      0.1s
+Attaching to app-db-1, app-api-1, app-web-1
+app-db-1   | 2026-02-19 18:12:34.123 UTC [1] LOG:  starting PostgreSQL 15.1...
+app-api-1  | 
+app-api-1  | > api@1.0.0 start
+app-api-1  | > node dist/main.js
+app-api-1  | 
+app-db-1   | 2026-02-19 18:12:34.456 UTC [1] LOG:  database system is ready to accept connections
+app-web-1  | 18:12:35 [info] Starting development server...
+app-api-1  | [Nest] 1  - 02/19/2026, 6:12:35 PM     LOG [NestFactory] Starting Nest application...
+app-web-1  | 18:12:36 [info] Ready on http://localhost:3000
+app-api-1  | [Nest] 1  - 02/19/2026, 6:12:36 PM     LOG [RoutesResolver] AppController {/}: +1ms
+app-api-1  | [Nest] 1  - 02/19/2026, 6:12:36 PM   ERROR [ExceptionsHandler] Connection refused: localhost:5432
+app-api-1  | Error: Connection refused
+app-api-1  |     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1494:16)
+app-web-1  | 18:12:37 [warn] API connection failed, retrying...


### PR DESCRIPTION
This PR expands the Docker filter library to include docker build and docker compose (up/logs). These are currently the most verbose Docker operations and represent a significant portion of context-window noise in AI-assisted development.

Technical Changes

1. Docker Build Filter (docker/build.toml)

- Implements progressive noise reduction for both BuildKit and Legacy builders.
- Signal Preservation: Whitelists CACHED markers and FINISHED summaries.
- Fail-Safe Behavior: Step headers are hidden on success but preserved on failure to maintain diagnostic context.
- Noise Stripping: Removes transfer, fetch, and extraction progress logs.

2. Docker Compose Filter (docker/compose.toml)

- Signal-Forward Approach: Uses a case-insensitive whitelist for critical log levels (ERROR, WARN, FATAL, panic) and service readiness markers (Ready, Started, Listening).
- Cleaning: Strips container/network lifecycle boilerplate while preserving service name prefixes for clear log attribution.

3. Integration & Testing

- New Tests: Added tests/filter_docker_build.rs and tests/filter_docker_compose.rs.
- Fixtures: Added realistic success/failure samples in tests/fixtures/docker/.
- Consistency: Updated tests/config_resolution.rs to reflect the expanded internal filter library (total count updated to 29).

Verification Results

- cargo test: All tests passing, including new Docker integration tests.
- cargo clippy -- -D warnings: Passed.
- cargo fmt -- --check: Passed.