### PR TITLE
chore(cli): rename crate from tokf-cli to tokf

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           done
 
       - name: Publish tokf-cli
-        run: cargo publish -p tokf-cli
+        run: cargo publish -p tokf
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -73,7 +73,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }} -p tokf-cli
+        run: cargo build --release --target ${{ matrix.target }} -p tokf
 
       - name: Package binary
         shell: bash

--- a/crates/tokf-cli/Cargo.toml
+++ b/crates/tokf-cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tokf-cli"
+name = "tokf"
 version = "0.2.5"
 edition.workspace = true
 license.workspace = true
@@ -8,9 +8,6 @@ homepage.workspace = true
 description = "Config-driven CLI tool that compresses command output before it reaches an LLM context"
 keywords = ["llm", "cli", "tokens", "ai", "context-window"]
 categories = ["command-line-utilities", "development-tools"]
-
-[lib]
-name = "tokf"
 
 [[bin]]
 name = "tokf"


### PR DESCRIPTION
## Summary

- Renames the package in `crates/tokf-cli/Cargo.toml` from `tokf-cli` to `tokf`
- Removes the now-redundant `[lib] name = "tokf"` override (defaults to package name)
- Updates `-p tokf-cli` flags in `release.yml` to `-p tokf`

## Why

The crate is already published on crates.io under the name `tokf` (owned by this project, currently at v0.2.2). The internal workspace name `tokf-cli` was a mismatch — users running `cargo install tokf` would install the right binary, but `cargo install tokf-cli` was the technically correct invocation.

## What doesn't change

- Directory remains `crates/tokf-cli/` (no need to rename it)
- Binary name stays `tokf`
- Workspace `Cargo.toml` members use the path, not the name
- release-please config/manifest use the path as key

## Test plan

- [x] `cargo build -p tokf` succeeds
- [x] `cargo test -p tokf` — 736 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)