### PR TITLE
feat(server): add GitHub OAuth device flow endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,13 +278,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -645,8 +665,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -656,9 +678,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -827,6 +851,24 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -835,13 +877,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1009,6 +1059,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1181,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lua-src"
@@ -1263,7 +1335,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -1457,6 +1529,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,8 +1614,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1498,7 +1635,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1508,6 +1655,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1578,6 +1734,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,7 +1828,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -1694,6 +1888,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1902,7 +2097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2074,7 +2269,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -2114,7 +2309,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -2198,6 +2393,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2312,10 +2510,16 @@ name = "tokf-server"
 version = "0.2.6"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
+ "chrono",
+ "hex",
  "http-body-util",
+ "rand 0.8.5",
+ "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "tokio",
  "tower",
@@ -2351,6 +2555,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2427,9 +2641,12 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-util",
  "http",
  "http-body",
+ "iri-string",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2508,6 +2725,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -2609,6 +2832,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,6 +2881,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2715,6 +2961,26 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -613,6 +613,65 @@ tokf cache clear   # delete the cache, forcing a rebuild on next run
 
 ---
 
+## Server authentication API
+
+tokf-server uses the [GitHub device flow](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow) so CLI clients can authenticate without handling secrets.
+
+### `POST /api/auth/device`
+
+Starts the device authorization flow. Returns a `user_code` and `verification_uri` for the user to visit in their browser. Rate-limited to 10 requests per IP per hour.
+
+**Response (201 Created):**
+
+```json
+{
+  "device_code": "dc-abc123",
+  "user_code": "ABCD-1234",
+  "verification_uri": "https://github.com/login/device",
+  "expires_in": 900,
+  "interval": 5
+}
+```
+
+### `POST /api/auth/token`
+
+Polls for a completed device authorization. The CLI calls this on an interval until the user has authorized.
+
+**Request body:**
+
+```json
+{ "device_code": "dc-abc123" }
+```
+
+**Response (200 OK) when authorized:**
+
+```json
+{
+  "access_token": "...",
+  "token_type": "bearer",
+  "expires_in": 7776000,
+  "user": { "id": 1, "username": "octocat", "avatar_url": "..." }
+}
+```
+
+**Response (200 OK) while waiting:**
+
+```json
+{ "error": "authorization_pending" }
+```
+
+Re-polling a completed device code is idempotent — a fresh token is issued.
+
+### Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `GITHUB_CLIENT_ID` | yes | OAuth App client ID |
+| `GITHUB_CLIENT_SECRET` | yes | OAuth App client secret |
+| `TRUST_PROXY` | no | Set `true` to trust `X-Forwarded-For` for IP extraction (default `false`) |
+
+---
+
 ## Acknowledgements
 
 tokf was heavily inspired by [rtk](https://github.com/rtk-ai/rtk) ([rtk-ai.app](https://www.rtk-ai.app/)) — a CLI proxy that compresses command output before it reaches an AI agent's context window. rtk pioneered the idea and demonstrated that 60–90% context reduction is achievable across common dev tools. tokf takes a different approach (TOML-driven filters, user-overridable library, Claude Code hook integration) but the core insight is theirs.

--- a/crates/tokf-server/Cargo.toml
+++ b/crates/tokf-server/Cargo.toml
@@ -25,6 +25,12 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1"
 sqlx = { version = "=0.8.6", default-features = false, features = ["postgres", "runtime-tokio-rustls", "uuid", "chrono", "macros", "migrate"] }
 uuid = { version = "1", features = ["v4", "serde"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+sha2 = "0.10"
+rand = "0.8"
+hex = "0.4"
+async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/crates/tokf-server/migrations/20260223000001_device_flows.sql
+++ b/crates/tokf-server/migrations/20260223000001_device_flows.sql
@@ -1,0 +1,17 @@
+CREATE TABLE device_flows (
+    id           BIGSERIAL PRIMARY KEY,
+    device_code  TEXT NOT NULL UNIQUE,
+    user_code    TEXT NOT NULL,
+    verification_uri TEXT NOT NULL,
+    interval_secs INT NOT NULL DEFAULT 5,
+    ip_address   TEXT NOT NULL,
+    status       TEXT NOT NULL DEFAULT 'pending'
+                 CHECK (status IN ('pending', 'completed', 'expired', 'denied')),
+    user_id      BIGINT REFERENCES users(id) ON DELETE SET NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at   TIMESTAMPTZ NOT NULL,
+    completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX ON device_flows(ip_address, created_at);
+CREATE INDEX ON device_flows(expires_at);

--- a/crates/tokf-server/src/auth/github.rs
+++ b/crates/tokf-server/src/auth/github.rs
@@ -1,0 +1,236 @@
+use serde::{Deserialize, Serialize};
+
+// ── Response types ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceCodeResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub expires_in: i64,
+    pub interval: i64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum AccessTokenResponse {
+    Success {
+        access_token: String,
+        token_type: String,
+        scope: String,
+    },
+    Pending {
+        error: String,
+        error_description: Option<String>,
+        interval: Option<i64>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubUser {
+    pub id: i64,
+    pub login: String,
+    pub avatar_url: String,
+    pub html_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubOrg {
+    pub login: String,
+}
+
+// ── Trait ────────────────────────────────────────────────────────────────────
+
+#[async_trait::async_trait]
+pub trait GitHubClient: Send + Sync {
+    async fn request_device_code(&self, client_id: &str) -> anyhow::Result<DeviceCodeResponse>;
+
+    async fn poll_access_token(
+        &self,
+        client_id: &str,
+        client_secret: &str,
+        device_code: &str,
+    ) -> anyhow::Result<AccessTokenResponse>;
+
+    async fn get_user(&self, access_token: &str) -> anyhow::Result<GitHubUser>;
+
+    async fn get_user_orgs(&self, access_token: &str) -> anyhow::Result<Vec<GitHubOrg>>;
+}
+
+// ── Real implementation ─────────────────────────────────────────────────────
+
+pub struct RealGitHubClient {
+    http: reqwest::Client,
+}
+
+impl RealGitHubClient {
+    /// Creates a new GitHub API client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying HTTP client cannot be built.
+    pub fn new() -> anyhow::Result<Self> {
+        let http = reqwest::Client::builder()
+            .user_agent("tokf-server")
+            .timeout(std::time::Duration::from_secs(10))
+            .build()?;
+        Ok(Self { http })
+    }
+}
+
+#[async_trait::async_trait]
+impl GitHubClient for RealGitHubClient {
+    async fn request_device_code(&self, client_id: &str) -> anyhow::Result<DeviceCodeResponse> {
+        let resp = self
+            .http
+            .post("https://github.com/login/device/code")
+            .header("Accept", "application/json")
+            .form(&[("client_id", client_id), ("scope", "read:user,read:org")])
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<DeviceCodeResponse>()
+            .await?;
+        Ok(resp)
+    }
+
+    async fn poll_access_token(
+        &self,
+        client_id: &str,
+        client_secret: &str,
+        device_code: &str,
+    ) -> anyhow::Result<AccessTokenResponse> {
+        let resp = self
+            .http
+            .post("https://github.com/login/oauth/access_token")
+            .header("Accept", "application/json")
+            .form(&[
+                ("client_id", client_id),
+                ("client_secret", client_secret),
+                ("device_code", device_code),
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+            ])
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<AccessTokenResponse>()
+            .await?;
+        Ok(resp)
+    }
+
+    async fn get_user(&self, access_token: &str) -> anyhow::Result<GitHubUser> {
+        let user = self
+            .http
+            .get("https://api.github.com/user")
+            .header("Accept", "application/json")
+            .bearer_auth(access_token)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<GitHubUser>()
+            .await?;
+        Ok(user)
+    }
+
+    async fn get_user_orgs(&self, access_token: &str) -> anyhow::Result<Vec<GitHubOrg>> {
+        let orgs = self
+            .http
+            .get("https://api.github.com/user/orgs")
+            .header("Accept", "application/json")
+            .bearer_auth(access_token)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<Vec<GitHubOrg>>()
+            .await?;
+        Ok(orgs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+    use super::*;
+
+    #[test]
+    fn deserializes_device_code_response() {
+        let json = r#"{
+            "device_code": "dc-123",
+            "user_code": "ABCD-1234",
+            "verification_uri": "https://github.com/login/device",
+            "expires_in": 900,
+            "interval": 5
+        }"#;
+        let resp: DeviceCodeResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.device_code, "dc-123");
+        assert_eq!(resp.user_code, "ABCD-1234");
+        assert_eq!(resp.interval, 5);
+    }
+
+    #[test]
+    fn deserializes_access_token_success() {
+        let json = r#"{
+            "access_token": "gho_abc123",
+            "token_type": "bearer",
+            "scope": "read:user,read:org"
+        }"#;
+        let resp: AccessTokenResponse = serde_json::from_str(json).unwrap();
+        assert!(matches!(resp, AccessTokenResponse::Success { .. }));
+    }
+
+    #[test]
+    fn deserializes_access_token_pending() {
+        let json = r#"{
+            "error": "authorization_pending",
+            "error_description": "The authorization request is still pending."
+        }"#;
+        let resp: AccessTokenResponse = serde_json::from_str(json).unwrap();
+        match resp {
+            AccessTokenResponse::Pending { error, .. } => {
+                assert_eq!(error, "authorization_pending");
+            }
+            AccessTokenResponse::Success { .. } => panic!("expected Pending variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_access_token_slow_down() {
+        let json = r#"{
+            "error": "slow_down",
+            "error_description": "Too many requests.",
+            "interval": 10
+        }"#;
+        let resp: AccessTokenResponse = serde_json::from_str(json).unwrap();
+        match resp {
+            AccessTokenResponse::Pending {
+                error, interval, ..
+            } => {
+                assert_eq!(error, "slow_down");
+                assert_eq!(interval, Some(10));
+            }
+            AccessTokenResponse::Success { .. } => panic!("expected Pending variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_github_user() {
+        let json = r#"{
+            "id": 42,
+            "login": "octocat",
+            "avatar_url": "https://avatars.githubusercontent.com/u/42",
+            "html_url": "https://github.com/octocat"
+        }"#;
+        let user: GitHubUser = serde_json::from_str(json).unwrap();
+        assert_eq!(user.id, 42);
+        assert_eq!(user.login, "octocat");
+    }
+
+    #[test]
+    fn deserializes_github_orgs() {
+        let json = r#"[{"login": "org-a"}, {"login": "org-b"}]"#;
+        let orgs: Vec<GitHubOrg> = serde_json::from_str(json).unwrap();
+        assert_eq!(orgs.len(), 2);
+        assert_eq!(orgs[0].login, "org-a");
+    }
+}

--- a/crates/tokf-server/src/auth/mock.rs
+++ b/crates/tokf-server/src/auth/mock.rs
@@ -1,0 +1,46 @@
+use crate::auth::github::{
+    AccessTokenResponse, DeviceCodeResponse, GitHubClient, GitHubOrg, GitHubUser,
+};
+
+/// A mock `GitHubClient` for tests that don't exercise the auth routes.
+/// All methods return reasonable defaults.
+pub struct NoOpGitHubClient;
+
+#[async_trait::async_trait]
+impl GitHubClient for NoOpGitHubClient {
+    async fn request_device_code(&self, _client_id: &str) -> anyhow::Result<DeviceCodeResponse> {
+        Ok(DeviceCodeResponse {
+            device_code: "mock-dc".to_string(),
+            user_code: "MOCK-1234".to_string(),
+            verification_uri: "https://github.com/login/device".to_string(),
+            expires_in: 900,
+            interval: 5,
+        })
+    }
+
+    async fn poll_access_token(
+        &self,
+        _client_id: &str,
+        _client_secret: &str,
+        _device_code: &str,
+    ) -> anyhow::Result<AccessTokenResponse> {
+        Ok(AccessTokenResponse::Pending {
+            error: "authorization_pending".to_string(),
+            error_description: None,
+            interval: None,
+        })
+    }
+
+    async fn get_user(&self, _access_token: &str) -> anyhow::Result<GitHubUser> {
+        Ok(GitHubUser {
+            id: 1,
+            login: "mock-user".to_string(),
+            avatar_url: "https://example.com/avatar.png".to_string(),
+            html_url: "https://github.com/mock-user".to_string(),
+        })
+    }
+
+    async fn get_user_orgs(&self, _access_token: &str) -> anyhow::Result<Vec<GitHubOrg>> {
+        Ok(vec![])
+    }
+}

--- a/crates/tokf-server/src/auth/mod.rs
+++ b/crates/tokf-server/src/auth/mod.rs
@@ -1,0 +1,6 @@
+pub mod github;
+// Intentionally public: integration test binaries import `NoOpGitHubClient` via
+// `tokf_server::auth::mock`. A feature gate was considered but adds CI complexity
+// for no real benefit — the mock types are harmless in production builds.
+pub mod mock;
+pub mod token;

--- a/crates/tokf-server/src/auth/token.rs
+++ b/crates/tokf-server/src/auth/token.rs
@@ -1,0 +1,125 @@
+use axum::{extract::FromRequestParts, http::request::Parts};
+use sha2::{Digest, Sha256};
+use sqlx::PgPool;
+
+use crate::error::AppError;
+
+/// Generates a cryptographically random bearer token (64 hex chars = 32 bytes).
+pub fn generate_token() -> String {
+    use rand::RngCore;
+    let mut buf = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut buf);
+    hex::encode(buf)
+}
+
+/// Returns the SHA-256 hex digest of the given token.
+pub fn hash_token(token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(token.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+/// Authenticated user extracted from `Authorization: Bearer <token>`.
+#[derive(Debug, Clone)]
+pub struct AuthUser {
+    pub user_id: i64,
+    pub username: String,
+}
+
+impl FromRequestParts<crate::state::AppState> for AuthUser {
+    type Rejection = AppError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &crate::state::AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let header = parts
+            .headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .ok_or(AppError::Unauthorized)?;
+
+        let token = header
+            .strip_prefix("Bearer ")
+            .ok_or(AppError::Unauthorized)?;
+        let token_hash = hash_token(token);
+
+        lookup_user_by_token_hash(&state.db, &token_hash).await
+    }
+}
+
+async fn lookup_user_by_token_hash(db: &PgPool, token_hash: &str) -> Result<AuthUser, AppError> {
+    let row = sqlx::query_as::<_, (i64, String, Option<chrono::DateTime<chrono::Utc>>)>(
+        "SELECT u.id, u.username, t.expires_at
+         FROM auth_tokens t
+         JOIN users u ON u.id = t.user_id
+         WHERE t.token_hash = $1",
+    )
+    .bind(token_hash)
+    .fetch_optional(db)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+    .ok_or(AppError::Unauthorized)?;
+
+    let (user_id, username, expires_at) = row;
+
+    if let Some(exp) = expires_at.filter(|&exp| exp < chrono::Utc::now()) {
+        tracing::debug!(expires_at = %exp, "token expired");
+        return Err(AppError::Unauthorized);
+    }
+
+    // Fire-and-forget: update last_used_at
+    let db = db.clone();
+    let hash = token_hash.to_string();
+    tokio::spawn(async move {
+        if let Err(e) =
+            sqlx::query("UPDATE auth_tokens SET last_used_at = NOW() WHERE token_hash = $1")
+                .bind(&hash)
+                .execute(&db)
+                .await
+        {
+            tracing::warn!("failed to update last_used_at: {e}");
+        }
+    });
+
+    Ok(AuthUser { user_id, username })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+
+    #[test]
+    fn generate_token_returns_64_hex_chars() {
+        let token = generate_token();
+        assert_eq!(token.len(), 64);
+        assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn generate_token_is_unique() {
+        let a = generate_token();
+        let b = generate_token();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn hash_token_is_deterministic() {
+        let token = "test-token-123";
+        assert_eq!(hash_token(token), hash_token(token));
+    }
+
+    #[test]
+    fn hash_token_returns_64_hex_chars() {
+        let hash = hash_token("anything");
+        assert_eq!(hash.len(), 64);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn different_tokens_produce_different_hashes() {
+        assert_ne!(hash_token("token-a"), hash_token("token-b"));
+    }
+}

--- a/crates/tokf-server/src/error.rs
+++ b/crates/tokf-server/src/error.rs
@@ -1,0 +1,114 @@
+use axum::{Json, http::StatusCode, response::IntoResponse};
+use serde_json::json;
+
+#[derive(Debug)]
+pub enum AppError {
+    Internal(String),
+    BadRequest(String),
+    NotFound(String),
+    RateLimited,
+    Unauthorized,
+}
+
+impl std::fmt::Display for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Internal(msg) => write!(f, "internal error: {msg}"),
+            Self::BadRequest(msg) => write!(f, "bad request: {msg}"),
+            Self::NotFound(msg) => write!(f, "not found: {msg}"),
+            Self::RateLimited => write!(f, "rate limited"),
+            Self::Unauthorized => write!(f, "unauthorized"),
+        }
+    }
+}
+
+impl std::error::Error for AppError {}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            Self::RateLimited => (
+                StatusCode::TOO_MANY_REQUESTS,
+                [("retry-after", "3600")],
+                Json(json!({ "error": "rate limit exceeded" })),
+            )
+                .into_response(),
+            Self::Internal(msg) => {
+                tracing::error!("internal error: {msg}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": "internal server error" })),
+                )
+                    .into_response()
+            }
+            Self::BadRequest(msg) => {
+                (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response()
+            }
+            Self::NotFound(msg) => {
+                (StatusCode::NOT_FOUND, Json(json!({ "error": msg }))).into_response()
+            }
+            Self::Unauthorized => (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "unauthorized" })),
+            )
+                .into_response(),
+        }
+    }
+}
+
+impl From<sqlx::Error> for AppError {
+    fn from(err: sqlx::Error) -> Self {
+        Self::Internal(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use axum::response::IntoResponse;
+    use http_body_util::BodyExt;
+
+    #[tokio::test]
+    async fn internal_error_returns_500() {
+        let resp = AppError::Internal("db down".to_string()).into_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "internal server error");
+    }
+
+    #[tokio::test]
+    async fn bad_request_returns_400() {
+        let resp = AppError::BadRequest("missing field".to_string()).into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "missing field");
+    }
+
+    #[tokio::test]
+    async fn not_found_returns_404() {
+        let resp = AppError::NotFound("no such flow".to_string()).into_response();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn rate_limited_returns_429_with_retry_after() {
+        let resp = AppError::RateLimited.into_response();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            resp.headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok()),
+            Some("3600")
+        );
+    }
+
+    #[tokio::test]
+    async fn unauthorized_returns_401() {
+        let resp = AppError::Unauthorized.into_response();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/tokf-server/src/lib.rs
+++ b/crates/tokf-server/src/lib.rs
@@ -1,4 +1,6 @@
+pub mod auth;
 pub mod config;
 pub mod db;
+pub mod error;
 pub mod routes;
 pub mod state;

--- a/crates/tokf-server/src/routes/auth.rs
+++ b/crates/tokf-server/src/routes/auth.rs
@@ -1,0 +1,360 @@
+use axum::{Json, extract::State, http::StatusCode};
+use serde::{Deserialize, Serialize};
+
+use crate::auth::github::{AccessTokenResponse, GitHubClient, GitHubUser};
+use crate::auth::token::{generate_token, hash_token};
+use crate::error::AppError;
+use crate::state::AppState;
+
+const MAX_FLOWS_PER_IP_PER_HOUR: i64 = 10;
+const TOKEN_TTL_SECONDS: i64 = 7_776_000; // 90 days
+
+// ── Request / Response types ────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct DeviceFlowResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub expires_in: i64,
+    pub interval: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PollTokenRequest {
+    pub device_code: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TokenResponse {
+    pub access_token: String,
+    pub token_type: String,
+    pub expires_in: i64,
+    pub user: TokenUser,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TokenUser {
+    pub id: i64,
+    pub username: String,
+    pub avatar_url: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PendingResponse {
+    pub error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interval: Option<i64>,
+}
+
+// ── IP extraction ───────────────────────────────────────────────────────────
+
+fn extract_ip(headers: &axum::http::HeaderMap, trust_proxy: bool) -> String {
+    if trust_proxy
+        && let Some(ip) = headers
+            .get("x-forwarded-for")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.split(',').next())
+            .map(|s| s.trim().to_string())
+    {
+        return ip;
+    }
+    "unknown".to_string()
+}
+
+// ── POST /api/auth/device ───────────────────────────────────────────────────
+
+/// Starts the GitHub device authorization flow.
+///
+/// # Errors
+///
+/// Returns `RateLimited` if the IP has exceeded 10 requests/hour, or
+/// `Internal` on GitHub API or database failures.
+pub async fn initiate_device_flow(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+) -> Result<(StatusCode, Json<DeviceFlowResponse>), AppError> {
+    let ip = extract_ip(&headers, state.trust_proxy);
+
+    // Piggyback cleanup of expired flows
+    let _ = sqlx::query("DELETE FROM device_flows WHERE expires_at < NOW()")
+        .execute(&state.db)
+        .await;
+
+    // Rate limit check
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM device_flows
+         WHERE ip_address = $1 AND created_at > NOW() - INTERVAL '1 hour'",
+    )
+    .bind(&ip)
+    .fetch_one(&state.db)
+    .await?;
+
+    if count >= MAX_FLOWS_PER_IP_PER_HOUR {
+        return Err(AppError::RateLimited);
+    }
+
+    let gh_resp = state
+        .github
+        .request_device_code(&state.github_client_id)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    // Store the device flow in DB
+    let interval_secs = i32::try_from(gh_resp.interval)
+        .map_err(|_| AppError::Internal("interval out of range".to_string()))?;
+    sqlx::query(
+        "INSERT INTO device_flows (device_code, user_code, verification_uri, interval_secs, ip_address, expires_at)
+         VALUES ($1, $2, $3, $4, $5, NOW() + make_interval(secs => $6))",
+    )
+    .bind(&gh_resp.device_code)
+    .bind(&gh_resp.user_code)
+    .bind(&gh_resp.verification_uri)
+    .bind(interval_secs)
+    .bind(&ip)
+    .bind(gh_resp.expires_in)
+    .execute(&state.db)
+    .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(DeviceFlowResponse {
+            device_code: gh_resp.device_code,
+            user_code: gh_resp.user_code,
+            verification_uri: gh_resp.verification_uri,
+            expires_in: gh_resp.expires_in,
+            interval: gh_resp.interval,
+        }),
+    ))
+}
+
+/// Polls for a completed device authorization and exchanges it for a bearer token.
+///
+/// # Errors
+///
+/// Returns `NotFound` for unknown device codes, `BadRequest` for denied or
+/// expired codes, or `Internal` on GitHub API / database failures.
+/// Re-polling a completed code is idempotent: a fresh token is issued for the
+/// same user.
+pub async fn poll_token(
+    State(state): State<AppState>,
+    Json(req): Json<PollTokenRequest>,
+) -> Result<axum::response::Response, AppError> {
+    let flow = sqlx::query_as::<_, (i64, String, Option<i64>)>(
+        "SELECT id, status, user_id FROM device_flows WHERE device_code = $1",
+    )
+    .bind(&req.device_code)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or_else(|| AppError::NotFound("unknown device code".to_string()))?;
+
+    let (flow_id, status, flow_user_id) = flow;
+
+    // Idempotent: if already completed, issue a fresh token for the same user
+    if status == "completed" {
+        return match flow_user_id {
+            Some(uid) => build_token_response(&state, uid).await,
+            None => Err(AppError::BadRequest("device code already used".to_string())),
+        };
+    }
+
+    // Poll GitHub for access token
+    let gh_resp = state
+        .github
+        .poll_access_token(
+            &state.github_client_id,
+            &state.github_client_secret,
+            &req.device_code,
+        )
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    match gh_resp {
+        AccessTokenResponse::Pending {
+            error, interval, ..
+        } => handle_pending_response(&state, flow_id, &error, interval).await,
+        AccessTokenResponse::Success { access_token, .. } => {
+            handle_github_success(&state, flow_id, &access_token).await
+        }
+    }
+}
+
+// ── Internal helpers ────────────────────────────────────────────────────────
+
+async fn handle_pending_response(
+    state: &AppState,
+    flow_id: i64,
+    error: &str,
+    interval: Option<i64>,
+) -> Result<axum::response::Response, AppError> {
+    match error {
+        "authorization_pending" => {
+            let body = PendingResponse {
+                error: error.to_string(),
+                interval: None,
+            };
+            Ok(axum::response::IntoResponse::into_response((
+                StatusCode::OK,
+                Json(body),
+            )))
+        }
+        "slow_down" => {
+            let body = PendingResponse {
+                error: error.to_string(),
+                interval,
+            };
+            Ok(axum::response::IntoResponse::into_response((
+                StatusCode::OK,
+                Json(body),
+            )))
+        }
+        "expired_token" => {
+            let _ = sqlx::query("UPDATE device_flows SET status = 'expired' WHERE id = $1")
+                .bind(flow_id)
+                .execute(&state.db)
+                .await;
+            Err(AppError::BadRequest("device code expired".to_string()))
+        }
+        "access_denied" => {
+            let _ = sqlx::query("UPDATE device_flows SET status = 'denied' WHERE id = $1")
+                .bind(flow_id)
+                .execute(&state.db)
+                .await;
+            Err(AppError::BadRequest("access denied by user".to_string()))
+        }
+        _ => Err(AppError::Internal(format!(
+            "unexpected GitHub error: {error}"
+        ))),
+    }
+}
+
+async fn handle_github_success(
+    state: &AppState,
+    flow_id: i64,
+    access_token: &str,
+) -> Result<axum::response::Response, AppError> {
+    let (user, orgs) = fetch_github_profile(&*state.github, access_token).await?;
+    let user_id = upsert_github_user(state, &user, &orgs).await?;
+    let (bearer, expires_in) = create_bearer_token(state, user_id).await?;
+
+    // Atomic CAS: only mark completed if still pending (prevents races)
+    let result = sqlx::query(
+        "UPDATE device_flows SET status = 'completed', user_id = $1, completed_at = NOW()
+         WHERE id = $2 AND status = 'pending'",
+    )
+    .bind(user_id)
+    .bind(flow_id)
+    .execute(&state.db)
+    .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::BadRequest("device code already used".to_string()));
+    }
+
+    let resp = TokenResponse {
+        access_token: bearer,
+        token_type: "bearer".to_string(),
+        expires_in,
+        user: TokenUser {
+            id: user_id,
+            username: user.login,
+            avatar_url: user.avatar_url,
+        },
+    };
+    Ok(axum::response::IntoResponse::into_response((
+        StatusCode::OK,
+        Json(resp),
+    )))
+}
+
+/// Look up a user by ID and issue a fresh bearer token.
+async fn build_token_response(
+    state: &AppState,
+    user_id: i64,
+) -> Result<axum::response::Response, AppError> {
+    let (username, avatar_url): (String, String) =
+        sqlx::query_as("SELECT username, avatar_url FROM users WHERE id = $1")
+            .bind(user_id)
+            .fetch_one(&state.db)
+            .await?;
+
+    let (bearer, expires_in) = create_bearer_token(state, user_id).await?;
+
+    let resp = TokenResponse {
+        access_token: bearer,
+        token_type: "bearer".to_string(),
+        expires_in,
+        user: TokenUser {
+            id: user_id,
+            username,
+            avatar_url,
+        },
+    };
+    Ok(axum::response::IntoResponse::into_response((
+        StatusCode::OK,
+        Json(resp),
+    )))
+}
+
+async fn upsert_github_user(
+    state: &AppState,
+    user: &GitHubUser,
+    orgs: &[crate::auth::github::GitHubOrg],
+) -> Result<i64, AppError> {
+    let org_logins: Vec<&str> = orgs.iter().map(|o| o.login.as_str()).collect();
+    let orgs_json =
+        serde_json::to_value(&org_logins).map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let user_id: i64 = sqlx::query_scalar(
+        "INSERT INTO users (github_id, username, avatar_url, profile_url, orgs)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (github_id) DO UPDATE SET
+             username = EXCLUDED.username,
+             avatar_url = EXCLUDED.avatar_url,
+             profile_url = EXCLUDED.profile_url,
+             orgs = EXCLUDED.orgs,
+             updated_at = NOW()
+         RETURNING id",
+    )
+    .bind(user.id)
+    .bind(&user.login)
+    .bind(&user.avatar_url)
+    .bind(&user.html_url)
+    .bind(&orgs_json)
+    .fetch_one(&state.db)
+    .await?;
+
+    Ok(user_id)
+}
+
+/// Generate and store a bearer token with a 90-day TTL.
+async fn create_bearer_token(state: &AppState, user_id: i64) -> Result<(String, i64), AppError> {
+    let bearer = generate_token();
+    let bearer_hash = hash_token(&bearer);
+
+    sqlx::query(
+        "INSERT INTO auth_tokens (user_id, token_hash, expires_at)
+         VALUES ($1, $2, NOW() + INTERVAL '90 days')",
+    )
+    .bind(user_id)
+    .bind(&bearer_hash)
+    .execute(&state.db)
+    .await?;
+
+    Ok((bearer, TOKEN_TTL_SECONDS))
+}
+
+async fn fetch_github_profile(
+    github: &dyn GitHubClient,
+    access_token: &str,
+) -> Result<(GitHubUser, Vec<crate::auth::github::GitHubOrg>), AppError> {
+    let user = github
+        .get_user(access_token)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    let orgs = github
+        .get_user_orgs(access_token)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok((user, orgs))
+}

