### PR TITLE
fix(ci): touch all .rs files in Dockerfile to trigger full recompilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ RUN mkdir -p crates/tokf-common/src \
 # ── Stage 2: build real source ───────────────────────────────────────────────
 FROM deps AS builder
 COPY crates/ crates/
-# Touch to ensure Cargo detects the source change.
-RUN touch crates/tokf-server/src/main.rs && \
+# Touch all source files so Cargo detects changes vs the empty stubs.
+RUN find crates/ -name '*.rs' -exec touch {} + && \
     cargo build --release -p tokf-server
 
 # ── Stage 3: minimal runtime image ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix Docker build failure where Cargo skipped recompiling `lib.rs` and all its modules (`auth`, `config`, `db`, `routes`, `state`, `storage`)
- The dep-caching stage creates empty `.rs` stubs; the build stage was only touching `main.rs`, so Cargo's fingerprinting missed the real `lib.rs` changes
- Now touches all `.rs` files with `find crates/ -name '*.rs' -exec touch {} +`

## Test plan
- [x] Verified `podman build --no-cache` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)