### PR TITLE
fix(cli,server): use test: prefix in multipart fields and add just recipes

### DIFF
--- a/.dupes-ignore.toml
+++ b/.dupes-ignore.toml
@@ -88,6 +88,10 @@ reason = "db_state/make_state - integration tests cannot access pub(crate) test 
 fingerprint = "3c8fb4c61f6efe4e"
 reason = "sync_tests validation rejection tests - each tests a different error case with different payloads; test clarity > DRY"
 
+[[ignore]]
+fingerprint = "e7c7421228f41810"
+reason = "TestHarness::blocking_get_filter/blocking_download_filter - spawn_blocking test boilerplate; test clarity > DRY"
+
 # Near duplicates
 
 [[ignore]]
@@ -105,3 +109,11 @@ reason = "config_search_paths/default_search_dirs - structurally similar but ser
 [[ignore]]
 fingerprint = "c0692f8ae6555b2b"
 reason = "get_history_entry/most_recent_command - idiomatic rusqlite query pattern; different SQL, types, and row mapping"
+
+[[ignore]]
+fingerprint = "4ad9184ca8858560"
+reason = "TestHarness::blocking_update_tests/blocking_search_filters - spawn_blocking test boilerplate; test clarity > DRY"
+
+[[ignore]]
+fingerprint = "9fc57c07628e198e"
+reason = "TestHarness::blocking_gain/blocking_list_machines - spawn_blocking test boilerplate; test clarity > DRY"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Container runtime: "podman" or "docker"
+CONTAINER_RUNTIME=podman
+
+# CockroachDB connection for integration/e2e tests
+DATABASE_URL=postgresql://root@localhost:26257/tokf_test?sslmode=disable

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /target
 .DS_Store
