### PR TITLE
feat(server,cli): add Terms of Service and account deletion

### DIFF
--- a/crates/e2e-tests/tests/auth_flow.rs
+++ b/crates/e2e-tests/tests/auth_flow.rs
@@ -45,7 +45,7 @@ async fn device_flow_creates_token(pool: PgPool) {
     let device_code = device.device_code.clone();
     let result = tokio::task::spawn_blocking(move || {
         let http = auth_http_client();
-        client::poll_token(&http, &poll_url, &device_code)
+        client::poll_token(&http, &poll_url, &device_code, None)
     })
     .await
     .unwrap()
@@ -87,7 +87,7 @@ async fn auth_then_register_machine_then_sync(pool: PgPool) {
     let dc = device.device_code.clone();
     let result = tokio::task::spawn_blocking(move || {
         let http = auth_http_client();
-        client::poll_token(&http, &poll_url, &dc)
+        client::poll_token(&http, &poll_url, &dc, None)
     })
     .await
     .unwrap()

--- a/crates/e2e-tests/tests/harness/mod.rs
+++ b/crates/e2e-tests/tests/harness/mod.rs
@@ -223,6 +223,7 @@ impl TestHarness {
             // Far-future expiry (year ~2554) so the token is always valid.
             expires_at: 18_446_744_073,
             mit_license_accepted: None,
+            tos_accepted_version: None,
         }
     }
 

--- a/crates/tokf-cli/src/auth/client.rs
+++ b/crates/tokf-cli/src/auth/client.rs
@@ -32,6 +32,12 @@ pub struct TokenResponse {
     pub token_type: String,
     pub expires_in: i64,
     pub user: TokenUser,
+    /// Current `ToS` version the server requires (absent from old servers).
+    #[serde(default)]
+    pub tos_current_version: Option<i32>,
+    /// Highest `ToS` version this user has accepted (absent from old servers).
+    #[serde(default)]
+    pub tos_accepted_version: Option<i32>,
 }
 
 // Manual Debug impl to redact the access_token secret
@@ -42,6 +48,8 @@ impl fmt::Debug for TokenResponse {
             .field("token_type", &self.token_type)
             .field("expires_in", &self.expires_in)
             .field("user", &self.user)
+            .field("tos_current_version", &self.tos_current_version)
+            .field("tos_accepted_version", &self.tos_accepted_version)
             .finish()
     }
 }
@@ -120,6 +128,9 @@ pub fn initiate_device_flow(
 
 /// Poll for a completed device authorization via `POST /api/auth/token`.
 ///
+/// When `tos_version` is `Some`, the version is included in the request body
+/// so the server can record acceptance atomically with the token exchange.
+///
 /// # Errors
 ///
 /// Returns an error if the server is unreachable or returns a 5xx status.
@@ -127,11 +138,16 @@ pub fn poll_token(
     client: &reqwest::blocking::Client,
     base_url: &str,
     device_code: &str,
+    tos_version: Option<i32>,
 ) -> anyhow::Result<PollResult> {
     let url = format!("{base_url}/api/auth/token");
+    let mut body = serde_json::json!({ "device_code": device_code });
+    if let Some(v) = tos_version {
+        body["tos_version"] = serde_json::json!(v);
+    }
     let resp = client
         .post(&url)
-        .json(&serde_json::json!({ "device_code": device_code }))
+        .json(&body)
         .send()
         .map_err(|e| anyhow::anyhow!("could not reach {url}: {e}"))?;
 
@@ -254,6 +270,43 @@ mod tests {
         assert_eq!(resp.expires_in, 7_776_000);
         assert_eq!(resp.user.id, 42);
         assert_eq!(resp.user.username, "octocat");
+    }
+
+    #[test]
+    fn deserialize_token_response_with_tos_fields() {
+        let json = r#"{
+            "access_token": "tok_secret",
+            "token_type": "bearer",
+            "expires_in": 7776000,
+            "user": {
+                "id": 42,
+                "username": "octocat",
+                "avatar_url": "https://avatars.githubusercontent.com/u/42"
+            },
+            "tos_current_version": 1,
+            "tos_accepted_version": 1
+        }"#;
+        let resp: TokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.tos_current_version, Some(1));
+        assert_eq!(resp.tos_accepted_version, Some(1));
+    }
+
+    #[test]
+    fn deserialize_token_response_without_tos_fields() {
+        // Old server doesn't send ToS fields — should default to None
+        let json = r#"{
+            "access_token": "tok_secret",
+            "token_type": "bearer",
+            "expires_in": 7776000,
+            "user": {
+                "id": 42,
+                "username": "octocat",
+                "avatar_url": "https://avatars.githubusercontent.com/u/42"
+            }
+        }"#;
+        let resp: TokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.tos_current_version, None);
+        assert_eq!(resp.tos_accepted_version, None);
     }
 
     #[test]

--- a/crates/tokf-cli/src/auth/credentials.rs
+++ b/crates/tokf-cli/src/auth/credentials.rs
@@ -19,6 +19,9 @@ pub struct StoredAuth {
     /// Whether the user has accepted the MIT license for filter publishing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mit_license_accepted: Option<bool>,
+    /// Highest Terms of Service version the user has accepted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tos_accepted_version: Option<i32>,
 }
 
 /// Loaded credentials: token (from keyring) + metadata (from TOML).