--- a/crates/tokf-server/src/routes/health.rs
+++ b/crates/tokf-server/src/routes/health.rs
@@ -29,6 +29,9 @@ mod tests {
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
+    use std::sync::Arc;
+
+    use crate::auth::mock::NoOpGitHubClient;
     use crate::state::AppState;
 
     fn test_state() -> AppState {
@@ -37,7 +40,13 @@ mod tests {
         let pool = sqlx::postgres::PgPoolOptions::new()
             .connect_lazy(&url)
             .expect("invalid DATABASE_URL");
-        AppState { db: pool }
+        AppState {
+            db: pool,
+            github: Arc::new(NoOpGitHubClient),
+            github_client_id: "test-client-id".to_string(),
+            github_client_secret: "test-client-secret".to_string(),
+            trust_proxy: true,
+        }
     }
 
     #[tokio::test]

--- a/crates/tokf-server/src/routes/mod.rs
+++ b/crates/tokf-server/src/routes/mod.rs
@@ -1,7 +1,11 @@
+pub mod auth;
 mod health;
 mod ready;
 
-use axum::{Router, routing::get};
+use axum::{
+    Router,
+    routing::{get, post},
+};
 
 use crate::state::AppState;
 
@@ -9,5 +13,7 @@ pub fn create_router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health::health))
         .route("/ready", get(ready::ready))