-.tokf/
+.env
+.tokf/*
+!.tokf/filters/
 tarpaulin-report.html
 .idea/
 .claude/worktrees/

--- a/.tokf/filters/just/test.toml
+++ b/.tokf/filters/just/test.toml
@@ -1,0 +1,51 @@
+# just-test.toml — Reuses cargo test filter logic (Level 3)
+# Matches all just test commands: test, test-db, test-e2e, test-all
+
+command = ["just test", "just test-db", "just test-e2e", "just test-all"]
+
+skip = [
+  "^cargo test",
+  "^\\s*Compiling ",
+  "^\\s*Downloading ",
+  "^\\s*Downloaded ",
+  "^\\s*Finished ",
+  "^\\s*Locking ",
+  "^running \\d+ tests?$",
+  "^test .+ \\.\\.\\. ok$",
+  "^\\s*$",
+  "^\\s*Doc-tests ",
+]
+
+[[section]]
+name = "failures"
+enter = "^failures:$"
+exit = "^failures:$"
+split_on = "^\\s*$"
+collect_as = "failure_blocks"
+
+[[section]]
+name = "failure_names"
+enter = "^failures:$"
+exit = "^\\s*$"
+match = "^\\s+\\S+"
+collect_as = "failure_list"
+
+[[section]]
+name = "summary"
+match = "^test result:"
+collect_as = "summary_lines"
+
+[on_success]
+aggregate = { from = "summary_lines", pattern = 'ok\. (\d+) passed', sum = "passed", count_as = "suites" }
+output = "✓ cargo test: {passed} passed ({suites} suites)"
+
+[on_failure]
+output = """
+FAILURES ({failure_blocks.count}):
+═══════════════════════════════════════
+{failure_blocks | each: "{index}. {value | truncate: 200}" | join: "\n"}
+
+{summary_lines | join: "\n"}"""
+
+[fallback]
+tail = 5

--- a/.tokf/filters/just/test_test/combined.toml
+++ b/.tokf/filters/just/test_test/combined.toml
@@ -1,0 +1,6 @@
+name = "test-all aggregates unit + DB + e2e suites"
+fixture = "combined.txt"
+exit_code = 0
+
+[[expect]]
+equals = "✓ cargo test: 173 passed (7 suites)"

--- a/.tokf/filters/just/test_test/combined.txt
+++ b/.tokf/filters/just/test_test/combined.txt
@@ -1,0 +1,56 @@
+cargo test
+   Compiling tokf v0.2.12 (/Users/dev/tokf/crates/tokf-cli)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.34s
+     Running unittests src/lib.rs (target/debug/deps/tokf-abc123)
+
+running 50 tests
+test config::tests::test_minimal_config ... ok
+test filter::tests::branch_fixed_output ... ok
+
+test result: ok. 50 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+     Running unittests src/main.rs (target/debug/deps/tokf-def456)
+
+running 20 tests
+test cli::tests::test_parse_args ... ok
+
+test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+cargo test -p tokf-server -- --ignored
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.75s
+     Running unittests src/lib.rs (target/debug/deps/tokf_server-31ca3b4b)
+
+running 65 tests
+test routes::filters::publish::tests::publish_filter_creates_record ... ok
+
+test result: ok. 65 passed; 0 failed; 0 ignored; 0 measured; 67 filtered out; finished in 19.32s
+
+     Running tests/db_integration.rs (target/debug/deps/db_integration-b43559fc)
+
+running 21 tests
+test migrations_apply_cleanly_and_all_tables_exist ... ok
+
+test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.54s
+
+cargo test -p e2e-tests -- --ignored
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.30s
+     Running tests/auth_flow.rs (target/debug/deps/auth_flow-390d1d5a)
+
+running 2 tests
+test device_flow_creates_token ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.86s
+
+     Running tests/publish_flow.rs (target/debug/deps/publish_flow-5f1e7900)
+
+running 10 tests
+test publish_filter_returns_hash ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.05s
+
+     Running tests/sync_flow.rs (target/debug/deps/sync_flow-263aa495)
+
+running 5 tests
+test sync_records_and_uploads_events ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.79s

--- a/.tokf/filters/just/test_test/pass.toml
+++ b/.tokf/filters/just/test_test/pass.toml
@@ -1,0 +1,6 @@
+name = "passing unit tests show aggregated summary"
+fixture = "pass.txt"
+exit_code = 0
+
+[[expect]]
+equals = "✓ cargo test: 23 passed (3 suites)"

--- a/.tokf/filters/just/test_test/pass.txt
+++ b/.tokf/filters/just/test_test/pass.txt
@@ -1,0 +1,27 @@
+cargo test
+   Compiling tokf v0.2.12 (/Users/dev/tokf/crates/tokf-cli)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.34s
+     Running unittests src/lib.rs (target/debug/deps/tokf-abc123)
+
+running 12 tests
+test config::tests::test_minimal_config ... ok
+test config::tests::test_deserialize_git_push ... ok
+test filter::tests::branch_fixed_output ... ok
+test filter::skip::tests::skip_removes_matching ... ok
+
+test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+     Running unittests src/main.rs (target/debug/deps/tokf-def456)
+
+running 8 tests
+test cli::tests::test_parse_args ... ok
+test cli::tests::test_version ... ok
+
+test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+   Doc-tests tokf
+
+running 3 tests
+test src/config/types.rs - config::types::FilterConfig (line 15) ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.15s

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,35 @@ cargo clippy --workspace --all-targets -- -D warnings  # Lint
 cargo fmt -- --check     # Format check
 ```
 
+### Database & end-to-end tests
+
+`tokf-server` uses CockroachDB. DB integration tests and end-to-end tests are `#[ignore]`d by default — they require `DATABASE_URL` and the `--ignored` flag.
+
+Copy `.env.example` → `.env` to configure `CONTAINER_RUNTIME` (`podman` or `docker`) and `DATABASE_URL`.
+
+```sh
+just db-start                  # start CockroachDB
+just db-status                 # check if running
+just db-setup                  # create tokf_test database
+just test-db                   # tokf-server integration tests
+just test-e2e                  # end-to-end tests
+just test-all                  # unit + DB + e2e
+just db-reset                  # wipe and restart fresh
+```
+
+Or manually:
+
+```sh
+podman compose -f crates/tokf-server/docker-compose.yml up -d
+export DATABASE_URL="postgresql://root@localhost:26257/tokf_test?sslmode=disable"
+psql "postgresql://root@localhost:26257/defaultdb?sslmode=disable" \
+  -c "CREATE DATABASE IF NOT EXISTS tokf_test"
+cargo test -p tokf-server -- --ignored
+cargo test -p e2e-tests -- --ignored
+```
+
+Each `#[crdb_test]` creates an isolated database per test with fresh migrations — no manual migration step needed.
+
 ## Documentation
 
 **Every user-facing feature or behaviour change must be documented in the same PR.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,6 +1794,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2385,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3471,6 +3482,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/tokf-cli/Cargo.toml
+++ b/crates/tokf-cli/Cargo.toml
@@ -29,7 +29,7 @@ include_dir = { version = "0.7", features = ["glob"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 rkyv = { version = "0.8", features = ["bytecheck", "unaligned"] }
 mlua = { version = "0.11.6", features = ["luau", "vendored", "error-send"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "blocking"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "blocking", "multipart"] }
 # linux-native uses kernel keyutils (no libdbus-sys dependency).
 # sync-secret-service would need libdbus-1-dev on Linux CI/build hosts.
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }

--- a/crates/tokf-common/src/multipart.rs
+++ b/crates/tokf-common/src/multipart.rs
@@ -29,7 +29,7 @@ mod tests {
         let (body, content_type) = build_body(&[
             ("filter", b"command = \"test\"\n"),
             ("mit_license_accepted", b"true"),
-            ("test/basic.toml", b"name = \"basic\"\n"),
+            ("test:basic.toml", b"name = \"basic\"\n"),
         ]);
         assert!(content_type.contains("boundary="));
         let body_str = String::from_utf8(body).unwrap();
@@ -41,7 +41,7 @@ mod tests {
         );
         assert!(body_str.contains("name=\"filter\""));
         assert!(body_str.contains("name=\"mit_license_accepted\""));
-        assert!(body_str.contains("name=\"test/basic.toml\""));
+        assert!(body_str.contains("name=\"test:basic.toml\""));
     }
 
     #[test]

--- a/crates/tokf-server/src/routes/filters/publish.rs
+++ b/crates/tokf-server/src/routes/filters/publish.rs
@@ -67,7 +67,7 @@ async fn parse_multipart(
             filter_bytes = Some(bytes.to_vec());
         } else if name == "mit_license_accepted" {
             mit_license_accepted = bytes.as_ref() == b"true";
-        } else if let Some(filename) = name.strip_prefix("test/")
+        } else if let Some(filename) = name.strip_prefix("test:")
             && !filename.is_empty()
         {
             test_files.push((filename.to_string(), bytes.to_vec()));
@@ -217,7 +217,7 @@ fn prepare_filter(fields: MultipartFields) -> Result<PreparedFilter, AppError> {
 /// Accepts a multipart form with:
 /// - `filter` — filter TOML bytes (required, ≤ 64 KB)
 /// - `mit_license_accepted` — must be `"true"` to acknowledge MIT license (required)
-/// - `test/<filename>` — individual test TOML files (optional, total upload ≤ 1 MB)
+/// - `test:<filename>` — individual test TOML files (optional, total upload ≤ 1 MB)
 ///
 /// The server computes the content hash from the uploaded bytes; clients never
 /// supply a hash. This prevents hash forgery.
@@ -351,11 +351,11 @@ mod tests {
                 ("filter", VALID_FILTER_TOML),
                 MIT_ACCEPT,
                 (
-                    "test/basic.toml",
+                    "test:basic.toml",
                     b"name = \"basic\"\n\n[[expect]]\ncontains = \"ok\"\n",
                 ),
                 (
-                    "test/advanced.toml",
+                    "test:advanced.toml",
                     b"name = \"advanced\"\n\n[[expect]]\ncontains = \"ok\"\n",
                 ),
             ],
@@ -438,7 +438,7 @@ mod tests {
             &[
                 ("filter", VALID_FILTER_TOML),
                 MIT_ACCEPT,
-                ("test/big.toml", &big_test),
+                ("test:big.toml", &big_test),
             ],
         )
         .await;

--- a/crates/tokf-server/src/routes/filters/search.rs
+++ b/crates/tokf-server/src/routes/filters/search.rs
@@ -413,7 +413,7 @@ mod tests {
             &token,
             b"command = \"git push\"\n",
             &[(
-                "test/basic.toml",
+                "test:basic.toml",
                 b"name = \"basic\"\n\n[[expect]]\ncontains = \"ok\"\n",
             )],
         )
@@ -487,11 +487,11 @@ mod tests {
             b"command = \"git push\"\n",
             &[
                 (
-                    "test/basic.toml",
+                    "test:basic.toml",
                     b"name = \"basic\"\n\n[[expect]]\ncontains = \"ok\"\n",
                 ),
                 (
-                    "test/edge.toml",
+                    "test:edge.toml",
                     b"name = \"edge\"\n\n[[expect]]\ncontains = \"ok\"\n",
                 ),
             ],

--- a/justfile
+++ b/justfile
@@ -1,3 +1,10 @@
+set dotenv-load
+
+# Defaults (overridden by .env or environment)
+CONTAINER_RUNTIME := env("CONTAINER_RUNTIME", "podman")
+DATABASE_URL := env("DATABASE_URL", "postgresql://root@localhost:26257/tokf_test?sslmode=disable")
+compose_file := "crates/tokf-server/docker-compose.yml"
+
 # Run all checks
 check: fmt-check lint test file-size
 
@@ -9,7 +16,7 @@ fmt:
 fmt-check:
     cargo fmt -- --check
 
-# Run tests
+# Run unit tests (no database required)
 test:
     cargo test
 
@@ -25,7 +32,7 @@ file-size:
 install:
     cargo install --path crates/tokf-cli
 
-# Install the CLI
+# Install the CLI (force)
 force-install:
     cargo install --force --path crates/tokf-cli
 
@@ -42,3 +49,42 @@ install-hooks:
     chmod +x scripts/hooks/pre-commit
     ln -sf ../../scripts/hooks/pre-commit .git/hooks/pre-commit
     @echo "Git hooks installed."
+
+# ── Database (CockroachDB) ────────────────────────────────────────────────────
+
+# Start CockroachDB
+db-start:
+    {{ CONTAINER_RUNTIME }} compose -f {{ compose_file }} up -d
+
+# Stop CockroachDB (preserves data)
+db-stop:
+    {{ CONTAINER_RUNTIME }} compose -f {{ compose_file }} down
+
+# Reset CockroachDB (removes all data)
+db-reset:
+    {{ CONTAINER_RUNTIME }} compose -f {{ compose_file }} down -v
+    {{ CONTAINER_RUNTIME }} compose -f {{ compose_file }} up -d
+
+# Check if CockroachDB is running
+db-status:
+    @{{ CONTAINER_RUNTIME }} compose -f {{ compose_file }} ps 2>/dev/null || echo "CockroachDB is not running. Start it with: just db-start"
+
+# Create the test database (idempotent)
+db-setup:
+    @psql "postgresql://root@localhost:26257/defaultdb?sslmode=disable" \
+      -c "CREATE DATABASE IF NOT EXISTS tokf_test" 2>/dev/null \
+      && echo "Database tokf_test is ready." \
+      || echo "Could not connect to CockroachDB. Is it running? Try: just db-start"
+
+# ── Integration & E2E tests ──────────────────────────────────────────────────
+
+# Run tokf-server DB integration tests
+test-db:
+    cargo test -p tokf-server -- --ignored
+
+# Run end-to-end tests
+test-e2e:
+    cargo test -p e2e-tests -- --ignored
+
+# Run all tests: unit + DB integration + e2e
+test-all: test test-db test-e2e


### PR DESCRIPTION
## Summary

- **Multipart fix**: Replace `test/` with `test:` prefix in multipart field names to avoid RFC 8187 `name*=utf-8''` encoding that axum cannot parse. Reverts CLI to reqwest's native `multipart::Form` (no more manual body builder).
- **Just recipes**: Add `db-start`, `db-stop`, `db-reset`, `db-status`, `db-setup`, `test-db`, `test-e2e`, `test-all` recipes with `.env`-based configuration for `CONTAINER_RUNTIME` (podman/docker) and `DATABASE_URL`.
- **Project filter**: Add `.tokf/filters/just/test.toml` matching all `just test*` commands with cargo test aggregation logic.
- **Documentation**: Update `CONTRIBUTING.md` and `CLAUDE.md` with DB setup and e2e test instructions (both `just` shortcuts and manual commands).

## Test plan

- [x] `cargo test --workspace` — 1128 unit tests pass
- [x] `cargo test -p tokf-server -- --ignored` — 86 DB integration tests pass
- [x] `cargo test -p e2e-tests -- --ignored` — 22 e2e tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `tokf verify just/test` — 2/2 filter test cases pass
- [x] `just db-status`, `just db-setup`, `just test-db`, `just test-e2e` — all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)