### PR TITLE
fix(config): use array syntax for fly.toml http_service.checks

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -14,14 +14,13 @@ primary_region = "iad"
   auto_stop_machines = false
   auto_start_machines = true
 
-  [http_service.checks]
-    [http_service.checks.health]
-      grace_period = "10s"
-      interval = "10s"
-      method = "GET"
-      path = "/ready"
-      protocol = "http"
-      timeout = "5s"
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "10s"
+    method = "GET"
+    path = "/ready"
+    protocol = "http"
+    timeout = "5s"
 
 # Graceful shutdown: SIGTERM triggers drain (30s in main.rs), then SIGKILL after 35s.
 # The 35s kill_timeout provides a 5-second buffer beyond the 30s drain period.


### PR DESCRIPTION
## Summary
- Fix `fly.toml` config validation error by changing `http_service.checks` from a nested table (`[http_service.checks]`) to an array of tables (`[[http_service.checks]]`)
- Fly's config parser expects `checks` to be an array, not a named map — the previous syntax caused: `json: cannot unmarshal object into Go struct field HTTPService.http_service.checks of type []*appconfig.ServiceHTTPCheck`

## Test plan
- [x] `fly deploy --config fly.toml` no longer fails config validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)