### PR TITLE
fix(ci): pin Docker builder to bookworm and fix release-please cycle

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -18,8 +18,8 @@
   ],
   "packages": {
     "crates/tokf-common": {},
-    "crates/tokf-cli": { "component": "tokf" },
-    "crates/tokf-server": {}
+    "crates/tokf-filter": {},
+    "crates/tokf-cli": { "component": "tokf" }
   },
   "plugins": [
     {
@@ -29,7 +29,7 @@
     {
       "type": "linked-versions",
       "groupName": "workspace",
-      "components": ["tokf-common", "tokf", "tokf-server"]
+      "components": ["tokf-common", "tokf-filter", "tokf"]
     }
   ]
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "crates/tokf-common": "0.2.12",
-  "crates/tokf-cli": "0.2.12",
-  "crates/tokf-server": "0.2.12"
+  "crates/tokf-filter": "0.2.12",
+  "crates/tokf-cli": "0.2.12"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # ── Stage 1: build ──────────────────────────────────────────────────────────
-FROM rust:slim AS builder
+FROM rust:slim-bookworm AS builder
 # g++ is required for mlua's vendored Luau build (C++ source compiled via cc crate)
 RUN apt-get update && apt-get install -y --no-install-recommends g++ && rm -rf /var/lib/apt/lists/*
 WORKDIR /app


### PR DESCRIPTION
## Summary

- **GLIBC fix**: Pin `rust:slim` → `rust:slim-bookworm` in Dockerfile so the builder and runtime stages use the same GLIBC version (2.36), fixing `GLIBC_2.38 not found` on Fly.io deployment
- **release-please fix**: Remove `tokf-server` from release-please config (`publish = false`, self-dependency in dev-deps causes cycle detection failure), add `tokf-filter` as a new publishable crate
- `cargo-workspace` plugin still updates `tokf-server`'s dependency version strings on release, so it stays in sync without being a managed package

## Test plan

- [x] CI passes (Docker build job validates the image builds correctly)
- [x] Deploy to Fly.io succeeds (no more GLIBC error)
- [ ] release-please workflow completes without dependency cycle error
- [ ] Verify `tokf-filter` appears in the next release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)