### PR TITLE
feat(ci): publish @tokf/catalog-types npm package on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,25 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+  publish-npm:
+    name: Publish @tokf/catalog-types to npm
+    needs: [publish]
+    if: startsWith(inputs.tag || github.event.release.tag_name, 'tokf-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+      - name: Publish catalog types
+        working-directory: crates/tokf-server/generated
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   build-binaries:
     name: Build ${{ matrix.target }}
     if: startsWith(inputs.tag || github.event.release.tag_name, 'tokf-v')

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -20,7 +20,11 @@
     "crates/tokf-common": {},
     "crates/tokf-filter": {},
     "crates/tokf-cli": { "component": "tokf" },
-    "crates/tokf-server": {}
+    "crates/tokf-server": {},
+    "crates/tokf-server/generated": {
+      "release-type": "node",
+      "component": "catalog-types"
+    }
   },
   "plugins": [
     {
@@ -30,7 +34,7 @@
     {
       "type": "linked-versions",
       "groupName": "workspace",
-      "components": ["tokf-common", "tokf-filter", "tokf", "tokf-server"]
+      "components": ["tokf-common", "tokf-filter", "tokf", "tokf-server", "catalog-types"]
     }
   ]
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,5 +3,6 @@
   "crates/tokf-filter": "0.2.16",
   "crates/tokf-cli": "0.2.16",
   "crates/tokf-server": "0.2.16",
+  "crates/tokf-server/generated": "0.2.16",
   "crates/e2e-tests": "0.1.4"
 }

--- a/crates/tokf-server/generated/package.json
+++ b/crates/tokf-server/generated/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@tokf/catalog-types",
+  "version": "0.2.16",
+  "description": "TypeScript types for the tokf filter catalog (auto-generated from Rust via ts-rs)",
+  "type": "module",
+  "exports": {
+    ".": "./catalog.ts"
+  },
+  "types": "./catalog.ts",
+  "files": ["*.ts"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mpecan/tokf",
+    "directory": "crates/tokf-server/generated"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `package.json` to `crates/tokf-server/generated/` so the ts-rs generated TypeScript types ship as `@tokf/catalog-types` on npm
- Adds a `publish-npm` job to the release workflow that publishes to npm after crates.io
- Registers the package with release-please so its version stays in sync with the workspace

The package ships raw `.ts` files — modern bundlers and Astro handle these natively without a build step. This enables `tokf-net` to consume catalog types as a proper dependency instead of copying files.

## Prerequisites (one-time manual setup)

- [x] Create `@tokf` npm organization at npmjs.com
- [x] Generate npm access token and add as `NPM_TOKEN` secret to this repo

## Test plan

- [x] `npm pack --dry-run` in `crates/tokf-server/generated/` — confirms all 6 `.ts` files are included
- [ ] After merging + next release: verify `@tokf/catalog-types` appears on npmjs.com
- [ ] `npm install @tokf/catalog-types` in tokf-net — verify types resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)