### PR TITLE
feat(rewrite): fair accounting for stripped pipes

### DIFF
--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -1,0 +1,77 @@
+//! Compute the "fair baseline" byte count by piping raw output through
+//! the original pipe command the user would have used without tokf.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Allowed first words for baseline pipe commands (security whitelist).
+const ALLOWED_COMMANDS: &[&str] = &["tail", "head", "grep"];
+
+/// Maximum time to wait for the baseline pipe command before falling back.
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Run the pipe command on the raw output to get the exact byte count
+/// the user would have seen without tokf.
+///
+/// Only allows `tail`, `head`, and `grep` as pipe commands (matching the
+/// rewrite module's strippable set). Falls back to `raw_output.len()` with
+/// a stderr warning on validation failure, spawn failure, or timeout.
+pub fn compute(raw_output: &str, pipe_cmd: &str) -> usize {
+    let first_word = pipe_cmd.split_whitespace().next().unwrap_or("");
+    if !ALLOWED_COMMANDS.contains(&first_word) {
+        eprintln!(
+            "[tokf] warning: --baseline-pipe command '{first_word}' not allowed, using full output"
+        );
+        return raw_output.len();
+    }
+
+    let Ok(mut child) = Command::new("sh")
+        .args(["-c", pipe_cmd])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
+        eprintln!("[tokf] warning: --baseline-pipe failed to spawn, using full output");
+        return raw_output.len();
+    };
+
+    if let Some(stdin) = child.stdin.as_mut() {
+        let _ = stdin.write_all(raw_output.as_bytes());
+    }
+    drop(child.stdin.take());
+
+    // Wait with timeout to prevent hanging on misbehaving pipe commands.
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => {
+                return match child.wait_with_output() {
+                    Ok(output) => output.stdout.len(),
+                    Err(e) => {
+                        eprintln!(
+                            "[tokf] warning: --baseline-pipe read failed: {e}, using full output"
+                        );
+                        raw_output.len()
+                    }
+                };
+            }
+            Ok(None) => {
+                if start.elapsed() >= TIMEOUT {
+                    let _ = child.kill();
+                    eprintln!(
+                        "[tokf] warning: --baseline-pipe timed out after {}s, using full output",
+                        TIMEOUT.as_secs()
+                    );
+                    return raw_output.len();
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(e) => {
+                eprintln!("[tokf] warning: --baseline-pipe wait failed: {e}, using full output");
+                return raw_output.len();
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod baseline;
 pub mod config;
 pub mod filter;
 pub mod history;

--- a/src/rewrite/compound.rs
+++ b/src/rewrite/compound.rs
@@ -27,11 +27,20 @@ pub fn split_compound(input: &str) -> Vec<(String, String)> {
     parts
 }
 
+/// Result of stripping a simple pipe from a command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StrippedPipe {
+    /// The base command with the pipe removed (e.g. "cargo test").
+    pub base: String,
+    /// The raw pipe suffix (e.g. "tail -5", "grep FAIL").
+    pub suffix: String,
+}
+
 /// If the command has exactly one bare pipe whose target is simple output
 /// truncation or filtering (tail, head, grep), return the base command
-/// with the pipe stripped. Returns `None` for multi-pipe chains, pipes to
+/// and pipe suffix. Returns `None` for multi-pipe chains, pipes to
 /// other commands, or tail/head with non-line-selection flags (-f, -c).
-pub fn strip_simple_pipe(command: &str) -> Option<String> {
+pub fn strip_simple_pipe(command: &str) -> Option<StrippedPipe> {
     let positions = bare_pipe_positions(command);
     if positions.len() != 1 {
         return None;
@@ -41,7 +50,10 @@ pub fn strip_simple_pipe(command: &str) -> Option<String> {
     let suffix = command[pipe_pos + 1..].trim();
 
     if is_strippable_suffix(suffix) {
-        Some(command[..pipe_pos].trim_end().to_string())
+        Some(StrippedPipe {
+            base: command[..pipe_pos].trim_end().to_string(),
+            suffix: suffix.to_string(),
+        })
     } else {
         None
     }
@@ -275,11 +287,18 @@ mod tests {
 
     // --- strip_simple_pipe ---
 
+    fn stripped(base: &str, suffix: &str) -> Option<StrippedPipe> {
+        Some(StrippedPipe {
+            base: base.to_string(),
+            suffix: suffix.to_string(),
+        })
+    }
+
     #[test]
     fn strip_tail_n() {
         assert_eq!(
             strip_simple_pipe("cargo test | tail -n 5"),
-            Some("cargo test".to_string())
+            stripped("cargo test", "tail -n 5")
         );
     }
 
@@ -287,7 +306,7 @@ mod tests {
     fn strip_tail_numeric() {
         assert_eq!(
             strip_simple_pipe("cargo test | tail -5"),
-            Some("cargo test".to_string())
+            stripped("cargo test", "tail -5")
         );
     }
 
@@ -295,7 +314,7 @@ mod tests {
     fn strip_tail_bare() {
         assert_eq!(
             strip_simple_pipe("cargo test | tail"),
-            Some("cargo test".to_string())
+            stripped("cargo test", "tail")
         );
     }
 
@@ -303,7 +322,7 @@ mod tests {
     fn strip_head_n() {
         assert_eq!(
             strip_simple_pipe("cargo test | head -n 10"),
-            Some("cargo test".to_string())
+            stripped("cargo test", "head -n 10")
         );
     }
 
@@ -311,7 +330,7 @@ mod tests {
     fn strip_head_bare() {
         assert_eq!(
             strip_simple_pipe("cargo test | head"),
-            Some("cargo test".to_string())
+            stripped("cargo test", "head")
         );
     }
 
@@ -319,7 +338,7 @@ mod tests {
     fn strip_tail_lines_long() {
         assert_eq!(
             strip_simple_pipe("cargo test | tail --lines=5"),
-            Some("cargo test".to_string())
+            stripped("cargo test", "tail --lines=5")
         );
     }
 
@@ -327,7 +346,7 @@ mod tests {
     fn strip_grep_pattern() {
         assert_eq!(
             strip_simple_pipe("cargo test | grep FAIL"),
-            Some("cargo test".to_string())
+            stripped("cargo test", "grep FAIL")
         );
     }
 
@@ -335,7 +354,7 @@ mod tests {
     fn strip_grep_case_insensitive() {
         assert_eq!(
             strip_simple_pipe("cargo test | grep -i error"),
-            Some("cargo test".to_string())
+            stripped("cargo test", "grep -i error")
         );
     }
 
@@ -343,7 +362,7 @@ mod tests {
     fn strip_grep_extended() {
         assert_eq!(
             strip_simple_pipe("cargo test | grep -E 'fail|error'"),
-            Some("cargo test".to_string())
+            stripped("cargo test", "grep -E 'fail|error'")
         );
     }
 
@@ -351,7 +370,7 @@ mod tests {
     fn strip_grep_invert() {
         assert_eq!(
             strip_simple_pipe("cargo test | grep -v noise"),
-            Some("cargo test".to_string())
+            stripped("cargo test", "grep -v noise")
         );
     }
 
@@ -400,7 +419,7 @@ mod tests {
         // The pipe inside the quotes is not a bare pipe; the real pipe is to tail.
         assert_eq!(
             strip_simple_pipe("grep 'a|b' | tail -5"),
-            Some("grep 'a|b'".to_string())
+            stripped("grep 'a|b'", "tail -5")
         );
     }
 
@@ -419,7 +438,7 @@ mod tests {
     fn strip_grep_combined_flags() {
         assert_eq!(
             strip_simple_pipe("cargo test | grep -iv error"),
-            Some("cargo test".to_string())
+            stripped("cargo test", "grep -iv error")
         );
     }
 
@@ -428,7 +447,7 @@ mod tests {
         // --lines with a space separator (not =)
         assert_eq!(
             strip_simple_pipe("cargo test | head --lines 10"),
-            Some("cargo test".to_string())
+            stripped("cargo test", "head --lines 10")
         );
     }
 

--- a/tests/cli_baseline.rs
+++ b/tests/cli_baseline.rs
@@ -1,0 +1,305 @@
+use std::process::Command;
+
+fn tokf() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_tokf"))
+}
+
+/// Helper: produce deterministic 10-line output for baseline tests.
+const TEN_LINE_CMD: &str = "for i in 1 2 3 4 5 6 7 8 9 10; do echo line$i; done";
+
+/// Helper: query the last event from the tracking DB.
+fn last_event(db_path: &std::path::Path) -> (i64, i64) {
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    conn.query_row(
+        "SELECT input_bytes, output_bytes FROM events ORDER BY rowid DESC LIMIT 1",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )
+    .unwrap()
+}
+
+// --- Core baseline-pipe tracking ---
+
+/// With --baseline-pipe 'tail -3', input_bytes should reflect ~3 lines, not all 10.
+#[test]
+fn baseline_pipe_records_piped_byte_count() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("test-fair.db");
+
+    let output = tokf()
+        .args([
+            "run",
+            "--no-filter",
+            "--baseline-pipe",
+            "tail -3",
+            "sh",
+            "-c",
+            TEN_LINE_CMD,
+        ])
+        .env("TOKF_DB_PATH", &db_path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "tokf run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let (input_bytes, _) = last_event(&db_path);
+
+    // `tail -3` of 10 lines → ~18-20 bytes. Must be much less than full (~61 bytes).
+    assert!(
+        input_bytes > 0,
+        "input_bytes should be positive, got {input_bytes}"
+    );
+    assert!(
+        input_bytes < 30,
+        "input_bytes should reflect ~3 lines (~18 bytes), got {input_bytes}"
+    );
+}
+
+/// Without --baseline-pipe, input_bytes should be the full output length.
+#[test]
+fn no_baseline_pipe_records_full_byte_count() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("test-full.db");
+
+    let output = tokf()
+        .args(["run", "--no-filter", "sh", "-c", TEN_LINE_CMD])
+        .env("TOKF_DB_PATH", &db_path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let (input_bytes, _) = last_event(&db_path);
+
+    // Full output: "line1\nline2\n...line10\n" ≈ 61 bytes
+    assert!(
+        input_bytes > 50,
+        "input_bytes should reflect full output (~61 bytes), got {input_bytes}"
+    );
+}
+
+// --- Passthrough output_bytes fix (remediation #2) ---
+
+/// In the no-filter passthrough path, output_bytes should be the full raw output
+/// (what tokf actually printed), not the piped baseline.
+#[test]
+fn passthrough_output_bytes_is_full_output() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("test-passthrough.db");
+
+    let output = tokf()
+        .args([
+            "run",
+            "--no-filter",
+            "--baseline-pipe",
+            "tail -3",
+            "sh",
+            "-c",
+            TEN_LINE_CMD,
+        ])
+        .env("TOKF_DB_PATH", &db_path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let (input_bytes, output_bytes) = last_event(&db_path);
+
+    // input_bytes = piped baseline (~18 bytes), output_bytes = full raw (~61 bytes)
+    assert!(
+        input_bytes < 30,
+        "input_bytes should be piped baseline, got {input_bytes}"
+    );
+    assert!(
+        output_bytes > 50,
+        "output_bytes should be full output, got {output_bytes}"
+    );
+    assert!(
+        output_bytes > input_bytes,
+        "output_bytes ({output_bytes}) should exceed input_bytes ({input_bytes})"
+    );
+}
+
+// --- Pipe command validation (remediation #5) ---
+
+/// An unrecognised pipe command is rejected and falls back to full output.
+#[test]
+fn baseline_pipe_rejects_unknown_command() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("test-reject.db");
+
+    let output = tokf()
+        .args([
+            "run",
+            "--no-filter",
+            "--baseline-pipe",
+            "wc -l",
+            "sh",
+            "-c",
+            TEN_LINE_CMD,
+        ])
+        .env("TOKF_DB_PATH", &db_path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    // Should have warned on stderr
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not allowed"),
+        "expected rejection warning, got: {stderr}"
+    );
+
+    // Should fall back to full output size
+    let (input_bytes, _) = last_event(&db_path);
+    assert!(
+        input_bytes > 50,
+        "should fall back to full output, got {input_bytes}"
+    );
+}
+
+// --- Pipe command failure (remediation #3) ---
+
+/// When the pipe command fails (e.g. grep with bad args producing no output),
+/// tokf does not crash and still records a tracking event.
+#[test]
+fn baseline_pipe_does_not_crash_on_pipe_failure() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("test-fail.db");
+
+    // grep with --nonexistent-flag exits with error and produces no stdout.
+    // compute_baseline will return 0 (stdout was empty). The important thing
+    // is that tokf doesn't crash and the event is recorded.
+    let output = tokf()
+        .args([
+            "run",
+            "--no-filter",
+            "--baseline-pipe",
+            "grep --nonexistent-flag-xyz",
+            "sh",
+            "-c",
+            TEN_LINE_CMD,
+        ])
+        .env("TOKF_DB_PATH", &db_path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "tokf should not crash on pipe failure: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Tracking should still have recorded an event (input_bytes may be 0
+    // since the failing grep produced no stdout).
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 1, "should record exactly one event");
+}
+
+// --- Grep baseline ---
+
+/// baseline-pipe with grep records byte count of matching lines only.
+#[test]
+fn baseline_pipe_grep_records_matching_lines() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("test-grep.db");
+
+    // Only "line1" and "line10" match "line1" → ~12 bytes (line1\nline10\n)
+    let output = tokf()
+        .args([
+            "run",
+            "--no-filter",
+            "--baseline-pipe",
+            "grep line1",
+            "sh",
+            "-c",
+            TEN_LINE_CMD,
+        ])
+        .env("TOKF_DB_PATH", &db_path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let (input_bytes, _) = last_event(&db_path);
+
+    // "line1\nline10\n" = 12 bytes. Must be much less than full (~61 bytes).
+    assert!(
+        input_bytes > 0,
+        "input_bytes should be positive, got {input_bytes}"
+    );
+    assert!(
+        input_bytes < 20,
+        "input_bytes should reflect matching lines (~12 bytes), got {input_bytes}"
+    );
+}
+
+// --- Empty output ---
+
+/// baseline-pipe with a command that produces no output records input_bytes = 0.
+#[test]
+fn baseline_pipe_empty_output() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("test-empty.db");
+
+    let output = tokf()
+        .args([
+            "run",
+            "--no-filter",
+            "--baseline-pipe",
+            "tail -3",
+            "sh",
+            "-c",
+            "exit 0",
+        ])
+        .env("TOKF_DB_PATH", &db_path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let (input_bytes, output_bytes) = last_event(&db_path);
+    assert_eq!(input_bytes, 0, "empty command → input_bytes = 0");
+    assert_eq!(output_bytes, 0, "empty command → output_bytes = 0");
+}
+
+// --- Head baseline ---
+
+/// baseline-pipe with head records byte count of first N lines.
+#[test]
+fn baseline_pipe_head_records_first_lines() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("test-head.db");
+
+    let output = tokf()
+        .args([
+            "run",
+            "--no-filter",
+            "--baseline-pipe",
+            "head -2",
+            "sh",
+            "-c",
+            TEN_LINE_CMD,
+        ])
+        .env("TOKF_DB_PATH", &db_path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let (input_bytes, _) = last_event(&db_path);
+
+    // "line1\nline2\n" = 12 bytes
+    assert!(
+        input_bytes > 0 && input_bytes < 20,
+        "input_bytes should reflect ~2 lines (~12 bytes), got {input_bytes}"
+    );
+}

--- a/tests/cli_hook.rs
+++ b/tests/cli_hook.rs
@@ -202,7 +202,7 @@ fn hook_handle_strips_pipe_to_grep() {
     let response: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
     assert_eq!(
         response["hookSpecificOutput"]["updatedInput"]["command"],
-        "tokf run cargo test"
+        "tokf run --baseline-pipe 'grep FAILED' cargo test"
     );
 }
 


### PR DESCRIPTION
## Summary

This PR adds smart pipe stripping to `tokf rewrite` and fair baseline accounting when pipes are stripped.

### Commit 1: Strip simple pipes when tokf filter is available

When a command pipes to `tail`, `head`, or `grep` for crude output truncation/filtering, and the base command matches a tokf filter, the pipe is stripped and tokf handles the output instead. tokf's structured filters provide more information-dense output with context, making the pipe unnecessary.

- `cargo test | tail -5` → `tokf run cargo test`
- `cargo test | grep FAIL` → `tokf run cargo test`
- `git diff HEAD | head -n 20` → `tokf run git diff HEAD`

**Not stripped:** multi-pipe chains (`cmd | grep x | wc -l`), non-filtering pipes (`wc`, `sort`, `tee`), commands without filters, `tail -f` (follow mode), byte-mode flags (`-c`).

Also refactors `has_bare_pipe` to delegate to `bare_pipe_positions` (eliminating duplicated quote-aware state machine logic), and extracts rewrite tests to a separate file.

### Commit 2: Fair accounting for stripped pipes

Without this, `tokf gain` reports inflated savings — it records `input_bytes` as the full raw command output, but without tokf the user would have only seen the piped result. Now the stripped pipe suffix is passed via `--baseline-pipe` to `tokf run`, which pipes the raw output through it to compute the exact baseline byte count.

- `cargo test | tail -5` → `tokf run --baseline-pipe 'tail -5' cargo test`
- `cargo test | grep -E 'fail|error'` → `tokf run --baseline-pipe 'grep -E '\''fail|error'\''' cargo test`

Includes hardening from code review:
- Shell-escape single quotes in `--baseline-pipe` values (`'\''` idiom)
- Whitelist pipe commands (`tail`/`head`/`grep`) before execution
- 5-second timeout on baseline subprocess to prevent hangs
- Warn on stderr when baseline pipe fails or is rejected
- Fix passthrough path: `output_bytes` reflects actual output, not baseline
- Document that `tokens_saved` can go negative with baseline pipes
- Extract `baseline` module to keep `main.rs` under 700-line limit

## Files changed

| File | Change |
|------|--------|
| `src/rewrite/compound.rs` | `StrippedPipe` struct; `strip_simple_pipe`; `bare_pipe_positions` refactor; strippability validators for tail/head/grep |
| `src/rewrite/mod.rs` | `rewrite_segment` pipe stripping logic; `inject_baseline_pipe` with quote escaping |
| `src/rewrite/tests.rs` | **New** — extracted rewrite unit tests + pipe stripping + quoted grep pattern tests |
| `src/baseline.rs` | **New** — `baseline::compute` with whitelist, timeout, warnings |
| `src/lib.rs` | Register `baseline` module |
| `src/main.rs` | `--baseline-pipe` CLI arg; passthrough `output_bytes` fix; `record_run` docs |
| `tests/cli_rewrite.rs` | Integration tests for pipe stripping, compound+pipe, edge cases |
| `tests/cli_hook.rs` | Hook handler pipe stripping tests |
| `tests/cli_baseline.rs` | **New** — 8 end-to-end tests (tail, head, grep, empty, rejection, failure, passthrough semantics) |

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` — 689 tests pass (14 suites)
- [x] Smoke: `tokf rewrite "cargo test | tail -5"` → correct output
- [x] Smoke: `tokf rewrite "cargo test | grep -E 'fail|error'"` → quotes properly escaped
- [x] `main.rs` at 651 lines (under 700 hard limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)