+        .route("/api/auth/device", post(auth::initiate_device_flow))
+        .route("/api/auth/token", post(auth::poll_token))
         .with_state(state)
 }

--- a/crates/tokf-server/src/routes/ready.rs
+++ b/crates/tokf-server/src/routes/ready.rs
@@ -42,6 +42,9 @@ mod tests {
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
+    use std::sync::Arc;
+
+    use crate::auth::mock::NoOpGitHubClient;
     use crate::state::AppState;
 
     /// Creates an `AppState` whose pool will always fail to acquire a connection.
@@ -52,7 +55,13 @@ mod tests {
             .acquire_timeout(std::time::Duration::from_millis(500))
             .connect_lazy("postgres://tokf:tokf@nonexistent-host.invalid:5432/tokf")
             .expect("lazy pool creation should not fail");
-        AppState { db: pool }
+        AppState {
+            db: pool,
+            github: Arc::new(NoOpGitHubClient),
+            github_client_id: "test-client-id".to_string(),
+            github_client_secret: "test-client-secret".to_string(),
+            trust_proxy: true,
+        }
     }
 
     #[tokio::test]

--- a/crates/tokf-server/src/state.rs
+++ b/crates/tokf-server/src/state.rs
@@ -1,4 +1,12 @@
+use std::sync::Arc;
+
+use crate::auth::github::GitHubClient;
+
 #[derive(Clone)]
 pub struct AppState {
     pub db: sqlx::PgPool,
+    pub github: Arc<dyn GitHubClient>,
+    pub github_client_id: String,
+    pub github_client_secret: String,
+    pub trust_proxy: bool,
 }


### PR DESCRIPTION
## Summary

- Add `POST /api/auth/device` and `POST /api/auth/token` endpoints implementing the GitHub device authorization flow
- Create `device_flows` migration with CHECK constraint on status
- Add `auth` module: `GitHubClient` trait (real + mock), SHA-256 token hashing, `AuthUser` extractor
- Add `AppError` enum with proper HTTP status codes and `Retry-After` on 429
- Add `TRUST_PROXY` and `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` config
- Rate limiting (10 requests/IP/hour), atomic CAS on completion, idempotent re-poll
- 10s request timeout on outbound GitHub API calls
- Document auth endpoints in README

Closes #111

## Test plan

- [x] 37 non-DB tests pass (`cargo test -p tokf-server`)
- [x] 811 workspace tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Formatting clean (`cargo fmt -- --check`)
- [ ] DB integration tests with live Postgres (CI runs `--include-ignored`)
  - Full device flow E2E (initiate → poll → user + token in DB)
  - Idempotent re-poll issues fresh token
  - Rate limit rejects 11th request
  - Expired flow cleanup on initiate
  - AuthUser extractor: valid, expired, missing header, NULL expires_at
  - Unknown GitHub error returns 500
  - Token response includes `expires_in`

🤖 Generated with [Claude Code](https://claude.com/claude-code)