### PR TITLE
ci: remove redundant wait-for-crates.io step after cargo publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,18 +27,6 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Wait for tokf-common on crates.io
-        run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | python3 -c "import sys,json; pkgs=json.load(sys.stdin)['packages']; print(next(p['version'] for p in pkgs if p['name']=='tokf-common'))")
-          for i in $(seq 1 10); do
-            if curl -sf "https://crates.io/api/v1/crates/tokf-common/${VERSION}" > /dev/null; then
-              echo "tokf-common ${VERSION} available on crates.io"
-              break
-            fi
-            echo "Waiting for tokf-common ${VERSION}... attempt $i/10"
-            sleep 30
-          done
-
       - name: Publish tokf-cli
         run: cargo publish -p tokf
         env:


### PR DESCRIPTION
## Summary

`cargo publish` already blocks until the published crate is visible on crates.io before it returns — as evidenced by the output in the failing run:

```
note: waiting for tokf-common v0.2.6 to be available at registry `crates-io`
help: you may press ctrl-c to skip waiting; the crate should be available shortly
Published tokf-common v0.2.6 at registry `crates-io`
```

The manual curl polling loop that followed was therefore redundant and introduced an unnecessary failure point (crates.io rate-limiting, transient API errors, etc.).

Removed the 12-line "Wait for tokf-common on crates.io" step entirely. The subsequent `cargo publish -p tokf` step already depends on `tokf-common` being resolvable, and cargo handles any remaining propagation delay itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)