@@ -30,6 +33,8 @@ pub struct LoadedAuth {
     pub expires_at: u64,
     /// Whether the user has accepted the MIT license for filter publishing.
     pub mit_license_accepted: Option<bool>,
+    /// Highest Terms of Service version the user has accepted.
+    pub tos_accepted_version: Option<i32>,
 }
 
 impl LoadedAuth {
@@ -87,17 +92,19 @@ pub fn save(
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    // Preserve any previously stored fields (e.g. mit_license_accepted)
+    // Preserve any previously stored fields (e.g. mit_license_accepted, tos_accepted_version)
     let existing = auth_config_path()
         .and_then(|p| fs::read_to_string(&p).ok())
         .and_then(|c| toml::from_str::<StoredAuth>(&c).ok());
-    let mit_license_accepted = existing.and_then(|e| e.mit_license_accepted);
+    let mit_license_accepted = existing.as_ref().and_then(|e| e.mit_license_accepted);
+    let tos_accepted_version = existing.as_ref().and_then(|e| e.tos_accepted_version);
 
     let meta = StoredAuth {
         username: username.to_string(),
         server_url: server_url.to_string(),
         expires_at,
         mit_license_accepted,
+        tos_accepted_version,
     };
     let content = toml::to_string_pretty(&meta)?;
     write_config_file(&path, &content)?;
@@ -127,6 +134,43 @@ pub(crate) fn save_license_accepted_to_path(
     path: &std::path::Path,
     accepted: bool,
 ) -> anyhow::Result<()> {
+    update_stored_auth(path, |meta| meta.mit_license_accepted = Some(accepted))
+}
+
+/// Persist the user's `ToS` acceptance version to the auth config file.
+///
+/// If no auth config file exists, creates a minimal one. Existing fields
+/// are preserved unchanged.
+///
+/// # Errors
+///
+/// Returns an error if the config directory cannot be determined or the file
+/// cannot be written.
+pub fn save_tos_accepted_version(version: i32) -> anyhow::Result<()> {
+    let path =
+        auth_config_path().ok_or_else(|| anyhow::anyhow!("cannot determine config directory"))?;
+    save_tos_accepted_version_to_path(&path, version)
+}
+
+/// Core logic for persisting `ToS` acceptance version to a specific path.
+///
+/// Separated from [`save_tos_accepted_version`] to allow direct testing
+/// without depending on the platform config directory.
+pub(crate) fn save_tos_accepted_version_to_path(
+    path: &std::path::Path,
+    version: i32,
+) -> anyhow::Result<()> {
+    update_stored_auth(path, |meta| meta.tos_accepted_version = Some(version))
+}
+
+/// Load-modify-save helper for [`StoredAuth`].
+///
+/// Reads the existing file (or creates a default), applies `mutate`, and
+/// writes back. Ensures the parent directory exists.
+fn update_stored_auth(
+    path: &std::path::Path,
+    mutate: impl FnOnce(&mut StoredAuth),
+) -> anyhow::Result<()> {
     let mut meta: StoredAuth = if path.exists() {
         let content = fs::read_to_string(path)?;
         toml::from_str(&content)?
@@ -136,10 +180,11 @@ pub(crate) fn save_license_accepted_to_path(
             server_url: String::new(),
             expires_at: 0,
             mit_license_accepted: None,
+            tos_accepted_version: None,
         }
     };
 
-    meta.mit_license_accepted = Some(accepted);
+    mutate(&mut meta);
 
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -166,6 +211,7 @@ pub fn load() -> Option<LoadedAuth> {
         server_url: meta.server_url,
         expires_at: meta.expires_at,
         mit_license_accepted: meta.mit_license_accepted,
+        tos_accepted_version: meta.tos_accepted_version,
     })
 }
 
@@ -320,6 +366,7 @@ mod tests {
             server_url: "https://api.tokf.net".to_string(),
             expires_at: 1_700_000_000,
             mit_license_accepted: None,
+            tos_accepted_version: None,
         };
         let serialized = toml::to_string_pretty(&meta).unwrap();
         let deserialized: StoredAuth = toml::from_str(&serialized).unwrap();
@@ -335,6 +382,7 @@ mod tests {
             server_url: "https://api.tokf.net".to_string(),
             expires_at: 0,
             mit_license_accepted: Some(true),
+            tos_accepted_version: None,
         };
         let serialized = toml::to_string_pretty(&meta).unwrap();
         assert!(
@@ -354,6 +402,7 @@ mod tests {
             server_url: "https://example.com".to_string(),
             expires_at: 9_999_999_999,
             mit_license_accepted: None,
+            tos_accepted_version: None,
         };
         let content = toml::to_string_pretty(&initial).unwrap();
         std::fs::write(&path, &content).unwrap();
@@ -444,6 +493,58 @@ mod tests {
     }
 
     #[test]
+    fn stored_auth_tos_version_roundtrip() {
+        let meta = StoredAuth {
+            username: "carol".to_string(),
+            server_url: "https://api.tokf.net".to_string(),
+            expires_at: 0,
+            mit_license_accepted: None,
+            tos_accepted_version: Some(1),
+        };
+        let serialized = toml::to_string_pretty(&meta).unwrap();
+        assert!(
+            serialized.contains("tos_accepted_version"),
+            "should serialize field: {serialized}"
+        );
+        let deserialized: StoredAuth = toml::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.tos_accepted_version, Some(1));
+    }
+
+    #[test]
+    fn stored_auth_missing_tos_version_defaults_to_none() {
+        let toml_str = r#"
+            username = "bob"
+            server_url = "https://api.tokf.net"
+        "#;
+        let meta: StoredAuth = toml::from_str(toml_str).unwrap();
+        assert_eq!(meta.tos_accepted_version, None);
+    }
+
+    #[test]
+    fn save_tos_accepted_version_preserves_other_fields() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("auth.toml");
+        let initial = StoredAuth {
+            username: "alice".to_string(),
+            server_url: "https://example.com".to_string(),
+            expires_at: 9_999_999_999,
+            mit_license_accepted: Some(true),
+            tos_accepted_version: None,
+        };
+        let content = toml::to_string_pretty(&initial).unwrap();
+        std::fs::write(&path, &content).unwrap();
+
+        save_tos_accepted_version_to_path(&path, 1).unwrap();
+
+        let result: StoredAuth = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(result.username, "alice");
+        assert_eq!(result.server_url, "https://example.com");
+        assert_eq!(result.expires_at, 9_999_999_999);
+        assert_eq!(result.mit_license_accepted, Some(true));
+        assert_eq!(result.tos_accepted_version, Some(1));
+    }
+
+    #[test]
     fn is_expired_unknown() {
         let auth = LoadedAuth {
             token: String::new(),
@@ -451,6 +552,7 @@ mod tests {
             server_url: String::new(),
             expires_at: 0,
             mit_license_accepted: None,
+            tos_accepted_version: None,
         };
         assert!(!auth.is_expired(), "unknown expiry should not be expired");
     }
@@ -468,6 +570,7 @@ mod tests {
             server_url: String::new(),
             expires_at: future,
             mit_license_accepted: None,
+            tos_accepted_version: None,
         };
         assert!(!auth.is_expired());
     }
@@ -480,6 +583,7 @@ mod tests {
             server_url: String::new(),
             expires_at: 1, // 1970 — definitely expired
             mit_license_accepted: None,
+            tos_accepted_version: None,
         };
         assert!(auth.is_expired());
     }

--- a/crates/tokf-cli/src/auth_cmd.rs
+++ b/crates/tokf-cli/src/auth_cmd.rs
@@ -1,27 +1,28 @@
+use std::io::{BufRead, Write};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use tokf::auth::{client, credentials};
+use tokf::remote::{account_client, http::Client, tos_client};
 
 const MAX_NETWORK_RETRIES: u32 = 3;
 
 pub fn cmd_auth_login() -> anyhow::Result<i32> {
-    // Check if already logged in
-    if let Some(auth) = credentials::load() {
-        eprintln!(
-            "[tokf] already logged in as {}. Run `tokf auth logout` first.",
-            auth.username
-        );
-        return Ok(0);
-    }
-
     let base_url = client::server_url();
+
+    // Check if already logged in — may need ToS re-acceptance
+    if let Some(auth) = credentials::load() {
+        return handle_existing_login(&auth, &base_url);
+    }
 
     if !client::is_secure_url(&base_url) {
         eprintln!(
             "[tokf] WARNING: server URL uses insecure HTTP — credentials will be sent unencrypted"
         );
     }
+
+    // Fetch current ToS version (unauthenticated)
+    let tos_version = prompt_tos_acceptance(&base_url)?;
 
     let http_client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(10))
@@ -58,13 +59,107 @@ pub fn cmd_auth_login() -> anyhow::Result<i32> {
     }
 
     eprintln!("[tokf] Waiting for authorization (press Ctrl+C to cancel)...");
