### PR TITLE
test(filter): add verify suites for docker/images and docker/ps

### DIFF
--- a/filters/docker/images_test/failure.toml
+++ b/filters/docker/images_test/failure.toml
@@ -1,0 +1,6 @@
+name = "daemon error shows tail"
+inline = "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"
+exit_code = 1
+
+[[expect]]
+contains = "Cannot connect"

--- a/filters/docker/images_test/success.toml
+++ b/filters/docker/images_test/success.toml
@@ -1,0 +1,9 @@
+name = "image list passes through"
+fixture = "success.txt"
+exit_code = 0
+
+[[expect]]
+contains = "REPOSITORY"
+
+[[expect]]
+contains = "nginx"

--- a/filters/docker/images_test/success.txt
+++ b/filters/docker/images_test/success.txt
@@ -1,0 +1,4 @@
+REPOSITORY          TAG       IMAGE ID       CREATED         SIZE
+ubuntu              22.04     1234567890ab   2 weeks ago     77.8MB
+nginx               latest    abcdef123456   3 weeks ago     187MB
+postgres            15        fedcba654321   1 month ago     412MB

--- a/filters/docker/ps_test/empty.toml
+++ b/filters/docker/ps_test/empty.toml
@@ -1,0 +1,9 @@
+name = "no running containers shows header only"
+inline = "CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES"
+exit_code = 0
+
+[[expect]]
+contains = "CONTAINER ID"
+
+[[expect]]
+not_contains = "Up"

--- a/filters/docker/ps_test/failure.toml
+++ b/filters/docker/ps_test/failure.toml
@@ -1,0 +1,6 @@
+name = "daemon error shows tail"
+inline = "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"
+exit_code = 1
+
+[[expect]]
+contains = "Cannot connect"

--- a/filters/docker/ps_test/success.toml
+++ b/filters/docker/ps_test/success.toml
@@ -1,0 +1,9 @@
+name = "running containers pass through"
+fixture = "success.txt"
+exit_code = 0
+
+[[expect]]
+contains = "CONTAINER ID"
+
+[[expect]]
+contains = "nginx"

--- a/filters/docker/ps_test/success.txt
+++ b/filters/docker/ps_test/success.txt
@@ -1,0 +1,3 @@
+CONTAINER ID   IMAGE     COMMAND                  CREATED         STATUS         PORTS                    NAMES
+a1b2c3d4e5f6   nginx     "/docker-entrypoint.…"   2 hours ago     Up 2 hours     0.0.0.0:80->80/tcp       webserver
+b2c3d4e5f6a1   postgres  "docker-entrypoint.s…"   3 hours ago     Up 3 hours     0.0.0.0:5432->5432/tcp   db


### PR DESCRIPTION
Add declarative verify suites for docker list filters.

- `docker/images_test/` — image list passthrough + daemon error
- `docker/ps_test/` — running containers, empty list, daemon error

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)