### PR TITLE
fix(cli): add --version flag to tokf

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use tokf::tracking;
 #[derive(Parser)]
 #[command(
     name = "tokf",
+    version,
     about = "Token filter — compress command output for LLM context"
 )]
 #[allow(clippy::struct_excessive_bools)] // CLI flags are naturally booleans


### PR DESCRIPTION
## Summary

- Adds `version` to the clap `#[command]` macro so `tokf --version` prints the package version instead of erroring

## Root cause

The `#[command]` derive macro had no `version` attribute, so clap had no version to display and returned an error.

## Test plan

- [x] `tokf --version` prints `tokf 0.1.5`
- [x] All 649 existing tests pass

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)