### PR TITLE
refactor(cli): address Copilot review feedback

### DIFF
--- a/crates/tokf-cli/src/remote/http.rs
+++ b/crates/tokf-cli/src/remote/http.rs
@@ -180,7 +180,7 @@ impl Client {
         form_builder: F,
     ) -> anyhow::Result<reqwest::blocking::Response>
     where
-        F: Fn() -> Form,
+        F: FnOnce() -> Form,
     {
         let url = self.url(path);
         let form = form_builder();

--- a/crates/tokf-cli/src/remote/mod.rs
+++ b/crates/tokf-cli/src/remote/mod.rs
@@ -265,9 +265,7 @@ mod tests {
     }
 
     #[test]
-    fn remote_error_display_connection_failed() {
-        // Build a reqwest error by attempting to connect to an invalid address.
-        // We test the Display format indirectly via the enum variant.
+    fn remote_error_display_unauthorized() {
         let err = RemoteError::Unauthorized;
         let msg = err.to_string();
         assert!(msg.contains("401 Unauthorized"));
@@ -341,10 +339,7 @@ mod tests {
     }
 
     #[test]
-    fn remote_error_display_request_error_no_debug() {
-        // RequestError should show a generic message without debug.
-        // We can't easily construct a reqwest::Error, so test the variant exists
-        // and is_transient returns false (tested separately).
+    fn remote_error_display_client_error_bad_request() {
         let err = RemoteError::ClientError {
             url: "https://api.tokf.net/bad".to_string(),
             status: reqwest::StatusCode::BAD_REQUEST,
@@ -352,6 +347,7 @@ mod tests {
         };
         let msg = err.to_string();
         assert!(msg.contains("400"));
+        assert!(msg.contains("TOKF_DEBUG=1"));
     }
 
     #[test]

--- a/crates/tokf-cli/src/remote/publish_client.rs
+++ b/crates/tokf-cli/src/remote/publish_client.rs
@@ -38,12 +38,12 @@ pub fn publish_filter(
 ) -> anyhow::Result<(bool, PublishResponse)> {
     let filter_bytes = filter_bytes.to_vec();
     let test_files = test_files.to_vec();
-    let resp = client.post_multipart("/api/filters", || {
+    let resp = client.post_multipart("/api/filters", move || {
         let mut form = Form::new()
-            .part("filter", Part::bytes(filter_bytes.clone()))
+            .part("filter", Part::bytes(filter_bytes))
             .part("mit_license_accepted", Part::text("true"));
-        for (name, bytes) in &test_files {
-            form = form.part(format!("test:{name}"), Part::bytes(bytes.clone()));
+        for (name, bytes) in test_files {
+            form = form.part(format!("test:{name}"), Part::bytes(bytes));
         }
         form
     })?;


### PR DESCRIPTION
## Summary

Follow-up from #200 addressing valid items from Copilot's review.

- **`post_multipart` now takes `FnOnce` instead of `Fn`** — POST is never retried, so the closure only runs once. This eliminates unnecessary `.clone()` calls on filter bytes and test files in `publish_filter`.
- **Rename `remote_error_display_connection_failed`** to `remote_error_display_unauthorized` — the test constructs `Unauthorized`, not `ConnectionFailed`.
- **Rename `remote_error_display_request_error_no_debug`** to `remote_error_display_client_error_bad_request` — the test constructs `ClientError`, not `RequestError`.

## Test plan

- [x] `cargo test --workspace` — 1228 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)