### PR TITLE
test(filter): add verify suites for cargo/check and cargo/install

### DIFF
--- a/filters/cargo/check_test/failure.toml
+++ b/filters/cargo/check_test/failure.toml
@@ -1,0 +1,6 @@
+name = "type error shows compiler output"
+fixture = "failure.txt"
+exit_code = 1
+
+[[expect]]
+contains = "error[E"

--- a/filters/cargo/check_test/failure.txt
+++ b/filters/cargo/check_test/failure.txt
@@ -1,0 +1,10 @@
+error[E0308]: mismatched types
+  --> src/main.rs:42:20
+   |
+42 |     let x: i32 = "hello";
+   |            ---   ^^^^^^^ expected `i32`, found `&str`
+   |            |
+   |            expected due to this
+
+For more information about this error, try `rustc --explain E0308`.
+error: could not compile `tokf` (bin "tokf") due to 1 previous error

--- a/filters/cargo/check_test/success.toml
+++ b/filters/cargo/check_test/success.toml
@@ -1,0 +1,6 @@
+name = "successful check collapses to single line"
+inline = "   Checking tokf v0.1.7 (/home/user/tokf)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.45s"
+exit_code = 0
+
+[[expect]]
+equals = "✓ cargo check: ok"

--- a/filters/cargo/install_test/failure.toml
+++ b/filters/cargo/install_test/failure.toml
@@ -1,0 +1,6 @@
+name = "installation failure shows error tail"
+fixture = "failure.txt"
+exit_code = 101
+
+[[expect]]
+contains = "error"

--- a/filters/cargo/install_test/failure.txt
+++ b/filters/cargo/install_test/failure.txt
@@ -1,0 +1,3 @@
+    Updating crates.io index
+  Downloading crates ...
+error: could not find `Cargo.toml` in `/tmp` or any parent directory

--- a/filters/cargo/install_test/success.toml
+++ b/filters/cargo/install_test/success.toml
@@ -1,0 +1,6 @@
+name = "successful install shows installed package line"
+fixture = "success.txt"
+exit_code = 0
+
+[[expect]]
+contains = "Installed package"

--- a/filters/cargo/install_test/success.txt
+++ b/filters/cargo/install_test/success.txt
@@ -1,0 +1,7 @@
+    Updating crates.io index
+  Downloading crates ...
+  Downloaded ripgrep v14.1.0
+   Compiling memchr v2.7.1
+   Compiling ripgrep v14.1.0
+    Installing ripgrep v14.1.0
+     Installed package `ripgrep v14.1.0` at /home/user/.cargo/bin/rg


### PR DESCRIPTION
Add declarative verify suites for the two remaining untested cargo filters.

- `cargo/check_test/` — success (collapses to single line) + type error failure
- `cargo/install_test/` — successful install + download error failure

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)