### PR TITLE
test(filter): add verify suites for go/build, go/vet, and kubectl/get

### DIFF
--- a/filters/go/build_test/failure.toml
+++ b/filters/go/build_test/failure.toml
@@ -1,0 +1,6 @@
+name = "compile error shows file references"
+fixture = "failure.txt"
+exit_code = 1
+
+[[expect]]
+contains = ".go:"

--- a/filters/go/build_test/failure.txt
+++ b/filters/go/build_test/failure.txt
@@ -1,0 +1,4 @@
+# myproject/cmd
+./main.go:15:2: undefined: foo
+./main.go:20:10: cannot use x (variable of type string) as int
+./utils.go:8:5: declared and not used: result

--- a/filters/go/build_test/success.toml
+++ b/filters/go/build_test/success.toml
@@ -1,0 +1,6 @@
+name = "clean build collapses to single line"
+inline = ""
+exit_code = 0
+
+[[expect]]
+equals = "✓ go build: ok"

--- a/filters/go/vet_test/failure.toml
+++ b/filters/go/vet_test/failure.toml
@@ -1,0 +1,6 @@
+name = "vet issues show file references"
+fixture = "failure.txt"
+exit_code = 1
+
+[[expect]]
+contains = ".go:"

--- a/filters/go/vet_test/failure.txt
+++ b/filters/go/vet_test/failure.txt
@@ -1,0 +1,3 @@
+# myproject
+./main.go:10:5: printf: wrong type for string
+./handler.go:34:2: loop variable captured by func literal

--- a/filters/go/vet_test/success.toml
+++ b/filters/go/vet_test/success.toml
@@ -1,0 +1,6 @@
+name = "clean vet collapses to single line"
+inline = ""
+exit_code = 0
+
+[[expect]]
+equals = "✓ go vet: ok"

--- a/filters/kubectl/get_test/failure.toml
+++ b/filters/kubectl/get_test/failure.toml
@@ -1,0 +1,6 @@
+name = "resource not found shows error"
+inline = "Error from server (NotFound): pods \"myapp\" not found"
+exit_code = 1
+
+[[expect]]
+contains = "NotFound"

--- a/filters/kubectl/get_test/success.toml
+++ b/filters/kubectl/get_test/success.toml
@@ -1,0 +1,9 @@
+name = "pod list passes through"
+fixture = "success.txt"
+exit_code = 0
+
+[[expect]]
+contains = "NAME"
+
+[[expect]]
+contains = "Running"

--- a/filters/kubectl/get_test/success.txt
+++ b/filters/kubectl/get_test/success.txt
@@ -1,0 +1,4 @@
+NAME                          READY   STATUS    RESTARTS   AGE
+nginx-deployment-7fb96c846b   1/1     Running   0          2d
+postgres-statefulset-0        1/1     Running   0          5d
+redis-deployment-5d4c9b8d7f   1/1     Running   2          12h


### PR DESCRIPTION
Add declarative verify suites for Go toolchain and kubectl filters.

- `go/build_test/` — clean build (collapses to single line) + compile error
- `go/vet_test/` — clean vet (collapses to single line) + vet issues
- `kubectl/get_test/` — pod list passthrough + not found error

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)