### PR TITLE
feat(hook): add OpenAI Codex CLI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,22 @@ This writes `.opencode/plugins/tokf.ts` (or `~/.config/opencode/plugins/tokf.ts`
 
 If tokf rewrite fails or no filter matches, the command passes through unmodified (fail-safe).
 
+### OpenAI Codex CLI
+
+tokf integrates with [OpenAI Codex CLI](https://github.com/openai/codex) via a skill that instructs the agent to prefix supported commands with `tokf run`.
+
+**Install (project-local):**
+```sh
+tokf hook install --tool codex
+```
+
+**Install (global):**
+```sh
+tokf hook install --tool codex --global
+```
+
+This writes `.agents/skills/tokf-run/SKILL.md` (or `~/.agents/skills/tokf-run/SKILL.md` for `--global`), which Codex auto-discovers. Unlike the Claude Code hook (which intercepts commands at the tool level), the Codex integration is skill-based: it teaches the agent to use `tokf run` as a command prefix. If tokf is not installed, the agent falls back to running commands without the prefix (fail-safe).
+
 ---
 
 ## Installation

--- a/crates/tokf-cli/skills/codex-run/SKILL.md
+++ b/crates/tokf-cli/skills/codex-run/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: tokf-run
+description: Compress verbose CLI output with tokf before returning results. Activates for git, cargo, npm, docker, go, gradle, kubectl, and other supported commands.
+---
+
+# tokf — Token Output Filter
+
+tokf compresses verbose command output so you receive concise, structured results instead of raw terminal dumps. It saves context tokens and makes output easier to reason about.
+
+## Rule
+
+When running a supported command, prefix it with `tokf run`:
+
+```
+tokf run <command>
+```
+
+**Examples:**
+
+```sh
+tokf run git status
+tokf run cargo test
+tokf run npm test
+tokf run docker ps
+```
+
+## Supported commands
+
+The following commands have built-in filters. Prefix these with `tokf run`:
+
+- `git status`, `git diff`, `git log`, `git push`, `git add`, `git commit`, `git show`
+- `cargo build`, `cargo test`, `cargo check`, `cargo clippy`, `cargo install`
+- `npm test`, `npm run`, `yarn test`, `pnpm test`
+- `docker build`, `docker compose`, `docker ps`, `docker images`
+- `go build`, `go vet`
+- `gradle build`, `gradle test`, `gradle dependencies`
+- `gh pr view`, `gh pr list`, `gh pr checks`, `gh issue view`, `gh issue list`
+- `kubectl get pods`
+- `next build`
+- `pnpm add`, `pnpm install`
+- `prisma generate`
+- `pytest`
+- `tsc`
+- `ls`
+
+Commands not in this list pass through unchanged when prefixed with `tokf run`.
+
+## Important rules
+
+1. **Never double-prefix.** If a command already starts with `tokf run`, do not add it again.
+2. **Arguments pass through.** Include all flags and arguments after the base command: `tokf run cargo test --release -- my_test`.
+3. **Fail-safe.** If `tokf` is not installed or not on PATH, run the command without the prefix.
+4. **Environment variables.** Place env vars before `tokf run`: `RUST_LOG=debug tokf run cargo test`.
+5. **Pipes.** Do not add redundant filtering pipes (e.g. `| grep`, `| tail`, `| head`) after `tokf run` commands — tokf already compresses the output. Piping tokf's output for other purposes (e.g. `tokf run cargo test | wc -l`) is fine.

--- a/crates/tokf-cli/src/hook/codex.rs
+++ b/crates/tokf-cli/src/hook/codex.rs
@@ -1,0 +1,134 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+
+const SKILL_MD: &str = include_str!("../../skills/codex-run/SKILL.md");
+
+/// Install the Codex CLI skill.
+///
+/// # Errors
+///
+/// Returns an error if the skill directory cannot be created or the skill file cannot be written.
+pub fn install(global: bool) -> anyhow::Result<()> {
+    let skill_dir = if global {
+        global_skill_dir()?
+    } else {
+        PathBuf::from(".agents/skills/tokf-run")
+    };
+    install_to(&skill_dir)
+}
+
+pub(crate) fn install_to(skill_dir: &Path) -> anyhow::Result<()> {
+    write_skill_file(skill_dir)?;
+    eprintln!(
+        "[tokf] Codex skill installed to {}",
+        skill_dir.join("SKILL.md").display()
+    );
+    eprintln!("[tokf] Codex will auto-discover the skill on next start.");
+    Ok(())
+}
+
+fn global_skill_dir() -> anyhow::Result<PathBuf> {
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    Ok(home.join(".agents/skills/tokf-run"))
+}
+
+fn write_skill_file(skill_dir: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(skill_dir)
+        .with_context(|| format!("failed to create skill dir: {}", skill_dir.display()))?;
+
+    let skill_file = skill_dir.join("SKILL.md");
+    std::fs::write(&skill_file, SKILL_MD)
+        .with_context(|| format!("failed to write skill file: {}", skill_file.display()))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn install_to_creates_skill_file() {
+        let dir = TempDir::new().unwrap();
+        let skill_dir = dir.path().join("tokf-run");
+
+        install_to(&skill_dir).unwrap();
+
+        assert!(skill_dir.join("SKILL.md").exists());
+    }
+
+    #[test]
+    fn install_to_is_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let skill_dir = dir.path().join("tokf-run");
+
+        install_to(&skill_dir).unwrap();
+        install_to(&skill_dir).unwrap();
+
+        // Only one file exists, no errors
+        let entries: Vec<_> = std::fs::read_dir(&skill_dir).unwrap().collect();
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn skill_file_has_frontmatter() {
+        let dir = TempDir::new().unwrap();
+        let skill_dir = dir.path().join("tokf-run");
+
+        install_to(&skill_dir).unwrap();
+
+        let content = std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+        assert!(
+            content.starts_with("---\n"),
+            "SKILL.md should start with YAML frontmatter"
+        );
+        assert!(
+            content.contains("name: tokf-run"),
+            "SKILL.md frontmatter should include name: tokf-run"
+        );
+    }
+
+    #[test]
+    fn skill_file_has_description() {
+        let content = SKILL_MD;
+        assert!(
+            content.contains("description:"),
+            "SKILL.md frontmatter should include description"
+        );
+    }
+
+    #[test]
+    fn skill_file_mentions_tokf_run() {
+        let content = SKILL_MD;
+        assert!(
+            content.contains("tokf run"),
+            "SKILL.md should instruct using tokf run"
+        );
+    }
+
+    #[test]
+    fn skill_file_has_no_double_prefix_rule() {
+        let content = SKILL_MD;
+        assert!(
+            content.contains("double-prefix"),
+            "SKILL.md should warn against double-prefixing"
+        );
+    }
+
+    #[test]
+    fn skill_file_has_fail_safe_rule() {
+        let content = SKILL_MD;
+        assert!(
+            content.contains("Fail-safe"),
+            "SKILL.md should include fail-safe instruction"
+        );
+    }
+
+    #[test]
+    fn embedded_content_is_not_empty() {
+        assert!(!SKILL_MD.is_empty(), "SKILL_MD should not be empty");
+    }
+}

--- a/crates/tokf-cli/src/hook/mod.rs
+++ b/crates/tokf-cli/src/hook/mod.rs
@@ -1,3 +1,4 @@
+pub mod codex;
 pub mod opencode;
 pub mod types;
 

--- a/crates/tokf-cli/src/main.rs
+++ b/crates/tokf-cli/src/main.rs
@@ -173,13 +173,15 @@ enum HookTool {
     ClaudeCode,
     #[value(name = "opencode")]
     OpenCode,
+    #[value(name = "codex")]
+    Codex,
 }
 
 #[derive(Subcommand)]
 enum HookAction {
     /// Handle a `PreToolUse` hook invocation (reads JSON from stdin)
     Handle,
-    /// Install the hook into the target tool's settings
+    /// Install the integration for the target tool
     Install {
         /// Install globally instead of project-local
         #[arg(long)]
@@ -679,6 +681,7 @@ fn cmd_hook_install(global: bool, tool: &HookTool) -> i32 {
         HookTool::ClaudeCode => hook::install(global),
         // R6: Updated variant name from Opencode to OpenCode.
         HookTool::OpenCode => hook::opencode::install(global),
+        HookTool::Codex => hook::codex::install(global),
     };
     match result {
         Ok(()) => 0,


### PR DESCRIPTION
## Summary

- Adds Codex CLI integration via `tokf hook install --tool codex` (local and `--global`)
- Installs a Codex skill (`.agents/skills/tokf-run/SKILL.md`) that instructs the agent to prefix supported commands with `tokf run`
- Skill-based approach (vs hook-based for Claude Code / plugin-based for OpenCode) — follows Codex's designed extension model with fail-safe fallback

## Changes

| File | Action |
|------|--------|
| `crates/tokf-cli/skills/codex-run/SKILL.md` | New — skill content with YAML frontmatter |
| `crates/tokf-cli/src/hook/codex.rs` | New — install module (7 unit tests) |
| `crates/tokf-cli/src/hook/mod.rs` | Add `pub mod codex` |
| `crates/tokf-cli/src/main.rs` | Add `Codex` variant to `HookTool` enum + dispatch |
| `crates/tokf-cli/tests/cli_hook.rs` | Add 4 integration tests |
| `README.md` | Add "OpenAI Codex CLI" documentation section |

## Test plan

- [x] `cargo test --workspace` — all 890 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — formatted
- [ ] Manual: `tokf hook install --tool codex` in a temp dir, verify `.agents/skills/tokf-run/SKILL.md`
- [ ] Manual: `tokf hook install --tool codex --global`, verify `~/.agents/skills/tokf-run/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)