### PR TITLE
ci: switch to Swatinem/rust-cache@v2 to reduce cache bloat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,17 +21,7 @@ jobs:
           toolchain: "1.93.0"
           components: rustfmt, clippy
 
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
         run: cargo fmt --all -- --check


### PR DESCRIPTION
## Problem

The manual `actions/cache@v5` setup was caching `target/` with a key tied to the `Cargo.lock` hash. Now that the pre-commit hook auto-stages `Cargo.lock` on every commit, the key changes on every push — creating a new ~5.7 GB cache entry each time while old ones accumulate until GitHub's 10 GB repo limit forces LRU eviction.

## Fix

Switch to `Swatinem/rust-cache@v2`, which is already used by the release workflow. It's smarter about cache management:
- Uses finer-grained keys (per-crate Cargo.toml hashes + Cargo.lock)
- Auto-prunes cache entries that weren't used in the current run
- Shares the registry download cache across key misses (avoids re-downloading crates)
- Doesn't accumulate stale full-`target/` snapshots

Net result: substantially smaller and more efficiently reused cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)