### PR TITLE
feat(cli): add --raw flag to history show

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ tokf history list              # recent entries (current project)
 tokf history list -l 20        # show 20 entries
 tokf history list --all        # entries from all projects
 tokf history show 42           # full details for entry #42
+tokf history show --raw 42     # print only the raw captured output
 tokf history search "error"    # search by command or output content
 tokf history clear             # clear current project history
 tokf history clear --all       # clear all history (destructive)
@@ -645,7 +646,7 @@ output = "{branch} — {counts}"
 
 ```
 ✓ cargo test: 42 passed (2.31s)
-Filtered - for full content call: `tokf history show 99`
+Filtered - full output: `tokf history show --raw 99`
 ```
 
 The hint is appended to stdout so it is visible to both humans and LLMs in the tool output. The history entry itself always stores the clean filtered output, without the hint line.

--- a/crates/tokf-cli/src/history_cmd.rs
+++ b/crates/tokf-cli/src/history_cmd.rs
@@ -31,7 +31,7 @@ pub fn cmd_history_list(limit: usize, all: bool) -> anyhow::Result<i32> {
     Ok(0)
 }
 
-pub fn cmd_history_show(id: i64) -> anyhow::Result<i32> {
+pub fn cmd_history_show(id: i64, raw: bool) -> anyhow::Result<i32> {
     let conn = open_history_conn()?;
 
     let entry = history::get_history_entry(&conn, id)?;
@@ -39,6 +39,11 @@ pub fn cmd_history_show(id: i64) -> anyhow::Result<i32> {
         eprintln!("[tokf] history entry {id} not found");
         return Ok(1);
     };
+
+    if raw {
+        print!("{}", entry.raw_output);
+        return Ok(0);
+    }
 
     println!("ID: {}", entry.id);
     println!("Timestamp: {}", entry.timestamp);

--- a/crates/tokf-cli/src/main.rs
+++ b/crates/tokf-cli/src/main.rs
@@ -205,6 +205,9 @@ enum HistoryAction {
     Show {
         /// Entry ID to show
         id: i64,
+        /// Print only the raw captured output (no metadata, no filtered output)
+        #[arg(long)]
+        raw: bool,
     },
     /// Search history by command or output content (current project by default)
     Search {
@@ -367,7 +370,7 @@ fn cmd_run(
     }
 
     if show_hint && let Some(id) = history_id {
-        println!("Filtered - for full content call: `tokf history show {id}`");
+        println!("Filtered - full output: `tokf history show --raw {id}`");
     }
 
     if cli.no_mask_exit_code {
@@ -590,7 +593,7 @@ fn main() {
         } => verify_cmd::cmd_verify(filter.as_deref(), *list, *json, *require_all),
         Commands::History { action } => or_exit(match action {
             HistoryAction::List { limit, all } => history_cmd::cmd_history_list(*limit, *all),
-            HistoryAction::Show { id } => history_cmd::cmd_history_show(*id),
+            HistoryAction::Show { id, raw } => history_cmd::cmd_history_show(*id, *raw),
             HistoryAction::Search { query, limit, all } => {
                 history_cmd::cmd_history_search(query, *limit, *all)
             }

--- a/crates/tokf-cli/tests/cli_history.rs
+++ b/crates/tokf-cli/tests/cli_history.rs
@@ -1,0 +1,257 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::items_after_statements
+)]
+
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn tokf_with_db(db_path: &Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tokf"));
+    cmd.env("TOKF_DB_PATH", db_path);
+    cmd
+}
+
+fn temp_db_dir() -> TempDir {
+    TempDir::new().expect("tempdir")
+}
+
+/// Create a temp directory with a local `.tokf/filters/echo.toml` filter and
+/// return `(dir, filters_dir)`. The filter replaces echo output with "filtered".
+fn setup_local_filter(show_history_hint: bool) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let filters_dir = dir.path().join(".tokf/filters");
+    std::fs::create_dir_all(&filters_dir).unwrap();
+    let hint_line = if show_history_hint {
+        "show_history_hint = true\n"
+    } else {
+        ""
+    };
+    std::fs::write(
+        filters_dir.join("echo.toml"),
+        format!("command = \"echo\"\n{hint_line}[on_success]\noutput = \"filtered\""),
+    )
+    .unwrap();
+    dir
+}
+
+// ---------------------------------------------------------------------------
+// history show --raw
+// ---------------------------------------------------------------------------
+
+#[test]
+fn history_show_raw_prints_only_raw_output() {
+    let db_dir = temp_db_dir();
+    let db = db_dir.path().join("tracking.db");
+    let work_dir = setup_local_filter(false);
+
+    // Run a filtered command so history is recorded.
+    let run_out = tokf_with_db(&db)
+        .current_dir(work_dir.path())
+        .args(["run", "echo", "hello world"])
+        .output()
+        .expect("run");
+    assert!(run_out.status.success());
+
+    // List history to find the entry ID.
+    let list_out = tokf_with_db(&db)
+        .current_dir(work_dir.path())
+        .args(["history", "list"])
+        .output()
+        .expect("history list");
+    let list_stdout = String::from_utf8_lossy(&list_out.stdout);
+    let id: &str = list_stdout.split_whitespace().next().expect("entry ID");
+
+    // Show with --raw: should print only raw output, no metadata.
+    let show_out = tokf_with_db(&db)
+        .args(["history", "show", "--raw", id])
+        .output()
+        .expect("history show --raw");
+    let stdout = String::from_utf8_lossy(&show_out.stdout);
+
+    assert!(
+        show_out.status.success(),
+        "exit: {:?}",
+        show_out.status.code()
+    );
+    assert!(
+        stdout.contains("hello world"),
+        "expected raw output, got: {stdout}"
+    );
+    // Must NOT contain metadata headers.
+    assert!(
+        !stdout.contains("ID:"),
+        "should not contain metadata, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("--- Raw Output ---"),
+        "should not contain section header, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("--- Filtered Output ---"),
+        "should not contain section header, got: {stdout}"
+    );
+}
+
+#[test]
+fn history_show_default_includes_metadata() {
+    let db_dir = temp_db_dir();
+    let db = db_dir.path().join("tracking.db");
+    let work_dir = setup_local_filter(false);
+
+    tokf_with_db(&db)
+        .current_dir(work_dir.path())
+        .args(["run", "echo", "hi"])
+        .output()
+        .expect("run");
+
+    let list_out = tokf_with_db(&db)
+        .current_dir(work_dir.path())
+        .args(["history", "list"])
+        .output()
+        .expect("history list");
+    let list_stdout = String::from_utf8_lossy(&list_out.stdout);
+    let id = list_stdout.split_whitespace().next().expect("entry ID");
+
+    let show_out = tokf_with_db(&db)
+        .args(["history", "show", id])
+        .output()
+        .expect("history show");
+    let stdout = String::from_utf8_lossy(&show_out.stdout);
+
+    assert!(show_out.status.success());
+    assert!(
+        stdout.contains("ID:"),
+        "should contain metadata, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("--- Raw Output ---"),
+        "should contain raw section, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("--- Filtered Output ---"),
+        "should contain filtered section, got: {stdout}"
+    );
+}
+
+#[test]
+fn history_show_not_found_exits_one() {
+    let db_dir = temp_db_dir();
+    let db = db_dir.path().join("tracking.db");
+
+    let out = tokf_with_db(&db)
+        .args(["history", "show", "99999"])
+        .output()
+        .expect("history show");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert_eq!(out.status.code(), Some(1), "expected exit 1");
+    assert!(
+        stderr.contains("not found"),
+        "expected 'not found' in stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn history_show_raw_not_found_exits_one() {
+    let db_dir = temp_db_dir();
+    let db = db_dir.path().join("tracking.db");
+
+    let out = tokf_with_db(&db)
+        .args(["history", "show", "--raw", "99999"])
+        .output()
+        .expect("history show --raw");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert_eq!(out.status.code(), Some(1), "expected exit 1");
+    assert!(
+        stderr.contains("not found"),
+        "expected 'not found' in stderr, got: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// history hint message
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hint_appears_with_show_history_hint_filter() {
+    let db_dir = temp_db_dir();
+    let db = db_dir.path().join("tracking.db");
+    let work_dir = setup_local_filter(true);
+
+    let out = tokf_with_db(&db)
+        .current_dir(work_dir.path())
+        .args(["run", "echo", "test"])
+        .output()
+        .expect("run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(out.status.success());
+    assert!(
+        stdout.contains("Filtered - full output: `tokf history show --raw"),
+        "expected hint in stdout, got: {stdout}"
+    );
+}
+
+#[test]
+fn hint_absent_without_show_history_hint() {
+    let db_dir = temp_db_dir();
+    let db = db_dir.path().join("tracking.db");
+    let work_dir = setup_local_filter(false);
+
+    let out = tokf_with_db(&db)
+        .current_dir(work_dir.path())
+        .args(["run", "echo", "test"])
+        .output()
+        .expect("run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(out.status.success());
+    assert!(
+        !stdout.contains("Filtered - full output:"),
+        "hint should not appear, got: {stdout}"
+    );
+}
+
+#[test]
+fn hint_contains_valid_history_id() {
+    let db_dir = temp_db_dir();
+    let db = db_dir.path().join("tracking.db");
+    let work_dir = setup_local_filter(true);
+
+    let run_out = tokf_with_db(&db)
+        .current_dir(work_dir.path())
+        .args(["run", "echo", "payload"])
+        .output()
+        .expect("run");
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    assert!(run_out.status.success());
+
+    // Extract the history ID from the hint line.
+    // Format: "Filtered - full output: `tokf history show --raw 1`"
+    let hint_line = stdout
+        .lines()
+        .find(|l| l.contains("Filtered - full output:"))
+        .expect("hint line not found");
+    let id = hint_line
+        .trim_end_matches('`')
+        .rsplit_once(' ')
+        .expect("space before ID")
+        .1;
+
+    // Verify that the ID is valid by fetching raw output.
+    let show_out = tokf_with_db(&db)
+        .args(["history", "show", "--raw", id])
+        .output()
+        .expect("history show --raw");
+    let raw_stdout = String::from_utf8_lossy(&show_out.stdout);
+
+    assert!(show_out.status.success(), "show --raw failed for id {id}");
+    assert!(
+        raw_stdout.contains("payload"),
+        "raw output should contain 'payload', got: {raw_stdout}"
+    );
+}

--- a/crates/tokf-common/src/config/types.rs
+++ b/crates/tokf-common/src/config/types.rs
@@ -151,7 +151,7 @@ pub struct FilterConfig {
     ///
     /// Example hint appended to output:
     /// ```text
-    /// Filtered - for full content call: `tokf history show 42`
+    /// Filtered - full output: `tokf history show --raw 42`
     /// ```
     ///
     /// This is useful for LLM consumers that need to know complete output is


### PR DESCRIPTION
## Summary
- Add `--raw` flag to `tokf history show` that prints only the raw captured output (no metadata, no filtered output)
- Update the hint message to point LLMs directly at `--raw`: `Filtered - full output: \`tokf history show --raw <id>\``
- Add 7 integration tests covering `--raw` output, not-found handling, and hint message behavior

## Test plan
- [x] `cargo test` — 810 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `tokf verify --require-all` — 90/90 stdlib cases passed
- [x] Manual: run `tokf run git status`, verify hint says `--raw`, then `tokf history show --raw <id>` returns only raw output

🤖 Generated with [Claude Code](https://claude.com/claude-code)