### PR TITLE
ci: remove crate packaging verification step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,3 @@ jobs:
       - name: Check file sizes
         run: bash scripts/check-file-sizes.sh
 
-      - name: Verify crate packaging
-        run: |
-          cargo package -p tokf-common --no-verify
-          cargo package -p tokf-cli --no-verify
-          # Confirm skill files are included in the tokf-cli package
-          cargo package -p tokf-cli --list | grep -q "skills/tokf-filter/SKILL.md" || \
-            { echo "ERROR: skill files missing from tokf-cli package"; exit 1; }


### PR DESCRIPTION
## Summary

Removes the "Verify crate packaging" CI step added in #137.

## Problem

`cargo package` (even with `--no-verify`) resolves all dependencies against crates.io. On release-please PRs, the version has been bumped (e.g. `0.2.5`) but `tokf-common 0.2.5` isn't published yet — so the step fails with:

```
failed to select a version for the requirement `tokf-common = "^0.2.5"`
candidate versions found which didn't match: 0.2.4
```

There's no straightforward way to run full packaging verification in CI when a workspace has inter-crate path dependencies that haven't been published yet.

## Fix

Drop the check. The structural fix from #137 (skill files now live inside `crates/tokf-cli/skills/`) is itself the correct prevention — files inside the crate are always packaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)