### PR TITLE
chore(ci): trigger tokf.net rebuild on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,3 +176,25 @@ jobs:
           git add Formula/tokf.rb
           git commit -m "chore: update tokf to v${{ steps.version.outputs.version }}"
           git push
+
+  trigger-site-rebuild:
+    name: Trigger tokf.net rebuild
+    needs: build-binaries
+    if: startsWith(github.event.release.tag_name, 'tokf-v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.REPOSITORY_BUTLER_APP_ID }}
+          private-key: ${{ secrets.REPOSITORY_BUTLER_PEM }}
+          repositories: tokf-net
+
+      - name: Dispatch rebuild
+        run: |
+          gh api repos/mpecan/tokf-net/dispatches \
+            --method POST \
+            --field event_type=tokf-release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Adds a `trigger-site-rebuild` job to `release.yml` that fires after binaries are built
- Uses the existing **repository-butler** GitHub App (new token scoped to `tokf-net` only) to post a `repository_dispatch` event to `mpecan/tokf-net`
- The marketing site then rebuilds automatically and picks up the new version number and changelog entry

## Pre-requisites (already done)

- GitHub App has **Actions: Write** permission on `tokf-net`
- `tokf-net/deploy.yml` has been updated to listen for `repository_dispatch` type `tokf-release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)