### PR TITLE
fix(config): normalize basename on both pattern and input words

### DIFF
--- a/crates/tokf-cli/src/config/mod.rs
+++ b/crates/tokf-cli/src/config/mod.rs
@@ -397,12 +397,6 @@ pub fn command_pattern_to_regex(pattern: &str) -> String {
     let mut regex = String::from("^");
 
     for (i, &word) in words.iter().enumerate() {
-        let word_re = if word == "*" {
-            r"\S+".to_string()
-        } else {
-            regex::escape(word)
-        };
-
         if i == 0 {
             if word == "*" {
                 regex.push_str(r"\S+");
@@ -412,8 +406,9 @@ pub fn command_pattern_to_regex(pattern: &str) -> String {
                 // `command = "mvnw test"` produce identical regexes.
                 let basename = extract_basename(word);
                 // Allow an optional leading path prefix (e.g. `/usr/bin/` or
-                // `./`) so that `/usr/bin/git` matches the pattern `git`.
-                regex.push_str(r"(?:[^\s]*/)?");
+                // `./` or `C:\tools\`) so that `/usr/bin/git` and
+                // `C:\tools\git` both match the pattern `git`.
+                regex.push_str(r"(?:[^\s]*[\\/])?");
                 regex.push_str(&regex::escape(basename));
             }
         } else if word == "*" {
@@ -432,6 +427,7 @@ pub fn command_pattern_to_regex(pattern: &str) -> String {
             // argument.  When the value would consume the target pattern word,
             // the NFA engine backtracks that optional group (making it empty)
             // so that `\s+{word_re}` can match instead.
+            let word_re = regex::escape(word);
             regex.push_str(r"(?:\s+-[^=\s]+(?:=[^\s]+)?(?:\s+[^-\s]\S*)?)*\s+");
             regex.push_str(&word_re);
         }

--- a/crates/tokf-cli/src/config/tests_basename.rs
+++ b/crates/tokf-cli/src/config/tests_basename.rs
@@ -231,6 +231,22 @@ fn regex_absolute_path_pattern_normalized() {
     );
 }
 
+// --- Windows path in regex input ---
+
+#[test]
+fn regex_windows_path_input() {
+    let r = command_pattern_to_regex("mvnw test");
+    let re = regex::Regex::new(&r).unwrap();
+    assert!(
+        re.is_match(r"C:\project\mvnw test"),
+        "Windows path should match"
+    );
+    assert!(
+        re.is_match(r"D:\tools\bin\mvnw test"),
+        "deep Windows path should match"
+    );
+}
+
 // --- negative regex cases ---
 
 #[test]


### PR DESCRIPTION
## Summary

- When a filter defines `command = "./mvnw test"`, tokf never matches because `extract_basename` was only applied to the **input** word, not the **pattern** word — so the comparison became `"mvnw" == "./mvnw"` → false
- The same issue existed in `command_pattern_to_regex` where `"./mvnw"` produced `\./mvnw` in the regex, preventing bare `mvnw test` from matching
- Now both `pattern_matches_prefix` and `command_pattern_to_regex` normalize the first word via `extract_basename`, making `./mvnw test`, `mvnw test`, `../some/mvnw test` all match equivalently

## Test plan

- [x] 22 new tests in `tests_basename.rs` covering:
  - Path-prefixed patterns on both sides (relative, absolute, Windows)
  - Single-word path patterns (no subcommand)
  - Wildcard at position 0 with path inputs
  - Empty basename edge cases (`/`, `git/`)
  - Negative cases (partial, prefix, suffix basename mismatches)
  - Path-prefixed pattern + transparent flag skipping interaction
  - Regex normalization equivalence (`./mvnw test` == `mvnw test`)
  - Regex negative basename cases
- [x] All 78 matching tests pass
- [x] `cargo clippy` clean
- [x] All files under 500-line soft limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)