### PR TITLE
fix(ci): stop running stdlib verify tests redundantly in cargo test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,10 @@ jobs:
         run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Run tests
-        run: cargo test --workspace -- --include-ignored
+        run: cargo test --workspace
+
+      - name: Run DB integration tests
+        run: cargo test -p tokf-server -- --ignored
 
       - name: Verify filter test suites
         id: verify

--- a/crates/tokf-cli/tests/verify_cmd.rs
+++ b/crates/tokf-cli/tests/verify_cmd.rs
@@ -10,8 +10,11 @@ fn tokf() -> Command {
 }
 
 // --- verify cargo/build ---
+// Covered by the dedicated `tokf verify` CI step; ignored to avoid running
+// stdlib filters twice. Run locally with `cargo test -- --ignored`.
 
 #[test]
+#[ignore = "covered by the dedicated `tokf verify` CI step"]
 fn verify_cargo_build_passes() {
     let output = tokf().args(["verify", "cargo/build"]).output().unwrap();
     assert_eq!(
@@ -29,8 +32,11 @@ fn verify_cargo_build_passes() {
 }
 
 // --- verify all stdlib suites ---
+// Covered by the dedicated `tokf verify` CI step; ignored to avoid running
+// stdlib filters twice. Run locally with `cargo test -- --ignored`.
 
 #[test]
+#[ignore = "covered by the dedicated `tokf verify` CI step"]
 fn verify_all_stdlib_suites_pass() {
     let output = tokf().args(["verify"]).output().unwrap();
     assert_eq!(


### PR DESCRIPTION
## Summary

- Mark `verify_cargo_build_passes` and `verify_all_stdlib_suites_pass` as `#[ignore]` — these duplicate the dedicated `tokf verify --require-all --scope stdlib` CI step
- Split CI's single `cargo test --workspace -- --include-ignored` into two steps:
  - `cargo test --workspace` — all non-ignored tests
  - `cargo test -p tokf-server -- --ignored` — DB integration tests only (require postgres)
- Ignored verify tests remain runnable locally via `cargo test -- --ignored`

## Test plan

- [x] `cargo test -p tokf -- verify` — 13 pass, 2 ignored
- [x] `cargo test -p tokf -- verify --ignored` — 2 pass (the ignored ones still work)
- [x] Clippy clean (ignore reasons provided)

🤖 Generated with [Claude Code](https://claude.com/claude-code)