### PR TITLE
feat(cli): pipe stripping control, --prefer-less mode, and override tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,17 @@ This copies the filter TOML and its test suite to your config directory, where i
 | `--no-filter` | Pass output through without filtering |
 | `--no-cache` | Bypass the filter discovery cache |
 | `--no-mask-exit-code` | Disable exit-code masking. By default tokf exits 0 and prepends `Error: Exit code N` on failure (works around [claude-code#27621](https://github.com/anthropics/claude-code/issues/27621)) |
+| `--baseline-pipe` | Pipe command for fair baseline accounting (injected by rewrite) |
+| `--prefer-less` | Compare filtered vs piped output and use whichever is smaller (requires `--baseline-pipe`) |
+
+### Rewrite configuration (`rewrites.toml`)
+
+tokf looks for a `rewrites.toml` file in two locations (first found wins):
+
+1. **Project-local**: `.tokf/rewrites.toml` — scoped to the current repository
+2. **User-level**: `~/.config/tokf/rewrites.toml` — applies to all projects
+
+This file controls custom rewrite rules, skip patterns, and pipe handling. All `[pipe]`, `[skip]`, and `[[rewrite]]` sections documented below go in this file.
 
 ### Piped commands
 
@@ -246,6 +257,44 @@ replace = "tokf run {0}"
 ```
 
 Use `tokf rewrite --verbose "cargo test | grep FAILED"` to see how a command is being rewritten.
+
+#### Disabling pipe stripping
+
+If you prefer tokf to never strip pipes (leaving piped commands unchanged), add a `[pipe]` section to `.tokf/rewrites.toml`:
+
+```toml
+[pipe]
+strip = false   # default: true
+```
+
+When `strip = false`, commands like `cargo test | tail -5` pass through the shell unchanged. Non-piped commands are still rewritten normally.
+
+#### Prefer less context mode
+
+Sometimes the piped output (e.g. `tail -5`) is actually smaller than the filtered output. The `prefer_less` option tells tokf to compare both at runtime and use whichever is smaller:
+
+```toml
+[pipe]
+prefer_less = true   # default: false
+```
+
+When a pipe is stripped, tokf injects `--prefer-less` alongside `--baseline-pipe`. At runtime:
+1. The filter runs normally
+2. The original pipe command also runs on the raw output
+3. tokf prints whichever result is smaller
+
+When the pipe output wins, the event is recorded with `pipe_override = 1` in the tracking DB. The `tokf gain` command shows how many times this happened:
+
+```
+tokf gain summary
+  total runs:     42
+  input tokens:   12,500 est.
+  output tokens:  3,200 est.
+  tokens saved:   9,300 est. (74.4%)
+  pipe preferred: 5 runs (pipe output was smaller than filter)
+```
+
+Note: `strip = false` takes priority — if pipe stripping is disabled, `prefer_less` has no effect.
 
 ### Environment variable prefixes
 

--- a/crates/tokf-cli/src/baseline.rs
+++ b/crates/tokf-cli/src/baseline.rs
@@ -11,19 +11,20 @@ const ALLOWED_COMMANDS: &[&str] = &["tail", "head", "grep"];
 /// Maximum time to wait for the baseline pipe command before falling back.
 const TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Run the pipe command on the raw output to get the exact byte count
-/// the user would have seen without tokf.
+/// Run the pipe command on the raw output and return the actual text the
+/// user would have seen.
 ///
 /// Only allows `tail`, `head`, and `grep` as pipe commands (matching the
-/// rewrite module's strippable set). Falls back to `raw_output.len()` with
-/// a stderr warning on validation failure, spawn failure, or timeout.
-pub fn compute(raw_output: &str, pipe_cmd: &str) -> usize {
+/// rewrite module's strippable set). Returns `None` on validation failure,
+/// spawn failure, timeout, or read error — callers should fall back to
+/// `raw_output` in that case.
+pub fn compute_output(raw_output: &str, pipe_cmd: &str) -> Option<String> {
     let first_word = pipe_cmd.split_whitespace().next().unwrap_or("");
     if !ALLOWED_COMMANDS.contains(&first_word) {
         eprintln!(
             "[tokf] warning: --baseline-pipe command '{first_word}' not allowed, using full output"
         );
-        return raw_output.len();
+        return None;
     }
 
     let Ok(mut child) = Command::new("sh")
@@ -34,7 +35,7 @@ pub fn compute(raw_output: &str, pipe_cmd: &str) -> usize {
         .spawn()
     else {
         eprintln!("[tokf] warning: --baseline-pipe failed to spawn, using full output");
-        return raw_output.len();
+        return None;
     };
 
     if let Some(stdin) = child.stdin.as_mut() {
@@ -48,12 +49,12 @@ pub fn compute(raw_output: &str, pipe_cmd: &str) -> usize {
         match child.try_wait() {
             Ok(Some(_status)) => {
                 return match child.wait_with_output() {
-                    Ok(output) => output.stdout.len(),
+                    Ok(output) => String::from_utf8(output.stdout).ok(),
                     Err(e) => {
                         eprintln!(
                             "[tokf] warning: --baseline-pipe read failed: {e}, using full output"
                         );
-                        raw_output.len()
+                        None
                     }
                 };
             }
@@ -64,14 +65,69 @@ pub fn compute(raw_output: &str, pipe_cmd: &str) -> usize {
                         "[tokf] warning: --baseline-pipe timed out after {}s, using full output",
                         TIMEOUT.as_secs()
                     );
-                    return raw_output.len();
+                    return None;
                 }
                 std::thread::sleep(Duration::from_millis(10));
             }
             Err(e) => {
                 eprintln!("[tokf] warning: --baseline-pipe wait failed: {e}, using full output");
-                return raw_output.len();
+                return None;
             }
         }
+    }
+}
+
+/// Run the pipe command on the raw output to get the exact byte count
+/// the user would have seen without tokf.
+///
+/// Falls back to `raw_output.len()` when the pipe command fails.
+pub fn compute(raw_output: &str, pipe_cmd: &str) -> usize {
+    compute_output(raw_output, pipe_cmd).map_or(raw_output.len(), |s| s.len())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_output_tail() {
+        let input = "line1\nline2\nline3\nline4\nline5\n";
+        let result = compute_output(input, "tail -2").unwrap();
+        assert_eq!(result, "line4\nline5\n");
+    }
+
+    #[test]
+    fn compute_output_head() {
+        let input = "line1\nline2\nline3\nline4\nline5\n";
+        let result = compute_output(input, "head -2").unwrap();
+        assert_eq!(result, "line1\nline2\n");
+    }
+
+    #[test]
+    fn compute_output_grep() {
+        let input = "apple\nbanana\napricot\ncherry\n";
+        let result = compute_output(input, "grep ap").unwrap();
+        assert_eq!(result, "apple\napricot\n");
+    }
+
+    #[test]
+    fn compute_output_disallowed_command() {
+        let result = compute_output("data", "rm -rf /");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn compute_delegates_to_compute_output() {
+        let input = "line1\nline2\nline3\n";
+        let bytes = compute(input, "head -1");
+        assert_eq!(bytes, "line1\n".len());
+    }
+
+    #[test]
+    fn compute_fallback_on_disallowed() {
+        let input = "some data";
+        let bytes = compute(input, "cat");
+        assert_eq!(bytes, input.len());
     }
 }

--- a/crates/tokf-cli/src/gain.rs
+++ b/crates/tokf-cli/src/gain.rs
@@ -49,6 +49,12 @@ fn cmd_gain_summary(conn: &rusqlite::Connection, json: bool) -> i32 {
                     format_num(s.tokens_saved),
                     s.savings_pct
                 );
+                if s.pipe_override_count > 0 {
+                    println!(
+                        "  pipe preferred: {} runs (pipe output was smaller than filter)",
+                        s.pipe_override_count
+                    );
+                }
             }
             0
         }
@@ -73,8 +79,13 @@ fn cmd_gain_by_filter(conn: &rusqlite::Connection, json: bool) -> i32 {
             } else {
                 println!("tokf gain by filter");
                 for r in &rows {
+                    let override_note = if r.pipe_override_count > 0 {
+                        format!("  pipe: {}", r.pipe_override_count)
+                    } else {
+                        String::new()
+                    };
                     println!(
-                        "  {:30}  runs: {:4}  saved: {} est. ({:.1}%)",
+                        "  {:30}  runs: {:4}  saved: {} est. ({:.1}%){override_note}",
                         r.filter_name,
                         r.commands,
                         format_num(r.tokens_saved),
@@ -105,8 +116,13 @@ fn cmd_gain_daily(conn: &rusqlite::Connection, json: bool) -> i32 {
             } else {
                 println!("tokf gain daily");
                 for r in &rows {
+                    let override_note = if r.pipe_override_count > 0 {
+                        format!("  pipe: {}", r.pipe_override_count)
+                    } else {
+                        String::new()
+                    };
                     println!(
-                        "  {}  runs: {:4}  saved: {} est. ({:.1}%)",
+                        "  {}  runs: {:4}  saved: {} est. ({:.1}%){override_note}",
                         r.date,
                         r.commands,
                         format_num(r.tokens_saved),

--- a/crates/tokf-cli/src/resolve.rs
+++ b/crates/tokf-cli/src/resolve.rs
@@ -116,6 +116,7 @@ pub fn record_run(
     output_bytes: usize,
     filter_time_ms: u128,
     exit_code: i32,
+    pipe_override: bool,
 ) {
     let Some(path) = tracking::db_path() else {
         eprintln!("[tokf] tracking: cannot determine DB path");
@@ -136,6 +137,7 @@ pub fn record_run(
         output_bytes,
         filter_time_ms,
         exit_code,
+        pipe_override,
     );
     if let Err(e) = tracking::record_event(&conn, &event) {
         eprintln!("[tokf] tracking error (record): {e:#}");

--- a/crates/tokf-cli/src/rewrite/tests.rs
+++ b/crates/tokf-cli/src/rewrite/tests.rs
@@ -223,6 +223,7 @@ fn rewrite_user_rule_takes_priority() {
 
     let config = RewriteConfig {
         skip: None,
+        pipe: None,
         rewrite: vec![RewriteRule {
             match_pattern: "^git status".to_string(),
             replace: "custom-wrapper {0}".to_string(),
@@ -245,6 +246,7 @@ fn rewrite_user_skip_prevents_rewrite() {
         skip: Some(types::SkipConfig {
             patterns: vec!["^git status".to_string()],
         }),
+        pipe: None,
         rewrite: vec![],
     };
     let result = rewrite_with_config("git status", &config, &[dir.path().to_path_buf()], false);
@@ -491,6 +493,7 @@ fn rewrite_user_rule_wraps_piped_command() {
     let dir = TempDir::new().unwrap();
     let config = RewriteConfig {
         skip: None,
+        pipe: None,
         rewrite: vec![RewriteRule {
             match_pattern: "^cargo test".to_string(),
             replace: "my-wrapper {0}{rest}".to_string(),
@@ -514,6 +517,7 @@ fn rewrite_skip_pattern_wins_over_pipe_guard() {
         skip: Some(types::SkipConfig {
             patterns: vec!["^git".to_string()],
         }),
+        pipe: None,
         rewrite: vec![],
     };
     let r = rewrite_with_config(

--- a/crates/tokf-cli/src/rewrite/tests_env.rs
+++ b/crates/tokf-cli/src/rewrite/tests_env.rs
@@ -226,6 +226,7 @@ fn rewrite_user_skip_pattern_matches_env_stripped_command() {
         skip: Some(types::SkipConfig {
             patterns: vec!["^git".to_string()],
         }),
+        pipe: None,
         rewrite: vec![],
     };
     // "FOO=bar git status" does NOT start with "git", so skip does not fire

--- a/crates/tokf-cli/src/rewrite/tests_pipe.rs
+++ b/crates/tokf-cli/src/rewrite/tests_pipe.rs
@@ -1,0 +1,176 @@
+//! Tests for the `[pipe]` config section: strip toggle and prefer-less flag injection.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::fs;
+
+use tempfile::TempDir;
+
+use super::*;
+
+// --- pipe strip toggle ---
+
+#[test]
+fn rewrite_pipe_strip_disabled_preserves_pipe() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("cargo-test.toml"),
+        "command = \"cargo test\"",
+    )
+    .unwrap();
+
+    let config = RewriteConfig {
+        skip: None,
+        pipe: Some(types::PipeConfig {
+            strip: false,
+            prefer_less: false,
+        }),
+        rewrite: vec![],
+    };
+    let r = rewrite_with_config(
+        "cargo test | tail -5",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    // strip=false: pipe is preserved, command passes through unchanged.
+    assert_eq!(r, "cargo test | tail -5");
+}
+
+#[test]
+fn rewrite_pipe_strip_disabled_non_piped_still_rewritten() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("cargo-test.toml"),
+        "command = \"cargo test\"",
+    )
+    .unwrap();
+
+    let config = RewriteConfig {
+        skip: None,
+        pipe: Some(types::PipeConfig {
+            strip: false,
+            prefer_less: false,
+        }),
+        rewrite: vec![],
+    };
+    let r = rewrite_with_config(
+        "cargo test --lib",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    // Non-piped commands are still rewritten normally.
+    assert_eq!(r, "tokf run cargo test --lib");
+}
+
+// --- prefer_less flag injection ---
+
+#[test]
+fn rewrite_prefer_less_injects_flag() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("cargo-test.toml"),
+        "command = \"cargo test\"",
+    )
+    .unwrap();
+
+    let config = RewriteConfig {
+        skip: None,
+        pipe: Some(types::PipeConfig {
+            strip: true,
+            prefer_less: true,
+        }),
+        rewrite: vec![],
+    };
+    let r = rewrite_with_config(
+        "cargo test | tail -5",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(
+        r,
+        "tokf run --baseline-pipe 'tail -5' --prefer-less cargo test"
+    );
+}
+
+#[test]
+fn rewrite_prefer_less_without_pipe_no_effect() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("cargo-test.toml"),
+        "command = \"cargo test\"",
+    )
+    .unwrap();
+
+    let config = RewriteConfig {
+        skip: None,
+        pipe: Some(types::PipeConfig {
+            strip: true,
+            prefer_less: true,
+        }),
+        rewrite: vec![],
+    };
+    let r = rewrite_with_config(
+        "cargo test --lib",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    // No pipe to strip, so --prefer-less is not injected.
+    assert_eq!(r, "tokf run cargo test --lib");
+}
+
+#[test]
+fn rewrite_strip_false_overrides_prefer_less() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("cargo-test.toml"),
+        "command = \"cargo test\"",
+    )
+    .unwrap();
+
+    let config = RewriteConfig {
+        skip: None,
+        pipe: Some(types::PipeConfig {
+            strip: false,
+            prefer_less: true,
+        }),
+        rewrite: vec![],
+    };
+    let r = rewrite_with_config(
+        "cargo test | tail -5",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    // strip=false takes priority — pipe is preserved, prefer_less has no effect.
+    assert_eq!(r, "cargo test | tail -5");
+}
+
+#[test]
+fn rewrite_compound_prefer_less_per_segment() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("git-add.toml"), "command = \"git add\"").unwrap();
+    fs::write(dir.path().join("git-diff.toml"), "command = \"git diff\"").unwrap();
+
+    let config = RewriteConfig {
+        skip: None,
+        pipe: Some(types::PipeConfig {
+            strip: true,
+            prefer_less: true,
+        }),
+        rewrite: vec![],
+    };
+    let r = rewrite_with_config(
+        "git add . && git diff | head -5",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(
+        r,
+        "tokf run git add . && tokf run --baseline-pipe 'head -5' --prefer-less git diff"
+    );
+}

--- a/crates/tokf-cli/src/rewrite/types.rs
+++ b/crates/tokf-cli/src/rewrite/types.rs
@@ -1,14 +1,36 @@
 use serde::Deserialize;
 
+const fn default_true() -> bool {
+    true
+}
+
 /// User-provided overrides loaded from `rewrites.toml`.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct RewriteConfig {
     /// Additional skip patterns (commands matching these are never rewritten).
     pub skip: Option<SkipConfig>,
 
+    /// Pipe stripping and prefer-less-context behaviour.
+    pub pipe: Option<PipeConfig>,
+
     /// User-defined rewrite rules (checked before auto-generated filter rules).
     #[serde(default)]
     pub rewrite: Vec<RewriteRule>,
+}
+
+/// Controls how tokf handles piped commands during rewriting.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PipeConfig {
+    /// Whether to strip simple pipes (tail/head/grep) when a filter matches.
+    /// Default: true (current behaviour).
+    #[serde(default = "default_true")]
+    pub strip: bool,
+
+    /// When true and a pipe is stripped, inject `--prefer-less` so that at
+    /// runtime tokf compares filtered vs piped output and uses whichever is
+    /// smaller.
+    #[serde(default)]
+    pub prefer_less: bool,
 }
 
 /// Extra skip patterns from user config.
@@ -101,5 +123,77 @@ patterns = []
         let config: RewriteConfig = toml::from_str(toml_str).unwrap();
         let skip = config.skip.unwrap();
         assert!(skip.patterns.is_empty());
+    }
+
+    #[test]
+    fn deserialize_pipe_section_defaults() {
+        let toml_str = r"
+[pipe]
+";
+        let config: RewriteConfig = toml::from_str(toml_str).unwrap();
+        let pipe = config.pipe.unwrap();
+        assert!(pipe.strip, "strip should default to true");
+        assert!(!pipe.prefer_less, "prefer_less should default to false");
+    }
+
+    #[test]
+    fn deserialize_pipe_strip_false() {
+        let toml_str = r"
+[pipe]
+strip = false
+";
+        let config: RewriteConfig = toml::from_str(toml_str).unwrap();
+        let pipe = config.pipe.unwrap();
+        assert!(!pipe.strip);
+    }
+
+    #[test]
+    fn deserialize_pipe_prefer_less_true() {
+        let toml_str = r"
+[pipe]
+prefer_less = true
+";
+        let config: RewriteConfig = toml::from_str(toml_str).unwrap();
+        let pipe = config.pipe.unwrap();
+        assert!(pipe.strip, "strip should still default to true");
+        assert!(pipe.prefer_less);
+    }
+
+    #[test]
+    fn deserialize_pipe_both_fields() {
+        let toml_str = r"
+[pipe]
+strip = false
+prefer_less = true
+";
+        let config: RewriteConfig = toml::from_str(toml_str).unwrap();
+        let pipe = config.pipe.unwrap();
+        assert!(!pipe.strip);
+        assert!(pipe.prefer_less);
+    }
+
+    #[test]
+    fn deserialize_no_pipe_section() {
+        let config: RewriteConfig = toml::from_str("").unwrap();
+        assert!(config.pipe.is_none());
+    }
+
+    #[test]
+    fn deserialize_pipe_with_other_sections() {
+        let toml_str = r#"
+[skip]
+patterns = ["^my-tool"]
+
+[pipe]
+strip = false
+
+[[rewrite]]
+match = "^docker compose"
+replace = "tokf run {0}"
+"#;
+        let config: RewriteConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.skip.is_some());
+        assert!(!config.pipe.unwrap().strip);
+        assert_eq!(config.rewrite.len(), 1);
     }
 }

--- a/crates/tokf-cli/tests/cli_tracking.rs
+++ b/crates/tokf-cli/tests/cli_tracking.rs
@@ -150,7 +150,7 @@ fn gain_tokens_saved_positive_after_filtered_run() {
     use tokf::tracking;
     let path = db.clone();
     let conn = tracking::open_db(&path).expect("open");
-    let ev = tracking::build_event("git status", Some("git status"), 4000, 400, 5, 0);
+    let ev = tracking::build_event("git status", Some("git status"), 4000, 400, 5, 0, false);
     tracking::record_event(&conn, &ev).expect("record");
     drop(conn);
 

--- a/crates/tokf-common/src/tracking/types.rs
+++ b/crates/tokf-common/src/tracking/types.rs
@@ -8,6 +8,8 @@ pub struct TrackingEvent {
     pub output_tokens_est: i64,
     pub filter_time_ms: i64,
     pub exit_code: i32,
+    /// True when `--prefer-less` chose the piped output over the filtered output.
+    pub pipe_override: bool,
 }
 
 #[derive(serde::Serialize)]
@@ -17,6 +19,7 @@ pub struct GainSummary {
     pub total_output_tokens: i64,
     pub tokens_saved: i64,
     pub savings_pct: f64,
+    pub pipe_override_count: i64,
 }
 
 #[derive(serde::Serialize)]
@@ -27,6 +30,7 @@ pub struct DailyGain {
     pub output_tokens: i64,
     pub tokens_saved: i64,
     pub savings_pct: f64,
+    pub pipe_override_count: i64,
 }
 
 #[derive(serde::Serialize)]
@@ -37,4 +41,5 @@ pub struct FilterGain {
     pub output_tokens: i64,
     pub tokens_saved: i64,
     pub savings_pct: f64,
+    pub pipe_override_count: i64,
 }


### PR DESCRIPTION
## Summary

- Add `[pipe]` config section to `rewrites.toml` with `strip` toggle (default: true) and `prefer_less` option
- At runtime, `--prefer-less` compares filtered vs piped output and prints whichever is smaller
- Track pipe overrides in the SQLite DB (`pipe_override` column) and display in `tokf gain`
- Cache piped output to avoid double execution when prefer-less is active
- `--prefer-less` without `--baseline-pipe` is a safe no-op (command runs normally)
- Add verbose-mode warning when `--prefer-less` has no effect (passthrough path)
- Document `rewrites.toml` search paths (`.tokf/rewrites.toml` project-local, `~/.config/tokf/rewrites.toml` user-level)

## Test plan

- [x] 871 tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] No file size hard limit violations
- [x] 5 new integration tests in `cli_baseline.rs` covering prefer-less runtime:
  - Filtered output wins → `pipe_override=false`
  - Piped output wins → `pipe_override=true`, correct output printed
  - `--prefer-less` without `--baseline-pipe` → no-op, runs normally
  - Disallowed pipe command → falls back to filtered
  - Passthrough path → verbose warning emitted
- [x] 6 new pipe control unit tests in `tests_pipe.rs`
- [x] 6 new tracking tests for `pipe_override` persistence and aggregation
- [x] 11 deserialization tests for `PipeConfig` in `types.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)