### PR TITLE
docs: document history hint, pipe stripping, and add docs requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,18 @@ cargo clippy -- -D warnings  # Lint
 cargo fmt -- --check     # Format check
 ```
 
+## Documentation
+
+**Every user-facing feature or behaviour change must be documented in the same PR.**
+
+- New filter fields → add to the "Common fields" block and any relevant prose in `README.md`.
+- New CLI flags or subcommands → add to the "Usage" / "Flags" tables in `README.md`.
+- Changed behaviour (e.g. how piped commands are handled) → update the relevant section in `README.md`.
+- New runtime behaviours visible to LLMs or end-users → document with a concrete example showing input and output.
+- Significant new features → consider adding a dedicated section in `README.md` with a short explanation and a code/shell example.
+
+Documentation lives in `README.md` (end-user reference) and `CONTRIBUTING.md` (contributor guide). Do not open a PR that adds or changes behaviour without also updating these files.
+
 ## What Not To Do
 
 - Don't add features beyond what the current issue asks for.


### PR DESCRIPTION
## Summary

- **Corrects** the piped-commands section in README — simple pipes to `grep`, `tail`, and `head` are stripped and handled by tokf's own filter; the README previously said all piped commands were passed through unchanged
- **Documents** the `show_history_hint` filter field and both trigger mechanisms: opt-in via TOML and automatic repetition detection
- **Adds a Documentation rule** to `CLAUDE.md` requiring all user-facing feature or behaviour changes to be documented in the same PR

## Changes

### README.md
- Piped commands section: accurate description of which pipes are stripped (grep/tail/head with supported flags) vs passed through (multi-pipe chains, wc, tee, unsupported flags)
- Common fields block: add `show_history_hint = true` example
- New "History hint" subsection under "Output history" explaining both trigger mechanisms with example output

### CLAUDE.md
- New "Documentation" section specifying what must be documented per PR and where (README vs CONTRIBUTING)

## Test plan

- [x] No code changes — documentation only
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)