### PR TITLE
feat(filter): show history hint for filtered output

### DIFF
--- a/crates/tokf-cli/src/history/tests.rs
+++ b/crates/tokf-cli/src/history/tests.rs
@@ -149,6 +149,29 @@ fn record_history_inserts_entry() {
 }
 
 #[test]
+fn record_history_returns_inserted_id() {
+    let (_dir, conn) = temp_db();
+    let config = HistoryConfig::default();
+
+    let id1 = record_history(
+        &conn,
+        &make_record("/proj", "git status", None, "raw", "filtered", 0),
+        &config,
+    )
+    .expect("record first");
+
+    let id2 = record_history(
+        &conn,
+        &make_record("/proj", "cargo test", None, "raw", "filtered", 0),
+        &config,
+    )
+    .expect("record second");
+
+    assert!(id1 > 0, "id should be positive");
+    assert!(id2 > id1, "second id should be greater than first");
+}
+
+#[test]
 fn record_history_all_fields_persisted() {
     let (_dir, conn) = temp_db();
     let config = HistoryConfig::default();

--- a/crates/tokf-common/src/config/types.rs
+++ b/crates/tokf-common/src/config/types.rs
@@ -145,6 +145,17 @@ pub struct FilterConfig {
     /// Variant entries for context-aware filter delegation.
     #[serde(default)]
     pub variant: Vec<Variant>,
+
+    /// When true, append a hint line after the filtered output telling the reader
+    /// how to retrieve the full, unfiltered output from history.
+    ///
+    /// Example hint appended to output:
+    /// `Filtered - for full content call: \`tokf history show 42\``
+    ///
+    /// This is useful for LLM consumers that need to know complete output is
+    /// available even though tokf has compressed it.
+    #[serde(default)]
+    pub show_history_hint: bool,
 }
 
 /// A pipeline step that runs a sub-command and captures its output.

--- a/justfile
+++ b/justfile
@@ -20,3 +20,11 @@ lint:
 # Check file sizes
 file-size:
     bash scripts/check-file-sizes.sh
+
+# Install the CLI
+install:
+    cargo install --path crates/tokf-cli
+
+# Install the CLI
+force-install:
+    cargo install --force --path crates/tokf-cli


### PR DESCRIPTION
## Summary

- Adds `show_history_hint = true` opt-in to filter TOML configs, which appends a hint line after filtered output telling the reader how to retrieve the full content: `Filtered - for full content call: \`tokf history show <ID>\``
- Automatically shows the hint when the same command is run twice in a row for the same project — a signal the LLM didn't act on the previous filtered output and may be confused
- Adds `install` and `force-install` commands to the justfile

## Details

**New `FilterConfig` field:**
```toml
show_history_hint = true  # opt-in per filter
```

**Automatic detection:** `try_was_recently_run()` checks if the most recent history entry for the current project matches the current command, triggering the hint without any filter config change.

**History API changes:**
- `record_history()` now returns the inserted row ID (`anyhow::Result<i64>`)
- `try_record()` now returns `Option<i64>` so callers can use the ID in the hint

## Test plan

- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] New tests: `record_history_returns_inserted_id`, `try_record_returns_id_on_success`, `try_was_recently_run_returns_true_for_repeated_command`, `try_was_recently_run_returns_false_for_different_command`, `try_was_recently_run_returns_false_on_empty_history`

🤖 Generated with [Claude Code](https://claude.com/claude-code)