### PR TITLE
fix(output): store savings_pct as 0-100, rename INSTALLS to RUNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1105,7 +1105,7 @@ Returns filters whose command pattern matches `<query>` as a substring, ranked b
 and install count.
 
 ```
-COMMAND              AUTHOR    SAVINGS%   INSTALLS
+COMMAND              AUTHOR    SAVINGS%   RUNS
 git push             alice       42.3%     1,234
 git push --force     bob         38.1%       891
 ```

--- a/crates/tokf-cli/src/search_cmd.rs
+++ b/crates/tokf-cli/src/search_cmd.rs
@@ -50,7 +50,7 @@ fn print_table(results: &[filter_client::FilterSummary]) {
         "COMMAND",
         "AUTHOR",
         "SAVINGS%",
-        "INSTALLS",
+        "RUNS",
         cmd_width = cmd_width,
         author_width = author_width,
     );

--- a/crates/tokf-server/migrations/20260302000000_savings_pct_to_percentage.sql
+++ b/crates/tokf-server/migrations/20260302000000_savings_pct_to_percentage.sql
@@ -1,0 +1,2 @@
+-- Convert savings_pct from fraction (0.0–1.0) to percentage (0–100).
+UPDATE filter_stats SET savings_pct = savings_pct * 100.0;

--- a/crates/tokf-server/src/routes/filters/search_tests.rs
+++ b/crates/tokf-server/src/routes/filters/search_tests.rs
@@ -282,6 +282,40 @@ async fn search_rejects_oversized_query(pool: PgPool) {
 }
 
 #[crdb_test_macro::crdb_test(migrations = "./migrations")]
+async fn get_filter_returns_nonzero_savings_pct(pool: PgPool) {
+    let (_, token) = insert_test_user(&pool, "get_savings").await;
+    let storage = Arc::new(InMemoryStorageClient::new());
+
+    let app =
+        crate::routes::create_router(make_state_with_storage(pool.clone(), Arc::clone(&storage)));
+    let hash = publish_filter_helper(app, &token, b"command = \"git push\"\n", &[]).await;
+
+    // Insert filter_stats with known savings_pct on the 0-100 scale
+    sqlx::query(
+        "INSERT INTO filter_stats
+            (filter_hash, total_commands, total_input_tokens, total_output_tokens, savings_pct, last_updated)
+         VALUES ($1, 10, 1000, 200, 80.0, NOW())",
+    )
+    .bind(&hash)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let app =
+        crate::routes::create_router(make_state_with_storage(pool.clone(), Arc::clone(&storage)));
+    let resp = get_request(app, &token, &format!("/api/filters/{hash}")).await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        json["savings_pct"], 80.0,
+        "savings_pct should be 80.0 (0-100 scale)"
+    );
+    assert_eq!(json["total_commands"], 10);
+}
+
+#[crdb_test_macro::crdb_test(migrations = "./migrations")]
 async fn search_wildcard_injection_does_not_return_all(pool: PgPool) {
     let (_, token) = insert_test_user(&pool, "wildcard_test").await;
     let storage = Arc::new(InMemoryStorageClient::new());

--- a/crates/tokf-server/src/routes/gain.rs
+++ b/crates/tokf-server/src/routes/gain.rs
@@ -478,6 +478,45 @@ mod tests {
     }
 
     #[crdb_test_macro::crdb_test(migrations = "./migrations")]
+    async fn filter_gain_returns_stats_with_savings_pct(pool: PgPool) {
+        init_test_tracing();
+        let hash = "teststats0000000000000000000000000000000000000000000000000000";
+
+        // Insert filter_stats directly with a known savings_pct on the 0-100 scale
+        sqlx::query(
+            "INSERT INTO filter_stats
+                (filter_hash, total_commands, total_input_tokens, total_output_tokens, savings_pct, last_updated)
+             VALUES ($1, 5, 2000, 400, 80.0, NOW())",
+        )
+        .bind(hash)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let resp = app(pool)
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/api/gain/filter/{hash}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = assert_status(resp, StatusCode::OK).await;
+        let result: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(result["filter_hash"], hash);
+        assert_eq!(result["total_commands"], 5);
+        assert_eq!(result["total_input_tokens"], 2000);
+        assert_eq!(result["total_output_tokens"], 400);
+        assert_eq!(
+            result["savings_pct"], 80.0,
+            "savings_pct should be 80.0 (0-100 scale)"
+        );
+        assert!(result["last_updated"].is_string());
+    }
+
+    #[crdb_test_macro::crdb_test(migrations = "./migrations")]
     async fn global_gain_does_not_expose_hostnames(pool: PgPool) {
         init_test_tracing();
         let (user_id, _) = create_user_and_token(&pool).await;

--- a/crates/tokf-server/src/routes/sync.rs
+++ b/crates/tokf-server/src/routes/sync.rs
@@ -144,7 +144,7 @@ async fn update_filter_stats(
             SUM(input_tokens)::INT8,
             SUM(output_tokens)::INT8,
             CASE WHEN SUM(input_tokens) > 0
-                 THEN (SUM(input_tokens) - SUM(output_tokens))::FLOAT8 / SUM(input_tokens)::FLOAT8
+                 THEN (SUM(input_tokens) - SUM(output_tokens))::FLOAT8 / SUM(input_tokens)::FLOAT8 * 100.0
                  ELSE 0.0 END,
             NOW()
          FROM usage_events WHERE filter_hash = $1

--- a/crates/tokf-server/src/routes/sync_tests.rs
+++ b/crates/tokf-server/src/routes/sync_tests.rs
@@ -362,10 +362,10 @@ async fn sync_updates_filter_stats_for_known_hash(pool: PgPool) {
     assert_eq!(total_commands, 2, "total_commands should be 2");
     assert_eq!(total_input, 1500, "total_input_tokens should be 1500");
     assert_eq!(total_output, 300, "total_output_tokens should be 300");
-    // savings_pct = (1500 - 300) / 1500 = 0.8
+    // savings_pct = (1500 - 300) / 1500 * 100 = 80.0
     assert!(
-        (savings_pct - 0.8).abs() < 0.001,
-        "savings_pct should be ~0.8, got {savings_pct}"
+        (savings_pct - 80.0).abs() < 0.1,
+        "savings_pct should be ~80.0, got {savings_pct}"
     );
 }
 

--- a/docs/community-filters.md
+++ b/docs/community-filters.md
@@ -23,7 +23,7 @@ Returns filters whose command pattern matches `<query>` as a substring, ranked b
 and install count.
 
 ```
-COMMAND              AUTHOR    SAVINGS%   INSTALLS
+COMMAND              AUTHOR    SAVINGS%   RUNS
 git push             alice       42.3%     1,234
 git push --force     bob         38.1%       891
 ```


### PR DESCRIPTION
## Summary

Closes #207.

- **Server**: `update_filter_stats` now computes `savings_pct` on a 0–100 scale (was 0–1 fraction), so `80%` savings stores as `80.0` instead of `0.8`
- **Migration**: backfills existing `filter_stats` rows with `savings_pct * 100.0`
- **CLI**: renamed misleading "INSTALLS" column header to "RUNS" in `tokf search` output
- **Docs**: updated `docs/community-filters.md` example table to match
- **Tests**: added integration tests for non-zero `savings_pct` through the search detail and gain/filter endpoints

## Test plan

- [x] `cargo test --workspace` — 1,389 passed
- [x] `just test-db` — 100 passed (includes 2 new tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)