### PR TITLE
fix(hook): auto-stage Cargo.lock after cargo test in pre-commit hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,12 +192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cargo-husky"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
-
-[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,11 +1410,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokf-cli"
-version = "0.2.5"
+name = "tokf"
+version = "0.2.6"
 dependencies = [
  "anyhow",
- "cargo-husky",
  "clap",
  "dirs",
  "include_dir",

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -21,6 +21,10 @@ out=$(cargo test 2>&1) || {
     exit 1
 }
 
+# cargo test may update Cargo.lock (new deps resolved, etc.). Stage it so
+# the committed state stays consistent with what was just tested.
+git add Cargo.lock
+
 out=$(bash scripts/check-file-sizes.sh 2>&1) || {
     echo "File size check failed."
     echo "$out"


### PR DESCRIPTION
## Summary

`cargo test` (and other cargo commands) can update `Cargo.lock` when dependencies change. Without re-staging it, the committed tree diverges from the tested state and leaves a dirty `Cargo.lock` in the working directory after every commit that touches `Cargo.toml` — which is why branch switches kept failing with "your local changes would be overwritten".

Adds `git add Cargo.lock` immediately after the `cargo test` step so any lock file update is folded into the commit automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)