-    poll_for_token(&http_client, &base_url, &device_resp)
+    poll_for_token(&http_client, &base_url, &device_resp, tos_version)
+}
+
+/// If already logged in, check whether `ToS` re-acceptance is needed.
+fn handle_existing_login(auth: &credentials::LoadedAuth, base_url: &str) -> anyhow::Result<i32> {
+    // Try to fetch current ToS version from server
+    let Ok(client) = Client::unauthenticated(base_url) else {
+        eprintln!(
+            "[tokf] Already logged in as {}. Run `tokf auth logout` first.",
+            auth.username
+        );
+        return Ok(0);
+    };
+
+    // Server unreachable or old server without ToS — just report logged in
+    let Ok(tos_info) = tos_client::fetch_tos_info(&client) else {
+        eprintln!(
+            "[tokf] Already logged in as {}. Run `tokf auth logout` first.",
+            auth.username
+        );
+        return Ok(0);
+    };
+
+    // Check if local version is current
+    if auth
+        .tos_accepted_version
+        .is_some_and(|v| v >= tos_info.version)
+    {
+        eprintln!(
+            "[tokf] Already logged in as {}. Run `tokf auth logout` first.",
+            auth.username
+        );
+        return Ok(0);
+    }
+
+    // ToS re-acceptance needed
+    eprintln!(
+        "[tokf] The Terms of Service have been updated (v{}).",
+        tos_info.version
+    );
+    print_tos_summary(&tos_info.url);
+
+    if !confirm_tos(tos_info.version)? {
+        eprintln!(
+            "[tokf] Terms declined. You remain logged in but some features may require acceptance."
+        );
+        return Ok(1);
+    }
+
+    // Record acceptance on server
+    let authed_client = Client::authed()?;
+    tos_client::accept_tos(&authed_client, tos_info.version)?;
+    credentials::save_tos_accepted_version(tos_info.version)?;
+    eprintln!("[tokf] Terms of Service v{} accepted.", tos_info.version);
+    Ok(0)
+}
+
+/// Fetch `ToS` info and prompt the user to accept before proceeding with login.
+///
+/// Returns the accepted version, or an error if declined.
+fn prompt_tos_acceptance(base_url: &str) -> anyhow::Result<Option<i32>> {
+    let Ok(client) = Client::unauthenticated(base_url) else {
+        return Ok(None); // Can't reach server — proceed without ToS
+    };
+
+    let Ok(tos_info) = tos_client::fetch_tos_info(&client) else {
+        return Ok(None); // Old server without ToS endpoint
+    };
+
+    eprintln!("[tokf] Before logging in, please review our Terms of Service.");
+    print_tos_summary(&tos_info.url);
+
+    if !confirm_tos(tos_info.version)? {
+        anyhow::bail!("Terms of Service declined — login cancelled");
+    }
+
+    Ok(Some(tos_info.version))
+}
+
+fn print_tos_summary(terms_url: &str) {
+    eprintln!("[tokf] Summary: tokf collects your GitHub profile, machine IDs, and");
+    eprintln!("[tokf]          aggregate token-count statistics. We do not collect");
+    eprintln!("[tokf]          command content or output. No data is sold or shared.");
+    eprintln!("[tokf]          No guarantees are provided.");
+    eprintln!("[tokf] Full terms: {terms_url}");
+}
+
+fn confirm_tos(version: i32) -> anyhow::Result<bool> {
+    eprint!("[tokf] Accept Terms of Service (v{version})? [y/N]: ");
+    std::io::stderr().flush()?;
+
+    let mut input = String::new();
+    std::io::stdin().lock().read_line(&mut input)?;
+    Ok(input.trim().eq_ignore_ascii_case("y") || input.trim().eq_ignore_ascii_case("yes"))
 }
 
 fn poll_for_token(
     http_client: &reqwest::blocking::Client,
     base_url: &str,
     device_resp: &client::DeviceFlowResponse,
+    tos_version: Option<i32>,
 ) -> anyhow::Result<i32> {
     let mut interval = device_resp.interval.clamp(1, 60);
     let expires_in = device_resp.expires_in.clamp(0, 1800);
@@ -76,7 +171,7 @@ fn poll_for_token(
     for _ in 0..max_attempts {
         thread::sleep(Duration::from_secs(interval.unsigned_abs()));
 
-        match client::poll_token(http_client, base_url, &device_resp.device_code) {
+        match client::poll_token(http_client, base_url, &device_resp.device_code, tos_version) {
             Ok(client::PollResult::Success(token_resp)) => {
                 credentials::save(
                     &token_resp.access_token,
@@ -84,6 +179,10 @@ fn poll_for_token(
                     base_url,
                     token_resp.expires_in,
                 )?;
+                // Save the accepted ToS version locally
+                if let Some(v) = tos_version {
+                    credentials::save_tos_accepted_version(v)?;
+                }
                 eprintln!();
                 eprintln!("[tokf] Logged in as {}", token_resp.user.username);
                 return Ok(0);
@@ -160,5 +259,43 @@ pub fn cmd_auth_status() -> anyhow::Result<i32> {
             println!("Not logged in. Run `tokf auth login` to authenticate.");
         }
     }
+    Ok(0)
+}
+
+pub fn cmd_auth_delete_account() -> anyhow::Result<i32> {
+    let auth = credentials::load()
+        .ok_or_else(|| anyhow::anyhow!("not logged in — run `tokf auth login` first"))?;
+
+    eprintln!("[tokf] WARNING: This will permanently delete your account.");
+    eprintln!("[tokf] The following data will be removed:");
+    eprintln!("[tokf]   - Auth tokens and sessions");
+    eprintln!("[tokf]   - Machine registrations and sync state");
+    eprintln!("[tokf]   - Usage statistics and event history");
+    eprintln!("[tokf]   - Terms of Service acceptance records");
+    eprintln!("[tokf] Your published filters will remain available to the community");
+    eprintln!("[tokf] with your account converted to unclaimed status.");
+    eprintln!();
+    eprint!(
+        "[tokf] Type your username ({}) to confirm deletion: ",
+        auth.username
+    );
+    std::io::stderr().flush()?;
+
+    let mut input = String::new();
+    std::io::stdin().lock().read_line(&mut input)?;
+    let input = input.trim();
+
+    if input != auth.username {
+        eprintln!("[tokf] Username does not match. Account deletion cancelled.");
+        return Ok(1);
+    }
+
+    let client = Client::authed()?;
+    account_client::delete_account(&client)?;
+
+    // Remove local credentials
+    credentials::remove();
+
+    eprintln!("[tokf] Account deleted. Local credentials removed.");
     Ok(0)
 }

--- a/crates/tokf-cli/src/main.rs
+++ b/crates/tokf-cli/src/main.rs
@@ -296,6 +296,8 @@ enum AuthAction {
     Logout,
     /// Show current authentication status (username, server URL)
     Status,
+    /// Permanently delete your account (requires confirmation)
+    DeleteAccount,
 }
 
 #[derive(Subcommand)]
@@ -437,6 +439,7 @@ fn main() {
             AuthAction::Login => auth_cmd::cmd_auth_login(),
             AuthAction::Logout => auth_cmd::cmd_auth_logout(),
             AuthAction::Status => auth_cmd::cmd_auth_status(),
+            AuthAction::DeleteAccount => auth_cmd::cmd_auth_delete_account(),
         }),
         Commands::Remote { action } => or_exit(match action {
             RemoteAction::Setup => remote_cmd::cmd_remote_setup(),

--- a/crates/tokf-cli/src/remote/account_client.rs
+++ b/crates/tokf-cli/src/remote/account_client.rs
@@ -1,0 +1,16 @@
+use super::http::Client;
+
+/// Delete the authenticated user's account on the server.
+///
+/// The server anonymizes the user profile and cascade-deletes auth tokens,
+/// machines, usage events, sync cursors, and `ToS` acceptance records.
+/// Published filters are preserved with the account converted to unclaimed.
+///
+/// # Errors
+///
+/// Returns an error on network failure or non-2xx status.
+pub fn delete_account(client: &Client) -> anyhow::Result<()> {
+    // client.delete() already validates 2xx via require_success()
+    client.delete("/api/account")?;
+    Ok(())
+}

--- a/crates/tokf-cli/src/remote/http.rs
+++ b/crates/tokf-cli/src/remote/http.rs
@@ -166,6 +166,19 @@ impl Client {
             .map_err(|e| anyhow::anyhow!("invalid response from server: {e}"))
     }
 
+    /// DELETE `{base_url}{path}`, returning the raw response.
+    ///
+    /// Does **not** retry — DELETE is non-idempotent in our usage
+    /// (account deletion is a one-shot operation).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on network failure or non-2xx status.
+    pub fn delete(&self, path: &str) -> anyhow::Result<reqwest::blocking::Response> {
+        let url = self.url(path);
+        Self::send_once(self.build_request(self.inner.delete(&url)), &url)
+    }
+
     /// POST `{base_url}{path}` with a multipart form.
     ///
     /// Returns the raw response — callers handle per-status-code logic (e.g.

--- a/crates/tokf-cli/src/remote/mod.rs
+++ b/crates/tokf-cli/src/remote/mod.rs
@@ -1,3 +1,4 @@
+pub mod account_client;
 pub mod client;
 pub mod filter_client;
 pub mod gain_client;
@@ -6,6 +7,7 @@ pub mod machine;
 pub mod publish_client;
 pub mod retry;
 pub mod sync_client;
+pub mod tos_client;
 
 use std::fmt;
 

--- a/crates/tokf-cli/src/remote/tos_client.rs
+++ b/crates/tokf-cli/src/remote/tos_client.rs
@@ -1,0 +1,64 @@
+use serde::{Deserialize, Serialize};
+
+use super::http::Client;
+
+#[derive(Debug, Deserialize)]
+pub struct TosInfoResponse {
+    pub version: i32,
+    pub url: String,
+}
+
+#[derive(Debug, Serialize)]
+struct AcceptTosRequest {
+    version: i32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AcceptTosResponse {
+    pub accepted_version: i32,
+    pub accepted_at: String,
+}
+
+/// Fetch the current `ToS` version and full-text URL from the server.
+///
+/// This is an unauthenticated endpoint.
+///
+/// # Errors
+///
+/// Returns an error on network failure or non-2xx status.
+pub fn fetch_tos_info(client: &Client) -> anyhow::Result<TosInfoResponse> {
+    client.get("/api/tos")
+}
+
+/// Record `ToS` acceptance on the server.
+///
+/// Requires authentication.
+///
+/// # Errors
+///
+/// Returns an error on network failure, non-2xx status, or version mismatch.
+pub fn accept_tos(client: &Client, version: i32) -> anyhow::Result<AcceptTosResponse> {
+    client.post("/api/tos/accept", &AcceptTosRequest { version })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_tos_info_response() {
+        let json = r#"{"version": 1, "url": "https://api.tokf.net/terms"}"#;
+        let resp: TosInfoResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.version, 1);
+        assert_eq!(resp.url, "https://api.tokf.net/terms");
+    }
+
+    #[test]
+    fn deserialize_accept_tos_response() {
+        let json = r#"{"accepted_version": 1, "accepted_at": "2026-03-02T00:00:00Z"}"#;
+        let resp: AcceptTosResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.accepted_version, 1);
+        assert_eq!(resp.accepted_at, "2026-03-02T00:00:00Z");
+    }
+}

--- a/crates/tokf-cli/tests/auth_client.rs
+++ b/crates/tokf-cli/tests/auth_client.rs
@@ -136,7 +136,7 @@ fn poll_token_success() {
         )
         .create();
 
-    let result = client::poll_token(&http_client(), &server.url(), "dc-123").unwrap();
+    let result = client::poll_token(&http_client(), &server.url(), "dc-123", None).unwrap();
     match result {
         client::PollResult::Success(resp) => {
             assert_eq!(resp.access_token, "tok_secret");
@@ -157,7 +157,7 @@ fn poll_token_pending() {
         .with_body(r#"{"error": "authorization_pending"}"#)
         .create();
 
-    let result = client::poll_token(&http_client(), &server.url(), "dc-123").unwrap();
+    let result = client::poll_token(&http_client(), &server.url(), "dc-123", None).unwrap();
     match result {
         client::PollResult::Pending { interval } => {
             assert_eq!(interval, 5); // default when not provided
@@ -177,7 +177,7 @@ fn poll_token_slow_down() {
         .with_body(r#"{"error": "slow_down", "interval": 15}"#)
         .create();
 
-    let result = client::poll_token(&http_client(), &server.url(), "dc-123").unwrap();
+    let result = client::poll_token(&http_client(), &server.url(), "dc-123", None).unwrap();
     match result {
         client::PollResult::SlowDown { interval } => {
             assert_eq!(interval, 15);
@@ -197,7 +197,7 @@ fn poll_token_client_error_denied() {
         .with_body(r#"{"error":"access_denied","error_description":"The user denied the request"}"#)
         .create();
 
-    let result = client::poll_token(&http_client(), &server.url(), "dc-123").unwrap();
+    let result = client::poll_token(&http_client(), &server.url(), "dc-123", None).unwrap();
     match result {
         client::PollResult::Failed(msg) => {
             assert_eq!(msg, "The user denied the request");
@@ -217,7 +217,7 @@ fn poll_token_client_error_expired() {
         .with_body(r#"{"error":"expired_token"}"#)
         .create();
 
-    let result = client::poll_token(&http_client(), &server.url(), "dc-123").unwrap();
+    let result = client::poll_token(&http_client(), &server.url(), "dc-123", None).unwrap();
     match result {
         client::PollResult::Failed(msg) => {
             assert_eq!(msg, "expired_token");
@@ -236,7 +236,7 @@ fn poll_token_server_error_5xx() {
         .with_body("Bad Gateway")
         .create();
 
-    let err = client::poll_token(&http_client(), &server.url(), "dc-123").unwrap_err();
+    let err = client::poll_token(&http_client(), &server.url(), "dc-123", None).unwrap_err();
     assert!(
         err.to_string().contains("HTTP 502"),
         "expected HTTP 502 in error, got: {err}"
@@ -254,7 +254,7 @@ fn poll_token_unparseable_200() {
         .with_body("not json at all")
         .create();
 
-    let err = client::poll_token(&http_client(), &server.url(), "dc-123").unwrap_err();
+    let err = client::poll_token(&http_client(), &server.url(), "dc-123", None).unwrap_err();
     assert!(
         err.to_string().contains("unexpected response"),
         "expected 'unexpected response' in error, got: {err}"
@@ -272,7 +272,7 @@ fn poll_token_unknown_error_string() {
         .with_body(r#"{"error": "some_unknown_error"}"#)
         .create();
 
-    let result = client::poll_token(&http_client(), &server.url(), "dc-123").unwrap();
+    let result = client::poll_token(&http_client(), &server.url(), "dc-123", None).unwrap();
     match result {
         client::PollResult::Failed(msg) => {
             assert_eq!(msg, "some_unknown_error");
@@ -295,7 +295,7 @@ fn poll_token_4xx_raw_text_sanitized() {
         .with_body(&body)
         .create();
 
-    let result = client::poll_token(&http_client(), &server.url(), "dc-123").unwrap();
+    let result = client::poll_token(&http_client(), &server.url(), "dc-123", None).unwrap();
     match result {
         client::PollResult::Failed(msg) => {
             // Should be truncated and control chars stripped

--- a/crates/tokf-cli/tests/auth_credentials.rs
+++ b/crates/tokf-cli/tests/auth_credentials.rs
@@ -36,6 +36,7 @@ fn stored_auth_toml_format() {
         server_url: "https://api.tokf.net".to_string(),
         expires_at: 1_700_000_000,
         mit_license_accepted: None,
+        tos_accepted_version: None,
     };
     let toml_str = toml::to_string_pretty(&meta).unwrap();
     assert!(toml_str.contains("username = \"testuser\""));
@@ -51,6 +52,7 @@ fn loaded_auth_has_named_fields() {
         server_url: "https://example.com".to_string(),
         expires_at: 0,
         mit_license_accepted: None,
+        tos_accepted_version: None,
     };
     assert_eq!(auth.token, "tok_123");
     assert_eq!(auth.username, "bob");
@@ -67,6 +69,7 @@ fn loaded_auth_expired_detection() {
         server_url: "https://example.com".to_string(),
         expires_at: 1, // epoch + 1 second = definitely expired
         mit_license_accepted: None,
+        tos_accepted_version: None,
     };
     assert!(auth.is_expired());
 }

--- a/crates/tokf-server/migrations/20260302000001_tos_and_account_deletion.sql
+++ b/crates/tokf-server/migrations/20260302000001_tos_and_account_deletion.sql
@@ -1,0 +1,20 @@
+-- no-transaction
+-- CockroachDB rejects multiple DDL changes to the same table in a single
+-- transaction. Run without a transaction so each statement commits independently.
+
+-- tos_acceptances: append-only audit log of Terms of Service acceptances.
+CREATE TABLE IF NOT EXISTS tos_acceptances (
+    id          BIGSERIAL PRIMARY KEY,
+    user_id     BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    tos_version INT NOT NULL,
+    accepted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ip_address  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_tos_acceptances_user_version
+    ON tos_acceptances(user_id, tos_version);
+
+-- Add a deleted_at column to users for soft-delete (account deletion).
+-- When a user deletes their account, we anonymize the row and set deleted_at.
+-- This preserves filter author_id references (filters are community resources).
+ALTER TABLE users ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;

--- a/crates/tokf-server/src/lib.rs
+++ b/crates/tokf-server/src/lib.rs
@@ -7,4 +7,5 @@ pub mod rate_limit;
 pub mod routes;
 pub mod state;
 pub mod storage;
+pub mod tos;
 pub mod verify;

--- a/crates/tokf-server/src/routes/account.rs
+++ b/crates/tokf-server/src/routes/account.rs
@@ -1,0 +1,207 @@
+use axum::extract::State;
+use axum::http::StatusCode;
+
+use crate::auth::token::AuthUser;
+use crate::error::AppError;
+use crate::state::AppState;
+
+/// Delete the authenticated user's account.
+///
+/// Anonymizes the user row (clears personal data, sets `visible = false`,
+/// marks `deleted_at`) so filter `author_id` references remain valid.
+/// Cascades deletion of auth tokens, machines (and their usage events /
+/// sync cursors), device flows, and `ToS` acceptance records.
+///
+/// Returns `204 No Content` on success.
+pub async fn delete_account(
+    State(state): State<AppState>,
+    user: AuthUser,
+) -> Result<StatusCode, AppError> {
+    // Run each statement independently (no wrapping transaction).
+    // CockroachDB's serializable isolation causes WriteTooOldError when
+    // a transaction DELETEs auth_tokens that were just read by the
+    // AuthUser extractor. Individual statements avoid this conflict and
+    // are safe here: each targets a different table, operations are
+    // idempotent, and partial failure is recoverable by re-running.
+
+    // Anonymize the user row first — this is the point of no return.
+    sqlx::query(
+        "UPDATE users SET
+            username = CONCAT('deleted-user-', id::TEXT),
+            avatar_url = '',
+            profile_url = '',
+            orgs = '[]'::jsonb,
+            visible = false,
+            deleted_at = NOW(),
+            updated_at = NOW()
+         WHERE id = $1",
+    )
+    .bind(user.user_id)
+    .execute(&state.db)
+    .await?;
+
+    // Delete cascading data that references user_id
+    sqlx::query("DELETE FROM tos_acceptances WHERE user_id = $1")
+        .bind(user.user_id)
+        .execute(&state.db)
+        .await?;
+
+    sqlx::query("DELETE FROM auth_tokens WHERE user_id = $1")
+        .bind(user.user_id)
+        .execute(&state.db)
+        .await?;
+
+    // usage_events.machine_id has no ON DELETE CASCADE, so delete explicitly.
+    // sync_cursors does cascade from machines.
+    sqlx::query(
+        "DELETE FROM usage_events WHERE machine_id IN
+             (SELECT id FROM machines WHERE user_id = $1)",
+    )
+    .bind(user.user_id)
+    .execute(&state.db)
+    .await?;
+
+    sqlx::query("DELETE FROM machines WHERE user_id = $1")
+        .bind(user.user_id)
+        .execute(&state.db)
+        .await?;
+
+    sqlx::query("DELETE FROM device_flows WHERE user_id = $1")
+        .bind(user.user_id)
+        .execute(&state.db)
+        .await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::delete;
+    use sqlx::PgPool;
+    use tower::ServiceExt;
+
+    use crate::routes::test_helpers::*;
+
+    use super::*;
+
+    fn app(pool: PgPool) -> Router {
+        Router::new()
+            .route("/api/account", delete(delete_account))
+            .with_state(make_state(pool))
+    }
+
+    #[crdb_test_macro::crdb_test(migrations = "./migrations")]
+    async fn delete_account_requires_auth(pool: PgPool) {
+        let resp = app(pool)
+            .oneshot(Request::delete("/api/account").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_status(resp, StatusCode::UNAUTHORIZED).await;
+    }
+
+    #[crdb_test_macro::crdb_test(migrations = "./migrations")]
+    async fn delete_account_anonymizes_user(pool: PgPool) {
+        let (user_id, token) = create_user_and_token(&pool).await;
+
+        let resp = app(pool.clone())
+            .oneshot(
+                Request::delete("/api/account")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_status(resp, StatusCode::NO_CONTENT).await;
+
+        // User row still exists but is anonymized
+        let (username, visible, deleted_at): (String, bool, Option<chrono::DateTime<chrono::Utc>>) =
+            sqlx::query_as("SELECT username, visible, deleted_at FROM users WHERE id = $1")
+                .bind(user_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            username.starts_with("deleted-user-"),
+            "expected anonymized username, got: {username}"
+        );
+        assert!(!visible);
+        assert!(deleted_at.is_some());
+
+        // Auth tokens are gone
+        let token_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM auth_tokens WHERE user_id = $1")
+                .bind(user_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(token_count, 0);
+    }
+
+    #[crdb_test_macro::crdb_test(migrations = "./migrations")]
+    async fn delete_account_preserves_filter_attribution(pool: PgPool) {
+        let (user_id, token) = create_user_and_token(&pool).await;
+
+        // Create a filter owned by this user
+        sqlx::query(
+            "INSERT INTO filters (content_hash, command_pattern, canonical_command, author_id, r2_key)
+             VALUES ('hash123', 'test *', 'test', $1, 'r2/hash123')",
+        )
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let resp = app(pool.clone())
+            .oneshot(
+                Request::delete("/api/account")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_status(resp, StatusCode::NO_CONTENT).await;
+
+        // Filter still exists and still references the user
+        let author_id: i64 =
+            sqlx::query_scalar("SELECT author_id FROM filters WHERE content_hash = 'hash123'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(author_id, user_id);
+    }
+
+    #[crdb_test_macro::crdb_test(migrations = "./migrations")]
+    async fn delete_account_token_becomes_invalid(pool: PgPool) {
+        let (_, token) = create_user_and_token(&pool).await;
+
+        // Delete the account
+        let resp = app(pool.clone())
+            .oneshot(
+                Request::delete("/api/account")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_status(resp, StatusCode::NO_CONTENT).await;
+
+        // Using the same token again should fail
+        let resp = app(pool)
+            .oneshot(
+                Request::delete("/api/account")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_status(resp, StatusCode::UNAUTHORIZED).await;
+    }
+}

--- a/crates/tokf-server/src/routes/auth.rs
+++ b/crates/tokf-server/src/routes/auth.rs
@@ -5,6 +5,7 @@ use crate::auth::github::{AccessTokenResponse, GitHubClient, GitHubUser};
 use crate::auth::token::{generate_token, hash_token};
 use crate::error::AppError;
 use crate::state::AppState;
+use crate::tos::CURRENT_TOS_VERSION;
 
 const MAX_FLOWS_PER_IP_PER_HOUR: i64 = 10;
 const TOKEN_TTL_SECONDS: i64 = 7_776_000; // 90 days
@@ -23,6 +24,9 @@ pub struct DeviceFlowResponse {
 #[derive(Debug, Deserialize)]
 pub struct PollTokenRequest {
     pub device_code: String,
+    /// `ToS` version the client accepted during login (absent for older clients).
+    #[serde(default)]
+    pub tos_version: Option<i32>,
 }
 
 #[derive(Debug, Serialize)]
@@ -31,6 +35,11 @@ pub struct TokenResponse {
     pub token_type: String,
     pub expires_in: i64,
     pub user: TokenUser,
+    /// Current `ToS` version the server requires.
+    pub tos_current_version: i32,
+    /// Highest `ToS` version this user has accepted (None if never accepted).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tos_accepted_version: Option<i32>,
 }
 
 #[derive(Debug, Serialize)]
@@ -166,7 +175,7 @@ pub async fn poll_token(
             error, interval, ..
         } => handle_pending_response(&state, flow_id, &error, interval).await,
         AccessTokenResponse::Success { access_token, .. } => {
-            handle_github_success(&state, flow_id, &access_token).await
+            handle_github_success(&state, flow_id, &access_token, req.tos_version).await
         }
     }
 }
@@ -224,6 +233,7 @@ async fn handle_github_success(
     state: &AppState,
     flow_id: i64,
     access_token: &str,
+    tos_version: Option<i32>,
 ) -> Result<axum::response::Response, AppError> {
     let (user, orgs) = fetch_github_profile(&*state.github, access_token).await?;
     let user_id = upsert_github_user(state, &user, &orgs).await?;
@@ -243,10 +253,20 @@ async fn handle_github_success(
         return Err(AppError::BadRequest("device code already used".to_string()));
     }
 
+    // Record ToS acceptance if the client sent a version matching current
+    let tos_accepted = if tos_version == Some(CURRENT_TOS_VERSION) {
+        record_tos_acceptance(state, user_id, CURRENT_TOS_VERSION).await?;
+        Some(CURRENT_TOS_VERSION)
+    } else {
+        get_accepted_tos_version(state, user_id).await?
+    };
+
     let resp = TokenResponse {
         access_token: bearer,
         token_type: "bearer".to_string(),
         expires_in,
+        tos_current_version: CURRENT_TOS_VERSION,
+        tos_accepted_version: tos_accepted,
         user: TokenUser {
             id: user_id,
             username: user.login,
@@ -271,11 +291,14 @@ async fn build_token_response(
             .await?;
 
     let (bearer, expires_in) = create_bearer_token(state, user_id).await?;
+    let tos_accepted = get_accepted_tos_version(state, user_id).await?;
 
     let resp = TokenResponse {
         access_token: bearer,
         token_type: "bearer".to_string(),
         expires_in,
+        tos_current_version: CURRENT_TOS_VERSION,
+        tos_accepted_version: tos_accepted,
         user: TokenUser {
             id: user_id,
             username,
@@ -349,4 +372,28 @@ async fn fetch_github_profile(
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
     Ok((user, orgs))
+}
+
+/// Query the highest `ToS` version the user has accepted, or `None`.
+async fn get_accepted_tos_version(state: &AppState, user_id: i64) -> Result<Option<i32>, AppError> {
+    let version: Option<i32> =
+        sqlx::query_scalar("SELECT MAX(tos_version) FROM tos_acceptances WHERE user_id = $1")
+            .bind(user_id)
+            .fetch_one(&state.db)
+            .await?;
+    Ok(version)
+}
+
+/// Insert a `ToS` acceptance record.
+async fn record_tos_acceptance(
+    state: &AppState,
+    user_id: i64,
+    version: i32,
+) -> Result<(), AppError> {
+    sqlx::query("INSERT INTO tos_acceptances (user_id, tos_version) VALUES ($1, $2)")
+        .bind(user_id)
+        .bind(version)
+        .execute(&state.db)
+        .await?;
+    Ok(())
 }

--- a/crates/tokf-server/src/routes/catalog_tests.rs
+++ b/crates/tokf-server/src/routes/catalog_tests.rs
@@ -8,24 +8,10 @@ use http_body_util::BodyExt;
 use sqlx::PgPool;
 use tower::ServiceExt;
 
-use crate::auth::token::hash_token;
 use crate::catalog::{CatalogEntry, CatalogIndex};
-use crate::routes::test_helpers::make_state;
+use crate::routes::test_helpers::{insert_service_token, make_state};
 use crate::storage::StorageClient as _;
 use crate::storage::mock::InMemoryStorageClient;
-
-/// Insert a service token into the DB and return the raw token string.
-async fn insert_service_token(pool: &PgPool, description: &str) -> String {
-    let token = crate::auth::token::generate_token();
-    let token_hash = hash_token(&token);
-    sqlx::query("INSERT INTO service_tokens (token_hash, description) VALUES ($1, $2)")
-        .bind(&token_hash)
-        .bind(description)
-        .execute(pool)
-        .await
-        .expect("failed to insert service token");
-    token
-}
 
 async fn post_refresh(app: axum::Router, token: &str) -> axum::response::Response {
     app.oneshot(

--- a/crates/tokf-server/src/routes/filters/publish/stdlib/tests.rs
+++ b/crates/tokf-server/src/routes/filters/publish/stdlib/tests.rs
@@ -7,24 +7,11 @@ use axum::{
 use http_body_util::BodyExt;
 use tower::ServiceExt;
 
-use crate::auth::token::hash_token;
 use crate::routes::filters::test_helpers::make_state;
+use crate::routes::test_helpers::insert_service_token;
 use crate::storage::mock::InMemoryStorageClient;
 
 use super::{StdlibFilterEntry, StdlibPublishRequest, StdlibTestFile};
-
-/// Insert a service token into the DB and return the raw token string.
-async fn insert_service_token(pool: &sqlx::PgPool, description: &str) -> String {
-    let token = crate::auth::token::generate_token();
-    let token_hash = hash_token(&token);
-    sqlx::query("INSERT INTO service_tokens (token_hash, description) VALUES ($1, $2)")
-        .bind(&token_hash)
-        .bind(description)
-        .execute(pool)
-        .await
-        .expect("failed to insert service token");
-    token
-}
 
 fn make_valid_request() -> StdlibPublishRequest {
     StdlibPublishRequest {

--- a/crates/tokf-server/src/routes/mod.rs
+++ b/crates/tokf-server/src/routes/mod.rs
@@ -1,3 +1,4 @@
+mod account;
 pub mod auth;
 mod catalog;
 mod filters;
@@ -8,6 +9,7 @@ mod machines;
 mod middleware;
 mod ready;
 mod sync;
+mod tos;
 
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod test_helpers;
@@ -15,7 +17,7 @@ pub mod test_helpers;
 use axum::{
     Router,
     extract::DefaultBodyLimit,
-    routing::{get, post, put},
+    routing::{delete, get, post, put},
 };
 
 use crate::state::AppState;
@@ -50,6 +52,10 @@ pub fn create_router(state: AppState) -> Router {
         .route("/api/gain", get(gain::get_gain))
         .route("/api/gain/global", get(gain::get_global_gain))
         .route("/api/gain/filter/{hash}", get(gain::get_filter_gain))
+        .route("/terms", get(tos::get_terms))
+        .route("/api/tos", get(tos::get_tos_info))
+        .route("/api/tos/accept", post(tos::accept_tos))
+        .route("/api/account", delete(account::delete_account))
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             general_rate_limit,

--- a/crates/tokf-server/src/routes/test_helpers.rs
+++ b/crates/tokf-server/src/routes/test_helpers.rs
@@ -75,6 +75,19 @@ pub fn make_state(pool: PgPool) -> AppState {
     }
 }
 
+/// Insert a service token into the DB and return the raw token string.
+pub async fn insert_service_token(pool: &PgPool, description: &str) -> String {
+    let token = generate_token();
+    let token_hash = hash_token(&token);
+    sqlx::query("INSERT INTO service_tokens (token_hash, description) VALUES ($1, $2)")
+        .bind(&token_hash)
+        .bind(description)
+        .execute(pool)
+        .await
+        .unwrap();
+    token
+}
+
 /// Inserts a test user and a non-expired auth token; returns `(user_id, token)`.
 pub async fn create_user_and_token(pool: &PgPool) -> (i64, String) {
     let user_id: i64 = sqlx::query_scalar(

--- a/crates/tokf-server/src/routes/tos.rs
+++ b/crates/tokf-server/src/routes/tos.rs
@@ -1,0 +1,202 @@
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+
+use crate::auth::token::AuthUser;
+use crate::error::AppError;
+use crate::state::AppState;
+use crate::tos::{CURRENT_TOS_VERSION, TOS_CONTENT_MD};
+
+// ── GET /terms ────────────────────────────────────────────────────────────────
+
+/// Serves the full Terms of Service as Markdown text.
+pub async fn get_terms() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        [("content-type", "text/markdown; charset=utf-8")],
+        TOS_CONTENT_MD,
+    )
+}
+
+// ── GET /api/tos ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct TosInfoResponse {
+    pub version: i32,
+    pub url: String,
+}
+
+/// Returns the current `ToS` version and a link to the full text.
+pub async fn get_tos_info(State(state): State<AppState>) -> Json<TosInfoResponse> {
+    Json(TosInfoResponse {
+        version: CURRENT_TOS_VERSION,
+        url: format!("{}/terms", state.public_url),
+    })
+}
+
+// ── POST /api/tos/accept ─────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct AcceptTosRequest {
+    pub version: i32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AcceptTosResponse {
+    pub accepted_version: i32,
+    pub accepted_at: String,
+}
+
+/// Records the authenticated user's acceptance of a specific `ToS` version.
+///
+/// # Errors
+///
+/// Returns `BadRequest` if the version doesn't match the current version,
+/// or `Unauthorized` if not authenticated.
+pub async fn accept_tos(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Json(req): Json<AcceptTosRequest>,
+) -> Result<Json<AcceptTosResponse>, AppError> {
+    if req.version != CURRENT_TOS_VERSION {
+        return Err(AppError::BadRequest(format!(
+            "expected ToS version {CURRENT_TOS_VERSION}, got {}",
+            req.version
+        )));
+    }
+
+    let accepted_at: chrono::DateTime<chrono::Utc> = sqlx::query_scalar(
+        "INSERT INTO tos_acceptances (user_id, tos_version) VALUES ($1, $2) RETURNING accepted_at",
+    )
+    .bind(user.user_id)
+    .bind(req.version)
+    .fetch_one(&state.db)
+    .await?;
+
+    Ok(Json(AcceptTosResponse {
+        accepted_version: req.version,
+        accepted_at: accepted_at.to_rfc3339(),
+    }))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::{get, post};
+    use sqlx::PgPool;
+    use tower::ServiceExt;
+
+    use crate::routes::test_helpers::*;
+    use crate::tos::CURRENT_TOS_VERSION;
+
+    use super::*;
+
+    fn app(pool: PgPool) -> Router {
+        Router::new()
+            .route("/terms", get(get_terms))
+            .route("/api/tos", get(get_tos_info))
+            .route("/api/tos/accept", post(accept_tos))
+            .with_state(make_state(pool))
+    }
+
+    #[crdb_test_macro::crdb_test(migrations = "./migrations")]
+    async fn get_terms_returns_markdown(pool: PgPool) {
+        let resp = app(pool)
+            .oneshot(Request::get("/terms").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(ct.contains("text/markdown"));
+        let body = assert_status(resp, StatusCode::OK).await;
+        let text = String::from_utf8_lossy(&body);
+        assert!(text.contains("Terms of Service"));
+    }
+
+    #[crdb_test_macro::crdb_test(migrations = "./migrations")]
+    async fn get_tos_info_returns_version(pool: PgPool) {
+        let resp = app(pool)
+            .oneshot(Request::get("/api/tos").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = assert_status(resp, StatusCode::OK).await;
+        let info: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(info["version"], CURRENT_TOS_VERSION);
+        assert!(info["url"].as_str().unwrap().contains("/terms"));
+    }
+
+    #[crdb_test_macro::crdb_test(migrations = "./migrations")]
+    async fn accept_tos_requires_auth(pool: PgPool) {
+        let resp = app(pool)
+            .oneshot(
+                Request::post("/api/tos/accept")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "version": CURRENT_TOS_VERSION }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_status(resp, StatusCode::UNAUTHORIZED).await;
+    }
+
+    #[crdb_test_macro::crdb_test(migrations = "./migrations")]
+    async fn accept_tos_records_acceptance(pool: PgPool) {
+        let (user_id, token) = create_user_and_token(&pool).await;
+        let resp = app(pool.clone())
+            .oneshot(
+                Request::post("/api/tos/accept")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::from(
+                        serde_json::json!({ "version": CURRENT_TOS_VERSION }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = assert_status(resp, StatusCode::OK).await;
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["accepted_version"], CURRENT_TOS_VERSION);
+
+        // Verify DB record
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM tos_acceptances WHERE user_id = $1 AND tos_version = $2",
+        )
+        .bind(user_id)
+        .bind(CURRENT_TOS_VERSION)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[crdb_test_macro::crdb_test(migrations = "./migrations")]
+    async fn accept_tos_rejects_wrong_version(pool: PgPool) {
+        let (_, token) = create_user_and_token(&pool).await;
+        let resp = app(pool)
+            .oneshot(
+                Request::post("/api/tos/accept")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::from(
+                        serde_json::json!({ "version": 999 }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_status(resp, StatusCode::BAD_REQUEST).await;
+    }
+}

--- a/crates/tokf-server/src/tos.rs
+++ b/crates/tokf-server/src/tos.rs
@@ -1,0 +1,6 @@
+/// Current Terms of Service version. Bump this when the terms change;
+/// users will be prompted to re-accept on their next `tokf auth login`.
+pub const CURRENT_TOS_VERSION: i32 = 1;
+
+/// The full Terms of Service text (Markdown), embedded at compile time.
+pub const TOS_CONTENT_MD: &str = include_str!("tos/content.md");

--- a/crates/tokf-server/src/tos/content.md
+++ b/crates/tokf-server/src/tos/content.md
@@ -1,0 +1,78 @@
+# tokf Terms of Service
+
+**Version 1** — Effective 2026-03-02
+
+## What tokf is
+
+tokf is a free, open-source command-output filter for LLM coding assistants.
+The optional server component (`api.tokf.net`) provides account management,
+filter sharing, and aggregate usage statistics. tokf is a community project
+with no profit motive.
+
+## What data we collect
+
+When you create an account and use tokf with the remote server, we store:
+
+- **GitHub profile**: your username, avatar URL, profile URL, and organization
+  memberships (public information from the GitHub API).
+- **Machine identifiers**: a locally-generated UUID and hostname for each
+  machine you register, used to deduplicate sync events.
+- **Aggregate usage statistics**: per-filter token counts (input tokens,
+  output tokens, command count). We do **not** store your command content,
+  arguments, or output.
+- **Published filters**: filter TOML files and test suites you choose to share
+  with the community.
+- **Terms of Service records**: which ToS version you accepted and when.
+
+We do **not** collect or store:
+- Command content or arguments
+- Command output (raw or filtered)
+- File contents or directory structures
+- Environment variables or secrets
+
+## What we use it for
+
+- **Attribution**: linking published filters to their author.
+- **Aggregate statistics**: computing community-wide token savings displayed
+  on the website and in `tokf gain --remote`.
+- **Sync deduplication**: ensuring usage events are not double-counted across
+  machines.
+
+We do not sell, share, or monetize your data. There is no advertising.
+
+## No guarantees
+
+tokf is provided **"as is"**, without warranty of any kind, express or implied.
+The service is maintained by volunteers and may experience downtime, data loss,
+or discontinuation without notice. We make no guarantees about availability,
+accuracy, or fitness for any particular purpose.
+
+## Account deletion
+
+You can delete your account at any time by running:
+
+```
+tokf auth delete-account
+```
+
+Deletion takes effect **immediately**. When you delete your account:
+
+- Your auth tokens, machine registrations, usage events, sync cursors,
+  and ToS acceptance records are permanently removed.
+- Your user profile is anonymized: personal details are cleared and the
+  account is marked as deleted.
+- Filters you published remain available to the community. Your account
+  is converted to an anonymized, unclaimed state (similar to stdlib filter
+  authors). Your GitHub username is no longer displayed.
+
+## Changes to these terms
+
+When we update these terms, the version number increases. You will be prompted
+to review and accept the new version the next time you run `tokf auth login`.
+Continued use of the remote server requires acceptance of the current terms.
+
+## Contact
+
+tokf is open source: <https://github.com/mpecan/tokf>
+
+For questions or concerns about these terms, open an issue on the repository.

--- a/crates/tokf-server/tests/db_integration.rs
+++ b/crates/tokf-server/tests/db_integration.rs
@@ -33,13 +33,11 @@ use sqlx::PgPool;
 use tokf_server::{
     auth::{
         github::{AccessTokenResponse, DeviceCodeResponse, GitHubClient, GitHubOrg, GitHubUser},
-        mock::{NoOpGitHubClient, SuccessGitHubClient},
+        mock::SuccessGitHubClient,
         token::{AuthUser, generate_token, hash_token},
     },
-    rate_limit::{IpRateLimiter, PublishRateLimiter, SyncRateLimiter},
-    routes::create_router,
+    routes::{create_router, test_helpers::make_state},
     state::AppState,
-    storage::noop::NoOpStorageClient,
 };
 use tower::ServiceExt;
 
@@ -58,19 +56,8 @@ async fn protected_ok(_user: AuthUser) -> Json<serde_json::Value> {
 
 fn db_state(pool: PgPool) -> AppState {
     AppState {
-        db: pool,
-        github: Arc::new(NoOpGitHubClient),
-        storage: Arc::new(NoOpStorageClient),
-        github_client_id: "test-client-id".to_string(),
-        github_client_secret: "test-client-secret".to_string(),
         trust_proxy: true,
-        public_url: "http://localhost:8080".to_string(),
-        publish_rate_limiter: Arc::new(PublishRateLimiter::new(100, 3600)),
-        search_rate_limiter: Arc::new(PublishRateLimiter::new(1000, 3600)),
-        sync_rate_limiter: Arc::new(SyncRateLimiter::new(100, 3600)),
-        ip_search_rate_limiter: Arc::new(IpRateLimiter::new(10000, 60)),
-        ip_download_rate_limiter: Arc::new(IpRateLimiter::new(10000, 60)),
-        general_rate_limiter: Arc::new(PublishRateLimiter::new(10000, 60)),
+        ..make_state(pool)
     }
 }
 


### PR DESCRIPTION
## Summary

- Add versioned Terms of Service: server endpoints (`GET /terms`, `GET /api/tos`, `POST /api/tos/accept`), CLI prompt during login, and re-acceptance on version bumps
- Add self-service account deletion (`DELETE /api/account` + `tokf auth delete-account`) that anonymizes the user profile while preserving filter attribution
- Record ToS acceptance atomically during device flow login; auth token response now includes `tos_current_version` and `tos_accepted_version`

## Changes

**Server:**
- Migration: `tos_acceptances` table, `deleted_at` column on `users`
- Three ToS routes + account deletion route with soft-delete (anonymize user, cascade tokens/machines/flows)
- Auth token response extended with ToS version fields (backward compatible via `#[serde(default)]`)

**CLI:**
- ToS prompt before login, re-acceptance check for existing sessions
- `tokf auth delete-account` with username confirmation
- `tos_accepted_version` persisted in credentials file
- New remote clients: `tos_client`, `account_client`; HTTP `delete()` method

## Test plan

- [x] `cargo test --workspace` — 1431 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `just test-db` — DB integration tests (9 new crdb_test cases for ToS + account routes)
- [ ] Manual: `tokf auth login` shows ToS prompt
- [ ] Manual: `tokf auth delete-account` prompts, deletes, cleans up

🤖 Generated with [Claude Code](https://claude.com/claude-code)