### PR TITLE
fix(config): change Fly primary region from iad to fra

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,5 +1,5 @@
 app = "tokf-server"
-primary_region = "iad"
+primary_region = "fra"
 
 [deploy]
   release_command = "./tokf-server migrate"


### PR DESCRIPTION
## Summary
- Change `primary_region` from `iad` (Virginia) to `fra` (Frankfurt) to co-locate with our other services

## Test plan
- [ ] Verify next deploy provisions in the `fra` region

🤖 Generated with [Claude Code](https://claude.com/claude-code)