### PR TITLE
docs: comprehensive pre-release documentation update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Use **Conventional Commits** strictly:
 
 Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `ci`, `perf`, `build`
 
-Scopes: `config`, `filter`, `runner`, `output`, `cli`, `hook`, `tracking`
+Scopes: `config`, `filter`, `runner`, `output`, `cli`, `hook`, `tracking`, `history`
 
 Examples:
 - `feat(filter): implement skip/keep line filtering`
@@ -71,6 +71,7 @@ src/
   lib.rs           — Public module declarations
   resolve.rs       — Filter resolution, command execution, tracking (binary crate)
   runner.rs        — Command execution, stdout/stderr capture
+  baseline.rs      — Fair baseline computation for piped commands
   config/
     mod.rs         — Config loading, file discovery, pattern matching
     types.rs       — Serde structs for the TOML schema
@@ -87,6 +88,7 @@ src/
     template.rs    — Template rendering, variable interpolation, pipe chains
     match_output.rs — Whole-output substring matching
     dedup.rs       — Line deduplication
+    parse.rs       — Declarative structured parser (branch + group)
     cleanup.rs     — ANSI stripping, line trimming, blank line handling
     lua.rs         — Luau script escape hatch
   rewrite/         — Shell rewrite engine (hook + CLI)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,14 +19,9 @@ The project requires a recent stable Rust toolchain. See `rust-toolchain.toml` f
 
 ## What to work on
 
-Check the [issue tracker](https://github.com/mpecan/tokf/issues) for open issues. Issues are labelled by phase:
+Check the [issue tracker](https://github.com/mpecan/tokf/issues) for open issues. Good first contributions include adding new filters, improving existing ones, or expanding documentation.
 
-- **Phase 1** (core runtime) — filter engine, CLI, config resolution
-- **Phase 2** (hook rewrite) — Claude Code hook integration
-- **Phase 3** (token tracking) — SQLite-backed savings stats
-- **Phase 4** (Lua escape hatch) — scripted filter logic
-
-If you want to add a new built-in filter, no issue is required — just open a PR with the TOML file and, if the output format is non-trivial, a fixture file.
+If you want to add a new built-in filter, no issue is required — just open a PR with the TOML file, a `_test/` suite, and fixture data.
 
 ---
 
@@ -40,7 +35,7 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 
 Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `ci`, `perf`, `build`
 
-Scopes: `config`, `filter`, `runner`, `output`, `cli`, `hook`, `tracking`
+Scopes: `config`, `filter`, `runner`, `output`, `cli`, `hook`, `tracking`, `history`
 
 Keep commits atomic — one logical change per commit.
 
@@ -73,10 +68,24 @@ When a limit genuinely harms readability, it can be overridden with `#[allow(...
 1. Create `filters/<tool>/<subcommand>.toml`
 2. Set `command` to the pattern users type (e.g. `"git push"`)
 3. Add `[on_success]` and/or `[on_failure]` branches
-4. Save a real command output as `tests/fixtures/<tool>_<subcommand>_<case>.txt`
-5. Add integration tests in `tests/filter_<tool>_<subcommand>.rs`
+4. Create a `<subcommand>_test/` directory adjacent to the TOML with declarative test cases
+5. Save real command output as fixture `.txt` files (inline fixtures work for short outputs)
+6. Run `tokf verify <tool>/<subcommand>` to validate
 
-Run `tokf test filters/my/filter.toml tests/fixtures/my_fixture.txt` to iterate quickly without a full `cargo test`.
+Example test case (`filters/git/push_test/success.toml`):
+
+```toml
+name = "successful push shows branch"
+fixture = "success.txt"
+exit_code = 0
+
+[[expect]]
+starts_with = "ok"
+```
+
+Use `tokf test filters/my/filter.toml tests/fixtures/my_fixture.txt` to iterate quickly on a single fixture.
+
+Every filter in the stdlib **must** have a `_test/` suite — CI enforces this with `tokf verify --require-all`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ tokf hook install --global # user-level (~/.config/tokf/)
 
 Once installed, every command Claude runs through the Bash tool is filtered transparently. Track cumulative savings with `tokf gain`.
 
+tokf also ships a filter-authoring skill that teaches Claude the complete filter schema:
+
+```sh
+tokf skill install          # project-local (.claude/skills/)
+tokf skill install --global # user-level (~/.claude/skills/)
+```
+
 ---
 
 ## Installation
@@ -316,6 +323,11 @@ output = "{1}: {2} → {3}"
 dedup = true                  # collapse consecutive identical lines
 dedup_window = 10             # optional: compare within a N-line sliding window
 
+strip_ansi = true             # strip ANSI escape sequences before processing
+trim_lines = true             # trim leading/trailing whitespace from each line
+strip_empty_lines = true      # remove all blank lines from the final output
+collapse_empty_lines = true   # collapse consecutive blank lines into one
+
 match_output = [              # whole-output substring checks, short-circuit the pipeline
   { contains = "rejected", output = "push rejected" },
 ]
@@ -487,6 +499,33 @@ tokf gain              # summary: total bytes saved and reduction %
 tokf gain --daily      # day-by-day breakdown
 tokf gain --by-filter  # breakdown by filter
 tokf gain --json       # machine-readable output
+```
+
+---
+
+## Output history
+
+tokf records raw and filtered outputs in a local SQLite database, useful for debugging filters or reviewing what an AI agent saw:
+
+```sh
+tokf history list              # recent entries (current project)
+tokf history list -l 20        # show 20 entries
+tokf history list --all        # entries from all projects
+tokf history show 42           # full details for entry #42
+tokf history search "error"    # search by command or output content
+tokf history clear             # clear current project history
+tokf history clear --all       # clear all history (destructive)
+```
+
+---
+
+## Cache management
+
+tokf caches the filter discovery index for faster startup. The cache rebuilds automatically when filters change, but you can manage it manually:
+
+```sh
+tokf cache info    # show cache location, size, and validity
+tokf cache clear   # delete the cache, forcing a rebuild on next run
 ```
 
 ---


### PR DESCRIPTION
## Summary

- **README.md**: Add missing `history`, `cache`, and `skill install` subcommand docs; add cleanup fields (`strip_ansi`, `trim_lines`, `strip_empty_lines`, `collapse_empty_lines`) to Common Fields
- **SKILL.md**: Add `[[variant]]` section (4.10) with full schema/examples; add cleanup fields to processing order and top-level fields table
- **step-reference.md**: Add field references for `strip_ansi`, `trim_lines`, `strip_empty_lines`, `collapse_empty_lines`, and `[[variant]]`
- **CLAUDE.md**: Add `parse.rs` and `baseline.rs` to architecture tree; add `history` commit scope
- **CONTRIBUTING.md**: Modernize filter workflow to recommend `_test/` suites; update phase descriptions; add `history` scope

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify SKILL.md processing order matches `filter/mod.rs` implementation
- [ ] Confirm all CLI subcommands from `main.rs` are documented in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)