### PR TITLE
test(filter): add verify suites for gh/issue, gh/pr, and git/show

### DIFF
--- a/filters/gh/issue_test/failure.toml
+++ b/filters/gh/issue_test/failure.toml
@@ -1,0 +1,6 @@
+name = "auth error shows tail"
+inline = "To get started with GitHub CLI, please run:  gh auth login\nAlternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token."
+exit_code = 4
+
+[[expect]]
+contains = "gh auth login"

--- a/filters/gh/issue_test/success.toml
+++ b/filters/gh/issue_test/success.toml
@@ -1,0 +1,9 @@
+name = "issue list passes through"
+fixture = "success.txt"
+exit_code = 0
+
+[[expect]]
+contains = "#"
+
+[[expect]]
+contains = "bug"

--- a/filters/gh/issue_test/success.txt
+++ b/filters/gh/issue_test/success.txt
@@ -1,0 +1,3 @@
+#42	Bug: memory leak in filter engine	OPEN	bug	about 2 days ago
+#38	feat: add JSON output mode	OPEN	enhancement	about 5 days ago
+#35	docs: improve README examples	CLOSED	docs	about 1 week ago

--- a/filters/gh/pr_test/failure.toml
+++ b/filters/gh/pr_test/failure.toml
@@ -1,0 +1,6 @@
+name = "auth error shows tail"
+inline = "To get started with GitHub CLI, please run:  gh auth login\nAlternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token."
+exit_code = 4
+
+[[expect]]
+contains = "gh auth login"

--- a/filters/gh/pr_test/success.toml
+++ b/filters/gh/pr_test/success.toml
@@ -1,0 +1,9 @@
+name = "PR list passes through"
+fixture = "success.txt"
+exit_code = 0
+
+[[expect]]
+contains = "#"
+
+[[expect]]
+contains = "OPEN"

--- a/filters/gh/pr_test/success.txt
+++ b/filters/gh/pr_test/success.txt
@@ -1,0 +1,3 @@
+#69	refactor: replace Rust filter tests with declarative verify suites	OPEN	about 2 hours ago
+#67	feat: add pnpm support	OPEN	about 1 day ago
+#61	feat: add tokf verify command	MERGED	about 3 days ago

--- a/filters/git/show_test/failure.toml
+++ b/filters/git/show_test/failure.toml
@@ -1,0 +1,6 @@
+name = "bad revision shows fatal error"
+inline = "fatal: bad object 'nonexistent'\nfatal: the remote end hung up unexpectedly"
+exit_code = 128
+
+[[expect]]
+contains = "fatal:"

--- a/filters/git/show_test/success.toml
+++ b/filters/git/show_test/success.toml
@@ -1,0 +1,6 @@
+name = "commit stat passes through unchanged"
+fixture = "success.txt"
+exit_code = 0
+
+[[expect]]
+contains = "file changed"

--- a/filters/git/show_test/success.txt
+++ b/filters/git/show_test/success.txt
@@ -1,0 +1,8 @@
+commit a1b2c3d4e5f6789012345678901234567890abcd
+Author: User <user@example.com>
+Date:   Fri Feb 20 12:00:00 2026 +0100
+
+    feat(filter): add new filter
+
+ src/filter/mod.rs | 10 ++++++++++
+ 1 file changed, 10 insertions(+), 0 deletions(-)


### PR DESCRIPTION
Add declarative verify suites for GitHub CLI and git show filters.

- `gh/issue_test/` — issue list passthrough + auth error
- `gh/pr_test/` — PR list passthrough + auth error
- `git/show_test/` — commit stat passthrough + bad revision error

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)