### PR TITLE
fix(rewrite)!: skip auto-rewrite for piped commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,30 @@ tokf show git/push         # print the TOML source
 | Flag | Description |
 |---|---|
 | `--timing` | Print how long filtering took |
-| `--verbose` | Show which filter was matched |
+| `--verbose` | Show which filter was matched (also explains skipped rewrites) |
 | `--no-filter` | Pass output through without filtering |
 | `--no-cache` | Bypass the filter discovery cache |
+
+### Piped commands
+
+Commands containing a shell pipe (`|`) are passed through unchanged by the hook and `tokf rewrite`. This is intentional — downstream tools like `grep`, `wc -l`, and `tee` depend on the raw output and would produce wrong results if tokf transformed it first.
+
+```sh
+# These are NOT rewritten — tokf leaves them alone:
+git diff HEAD | head -5
+cargo test | grep FAILED
+kubectl get pods | grep Running | wc -l
+```
+
+If you want tokf to wrap a specific piped command, add an explicit rule to `.tokf/rewrites.toml`:
+
+```toml
+[[rewrite]]
+match = "^cargo test \\| tee"
+replace = "tokf run {0}"
+```
+
+Use `tokf rewrite --verbose "cargo test | grep FAILED"` to see why a command was not rewritten.
 
 ---
 

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -56,7 +56,7 @@ pub(crate) fn handle_json_with_config(
         return false;
     };
 
-    let rewritten = rewrite::rewrite_with_config(&command, user_config, search_dirs);
+    let rewritten = rewrite::rewrite_with_config(&command, user_config, search_dirs, false);
 
     if rewritten == command {
         return false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -506,7 +506,7 @@ fn main() {
             1
         }),
         Commands::Ls => cmd_ls(cli.verbose),
-        Commands::Rewrite { command } => cmd_rewrite(command),
+        Commands::Rewrite { command } => cmd_rewrite(command, cli.verbose),
         Commands::Which { command } => cmd_which(command, cli.verbose),
         Commands::Show { filter } => cmd_show(filter),
         Commands::Hook { action } => match action {
@@ -584,8 +584,8 @@ fn cmd_show(filter: &str) -> i32 {
     0
 }
 
-fn cmd_rewrite(command: &str) -> i32 {
-    let result = rewrite::rewrite(command);
+fn cmd_rewrite(command: &str, verbose: bool) -> i32 {
+    let result = rewrite::rewrite(command, verbose);
     println!("{result}");
     0
 }


### PR DESCRIPTION
Closes #92

> ⚠️ **Breaking change** — see below.

## Summary

- Commands containing a bare shell pipe (`|`) are now passed through unchanged by the hook and `tokf rewrite` — downstream tools like `grep`, `wc -l`, and `tee` depend on the raw output
- `has_bare_pipe` is quote-aware: pipes inside single/double quotes (e.g. `grep -E 'foo|bar'`) are no longer false positives
- Pipe guard is placed **after** user rewrite rules, so `rewrites.toml` can still explicitly wrap piped commands
- `--verbose` now emits `[tokf] skipping rewrite: command contains a pipe` when a piped command is skipped

## Breaking changes

**Runtime behaviour:** piped commands (e.g. `cargo test | grep FAILED`) are no longer rewritten by the hook or `tokf rewrite`. Previously they were wrapped with `tokf run`, causing downstream tools to receive tokf-filtered rather than raw output — which was almost always wrong for data-extraction pipelines.

**API:** `rewrite(command: &str)` → `rewrite(command: &str, verbose: bool)`. Callers using tokf as a library crate must add the `verbose` argument.

This should ship as **0.2.0**.

## Migration

Users who intentionally want tokf to wrap a piped command can add an explicit rule to `.tokf/rewrites.toml`:

```toml
[[rewrite]]
match = "^cargo test"
replace = "my-wrapper {0}{rest}"
```

## Test plan

- [x] `cargo test` — all 632 tests pass
- [x] `tokf rewrite "cargo test | grep FAILED"` → prints `cargo test | grep FAILED` unchanged
- [x] `tokf rewrite "cargo test || echo failed"` → prints `tokf run cargo test || echo failed`
- [x] `tokf rewrite --verbose "cargo test | grep FAILED"` → prints unchanged + stderr note
- [x] `tokf rewrite "git log --grep='feat|fix'"` → prints `tokf run git log --grep='feat|fix'` (quoted pipe not treated as bare)
- [x] Custom `rewrites.toml` rule with `match = "^cargo test"` and `replace = "my-wrapper {0}{rest}"` wraps `cargo test | grep FAILED` correctly

BREAKING CHANGE: piped commands (e.g. `cargo test | grep FAILED`) are no longer rewritten by the hook or `tokf rewrite`. Previously they were wrapped with `tokf run`, causing downstream tools to receive filtered rather than raw output. The public `rewrite(command, verbose)` function signature now requires a `verbose: bool` argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)