### PR TITLE
test(filter): add verify suites for prisma/generate, pytest, and tsc

### DIFF
--- a/filters/prisma/generate_test/failure.toml
+++ b/filters/prisma/generate_test/failure.toml
@@ -1,0 +1,6 @@
+name = "schema error shows tail"
+fixture = "failure.txt"
+exit_code = 1
+
+[[expect]]
+contains = "error"

--- a/filters/prisma/generate_test/failure.txt
+++ b/filters/prisma/generate_test/failure.txt
@@ -1,0 +1,10 @@
+┌─────────────────────────────────────────────────────────┐
+│ Prisma schema loaded from prisma/schema.prisma          │
+└─────────────────────────────────────────────────────────┘
+Environment variables loaded from .env
+error: Schema parsing error
+  --> schema.prisma:10
+  |
+10|   unknown_field String
+  |
+  Attribute not known: "@unknown_field"

--- a/filters/prisma/generate_test/success.toml
+++ b/filters/prisma/generate_test/success.toml
@@ -1,0 +1,6 @@
+name = "generate extracts client version"
+fixture = "success.txt"
+exit_code = 0
+
+[[expect]]
+starts_with = "✓ Generated"

--- a/filters/prisma/generate_test/success.txt
+++ b/filters/prisma/generate_test/success.txt
@@ -1,0 +1,5 @@
+┌─────────────────────────────────────────────────────────┐
+│ Prisma schema loaded from prisma/schema.prisma          │
+└─────────────────────────────────────────────────────────┘
+Environment variables loaded from .env
+✔ Generated Prisma Client (v5.9.1) to ./node_modules/@prisma/client in 67ms

--- a/filters/pytest_test/failure.toml
+++ b/filters/pytest_test/failure.toml
@@ -1,0 +1,6 @@
+name = "test failure shows FAILED summary"
+fixture = "failure.txt"
+exit_code = 1
+
+[[expect]]
+contains = "FAILED"

--- a/filters/pytest_test/failure.txt
+++ b/filters/pytest_test/failure.txt
@@ -1,0 +1,9 @@
+.F...
+================================== FAILURES ===================================
+_________________________________ test_add ____________________________________
+tests/test_math.py:10: in test_add
+>     assert add(1, 2) == 4
+E     AssertionError: assert 3 == 4
+=========================== short test summary info ============================
+FAILED tests/test_math.py::test_add - AssertionError: assert 3 == 4
+1 failed, 4 passed in 0.15s

--- a/filters/pytest_test/success.toml
+++ b/filters/pytest_test/success.toml
@@ -1,0 +1,6 @@
+name = "all tests pass shows summary"
+inline = ".....\n5 passed in 0.12s"
+exit_code = 0
+
+[[expect]]
+equals = "✓ pytest: 5 passed"

--- a/filters/tsc_test/failure.toml
+++ b/filters/tsc_test/failure.toml
@@ -1,0 +1,6 @@
+name = "type errors show file references"
+fixture = "failure.txt"
+exit_code = 1
+
+[[expect]]
+contains = "error TS"

--- a/filters/tsc_test/failure.txt
+++ b/filters/tsc_test/failure.txt
@@ -1,0 +1,5 @@
+src/app.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.
+src/utils.ts(34,12): error TS2339: Property 'foo' does not exist on type 'Bar'.
+src/components/Button.tsx(8,3): warning TS6133: 'unused' is declared but its value is never read.
+
+Found 3 errors in 3 files.

--- a/filters/tsc_test/no_errors_message.toml
+++ b/filters/tsc_test/no_errors_message.toml
@@ -1,0 +1,6 @@
+name = "found 0 errors message shows no errors variant"
+inline = "Found 0 errors in 10 files."
+exit_code = 0
+
+[[expect]]
+equals = "✓ TypeScript: no errors"

--- a/filters/tsc_test/success.toml
+++ b/filters/tsc_test/success.toml
@@ -1,0 +1,6 @@
+name = "no errors collapses to single line"
+inline = ""
+exit_code = 0
+
+[[expect]]
+equals = "✓ TypeScript: ok"


### PR DESCRIPTION
Add declarative verify suites for Prisma, pytest, and TypeScript filters.

- `prisma/generate_test/` — extracts client version on success, schema error on failure
- `pytest_test/` — all passed (collapses to count), test failure shows FAILED line
- `tsc_test/` — empty output (ok), "Found 0 errors" message, type error references

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)