### PR TITLE
test(filter): add verify suites for JS ecosystem filters

### DIFF
--- a/filters/next/build_test/failure.toml
+++ b/filters/next/build_test/failure.toml
@@ -1,0 +1,6 @@
+name = "build error shows tail"
+fixture = "failure.txt"
+exit_code = 1
+
+[[expect]]
+contains = "error"

--- a/filters/next/build_test/failure.txt
+++ b/filters/next/build_test/failure.txt
@@ -1,0 +1,12 @@
+info  - Loaded env from /app/.env
+info  - Using webpack 5. Opts in to future default behavior
+   Creating an optimized production build ...
+Failed to compile.
+
+./src/app/page.tsx
+Type error: Type 'string' is not assignable to type 'number'.
+
+  10 | const x: number = "hello"
+     |                   ^^^^^^^
+
+error: build failed

--- a/filters/next/build_test/success.toml
+++ b/filters/next/build_test/success.toml
@@ -1,0 +1,9 @@
+name = "next build strips info lines"
+fixture = "success.txt"
+exit_code = 0
+
+[[expect]]
+not_contains = "info  -"
+
+[[expect]]
+contains = "Compiled"

--- a/filters/next/build_test/success.txt
+++ b/filters/next/build_test/success.txt
@@ -1,0 +1,11 @@
+info  - Loaded env from /app/.env
+info  - Using webpack 5. Opts in to future default behavior
+   Creating an optimized production build ...
+ ✓ Compiled successfully
+ ✓ Linting and checking validity of types
+ ✓ Collecting page data
+ ✓ Generating static pages (3/3)
+
+Route (app)                              Size     First Load JS
+┌ ○ /                                    5.23 kB        87.2 kB
+└ ○ /about                               2.11 kB        84.1 kB

--- a/filters/npm/run_test/failure.toml
+++ b/filters/npm/run_test/failure.toml
@@ -1,0 +1,6 @@
+name = "script failure shows tail"
+fixture = "failure.txt"
+exit_code = 1
+
+[[expect]]
+contains = "ERR"

--- a/filters/npm/run_test/failure.txt
+++ b/filters/npm/run_test/failure.txt
@@ -1,0 +1,10 @@
+> myapp@1.0.0 test
+> jest
+
+FAIL src/app.test.js
+  ● Test suite failed to run
+
+    Cannot find module './missing' from 'src/app.test.js'
+
+npm ERR! code ELIFECYCLE
+npm ERR! errno 1

--- a/filters/npm/run_test/success.toml
+++ b/filters/npm/run_test/success.toml
@@ -1,0 +1,9 @@
+name = "npm run strips package header and noise"
+fixture = "success.txt"
+exit_code = 0
+
+[[expect]]
+not_contains = "@1.0.0"
+
+[[expect]]
+contains = "compiled successfully"

--- a/filters/npm/run_test/success.txt
+++ b/filters/npm/run_test/success.txt
@@ -1,0 +1,6 @@
+> myapp@1.0.0 build
+> webpack --mode production
+
+assets by status 142 KiB [emitted]
+  asset bundle.js 142 KiB [emitted] [minimized] (name: main)
+webpack 5.75.0 compiled successfully in 2340 ms

--- a/filters/pnpm/add_test/failure.toml
+++ b/filters/pnpm/add_test/failure.toml
@@ -1,0 +1,6 @@
+name = "package not found shows error"
+inline = " ERR_PNPM_NO_MATCHING_VERSION  No matching version found for nonexistent-pkg@latest"
+exit_code = 1
+
+[[expect]]
+contains = "ERR_PNPM"

--- a/filters/pnpm/add_test/success.toml
+++ b/filters/pnpm/add_test/success.toml
@@ -1,0 +1,9 @@
+name = "pnpm add strips progress and shows result"
+fixture = "success.txt"
+exit_code = 0
+
+[[expect]]
+not_contains = "Progress:"
+
+[[expect]]
+contains = "lodash"

--- a/filters/pnpm/add_test/success.txt
+++ b/filters/pnpm/add_test/success.txt
@@ -1,0 +1,7 @@
+ Progress: resolved 42, reused 42, downloaded 0, added 1
+Packages: +1
++
+dependencies:
++ lodash 4.17.21
+
+Done in 892ms

--- a/filters/pnpm/install_test/failure.toml
+++ b/filters/pnpm/install_test/failure.toml
@@ -1,0 +1,6 @@
+name = "lockfile conflict shows error"
+inline = " ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with \"frozen-lockfile\" because pnpm-lock.yaml is not up to date"
+exit_code = 1
+
+[[expect]]
+contains = "ERR_PNPM"

--- a/filters/pnpm/install_test/success.toml
+++ b/filters/pnpm/install_test/success.toml
@@ -1,0 +1,9 @@
+name = "pnpm install strips progress lines"
+fixture = "success.txt"
+exit_code = 0
+
+[[expect]]
+not_contains = "Progress:"
+
+[[expect]]
+contains = "Done"

--- a/filters/pnpm/install_test/success.txt
+++ b/filters/pnpm/install_test/success.txt
@@ -1,0 +1,4 @@
+ Progress: resolved 120, reused 120, downloaded 0, added 0
+Already up to date
+
+Done in 892ms


### PR DESCRIPTION
Add declarative verify suites for JS build tool filters.

- `next/build_test/` — strips info lines, compile success + type error failure
- `npm/run_test/` — strips package header, build success + script failure
- `pnpm/add_test/` — strips progress lines, install success + not found error
- `pnpm/install_test/` — strips progress lines, install success + lockfile error

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)