### PR TITLE
docs(readme): document eject subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ tokf which "cargo test"    # which filter would match
 tokf show git/push         # print the TOML source
 ```
 
+### Customize a built-in filter
+
+```sh
+tokf eject cargo/build            # copy to .tokf/filters/ (project-local)
+tokf eject cargo/build --global   # copy to ~/.config/tokf/filters/ (user-level)
+```
+
+This copies the filter TOML and its test suite to your config directory, where it shadows the built-in. Edit the ejected copy freely — tokf's priority system ensures your version is used instead of the original.
+
 ### Flags
 
 | Flag | Description |


### PR DESCRIPTION
## Summary
- Add documentation for `tokf eject` to the README under a new "Customize a built-in filter" section
- This was missed from #100

## Test plan
- [x] README renders correctly with the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)