### PR TITLE
fix: Update test suite verification command in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,8 @@ jobs:
         run: cargo test --workspace -- --include-ignored
 
       - name: Verify filter test suites
-        run: ./target/debug/tokf verify --require-all
+        working-directory: ./crates/tokf-cli
+        run: ../../target/debug/tokf verify --require-all --scope stdlib
 
       - name: Check file sizes
         run: bash scripts/check-file-sizes.sh


### PR DESCRIPTION
This pull request updates the GitHub Actions CI workflow to improve the way the "Verify filter test suites" step is executed. The main change is specifying the working directory and adding a scope to the verification command.

**CI workflow improvements:**

* The "Verify filter test suites" step in `.github/workflows/ci.yml` now sets the `working-directory` to `./crates/tokf-cli` and updates the command to run `../../target/debug/tokf verify --require-all --scope stdlib`, ensuring the verification is scoped to the standard library and executed from the correct directory.