### PR TITLE
fix(server,cli): use i64 for ToS version fields (CockroachDB INT8)

### DIFF
--- a/crates/tokf-cli/src/auth/client.rs
+++ b/crates/tokf-cli/src/auth/client.rs
@@ -34,10 +34,10 @@ pub struct TokenResponse {
     pub user: TokenUser,
     /// Current `ToS` version the server requires (absent from old servers).
     #[serde(default)]
-    pub tos_current_version: Option<i32>,
+    pub tos_current_version: Option<i64>,
     /// Highest `ToS` version this user has accepted (absent from old servers).
     #[serde(default)]
-    pub tos_accepted_version: Option<i32>,
+    pub tos_accepted_version: Option<i64>,
 }
 
 // Manual Debug impl to redact the access_token secret
@@ -138,7 +138,7 @@ pub fn poll_token(
     client: &reqwest::blocking::Client,
     base_url: &str,
     device_code: &str,
-    tos_version: Option<i32>,
+    tos_version: Option<i64>,
 ) -> anyhow::Result<PollResult> {
     let url = format!("{base_url}/api/auth/token");
     let mut body = serde_json::json!({ "device_code": device_code });

--- a/crates/tokf-cli/src/auth/credentials.rs
+++ b/crates/tokf-cli/src/auth/credentials.rs
@@ -21,7 +21,7 @@ pub struct StoredAuth {
     pub mit_license_accepted: Option<bool>,
     /// Highest Terms of Service version the user has accepted.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tos_accepted_version: Option<i32>,
+    pub tos_accepted_version: Option<i64>,
 }
 
 /// Loaded credentials: token (from keyring) + metadata (from TOML).
@@ -34,7 +34,7 @@ pub struct LoadedAuth {
     /// Whether the user has accepted the MIT license for filter publishing.
     pub mit_license_accepted: Option<bool>,
     /// Highest Terms of Service version the user has accepted.
-    pub tos_accepted_version: Option<i32>,
+    pub tos_accepted_version: Option<i64>,
 }
 
 impl LoadedAuth {
@@ -146,7 +146,7 @@ pub(crate) fn save_license_accepted_to_path(
 ///
 /// Returns an error if the config directory cannot be determined or the file
 /// cannot be written.
-pub fn save_tos_accepted_version(version: i32) -> anyhow::Result<()> {
+pub fn save_tos_accepted_version(version: i64) -> anyhow::Result<()> {
     let path =
         auth_config_path().ok_or_else(|| anyhow::anyhow!("cannot determine config directory"))?;
     save_tos_accepted_version_to_path(&path, version)
@@ -158,7 +158,7 @@ pub fn save_tos_accepted_version(version: i32) -> anyhow::Result<()> {
 /// without depending on the platform config directory.
 pub(crate) fn save_tos_accepted_version_to_path(
     path: &std::path::Path,
-    version: i32,
+    version: i64,
 ) -> anyhow::Result<()> {
     update_stored_auth(path, |meta| meta.tos_accepted_version = Some(version))
 }

--- a/crates/tokf-cli/src/auth_cmd.rs
+++ b/crates/tokf-cli/src/auth_cmd.rs
@@ -119,7 +119,7 @@ fn handle_existing_login(auth: &credentials::LoadedAuth, base_url: &str) -> anyh
 /// Fetch `ToS` info and prompt the user to accept before proceeding with login.
 ///
 /// Returns the accepted version, or an error if declined.
-fn prompt_tos_acceptance(base_url: &str) -> anyhow::Result<Option<i32>> {
+fn prompt_tos_acceptance(base_url: &str) -> anyhow::Result<Option<i64>> {
     let Ok(client) = Client::unauthenticated(base_url) else {
         return Ok(None); // Can't reach server — proceed without ToS
     };
@@ -146,7 +146,7 @@ fn print_tos_summary(terms_url: &str) {
     eprintln!("[tokf] Full terms: {terms_url}");
 }
 
-fn confirm_tos(version: i32) -> anyhow::Result<bool> {
+fn confirm_tos(version: i64) -> anyhow::Result<bool> {
     eprint!("[tokf] Accept Terms of Service (v{version})? [y/N]: ");
     std::io::stderr().flush()?;
 
@@ -159,7 +159,7 @@ fn poll_for_token(
     http_client: &reqwest::blocking::Client,
     base_url: &str,
     device_resp: &client::DeviceFlowResponse,
-    tos_version: Option<i32>,
+    tos_version: Option<i64>,
 ) -> anyhow::Result<i32> {
     let mut interval = device_resp.interval.clamp(1, 60);
     let expires_in = device_resp.expires_in.clamp(0, 1800);

--- a/crates/tokf-cli/src/remote/tos_client.rs
+++ b/crates/tokf-cli/src/remote/tos_client.rs
@@ -4,18 +4,18 @@ use super::http::Client;
 
 #[derive(Debug, Deserialize)]
 pub struct TosInfoResponse {
-    pub version: i32,
+    pub version: i64,
     pub url: String,
 }
 
 #[derive(Debug, Serialize)]
 struct AcceptTosRequest {
-    version: i32,
+    version: i64,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct AcceptTosResponse {
-    pub accepted_version: i32,
+    pub accepted_version: i64,
     pub accepted_at: String,
 }
 
@@ -37,7 +37,7 @@ pub fn fetch_tos_info(client: &Client) -> anyhow::Result<TosInfoResponse> {
 /// # Errors
 ///
 /// Returns an error on network failure, non-2xx status, or version mismatch.
-pub fn accept_tos(client: &Client, version: i32) -> anyhow::Result<AcceptTosResponse> {
+pub fn accept_tos(client: &Client, version: i64) -> anyhow::Result<AcceptTosResponse> {
     client.post("/api/tos/accept", &AcceptTosRequest { version })
 }
 

--- a/crates/tokf-server/src/routes/auth.rs
+++ b/crates/tokf-server/src/routes/auth.rs
@@ -26,7 +26,7 @@ pub struct PollTokenRequest {
     pub device_code: String,
     /// `ToS` version the client accepted during login (absent for older clients).
     #[serde(default)]
-    pub tos_version: Option<i32>,
+    pub tos_version: Option<i64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -36,10 +36,10 @@ pub struct TokenResponse {
     pub expires_in: i64,
     pub user: TokenUser,
     /// Current `ToS` version the server requires.
-    pub tos_current_version: i32,
+    pub tos_current_version: i64,
     /// Highest `ToS` version this user has accepted (None if never accepted).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tos_accepted_version: Option<i32>,
+    pub tos_accepted_version: Option<i64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -233,7 +233,7 @@ async fn handle_github_success(
     state: &AppState,
     flow_id: i64,
     access_token: &str,
-    tos_version: Option<i32>,
+    tos_version: Option<i64>,
 ) -> Result<axum::response::Response, AppError> {
     let (user, orgs) = fetch_github_profile(&*state.github, access_token).await?;
     let user_id = upsert_github_user(state, &user, &orgs).await?;
@@ -375,8 +375,8 @@ async fn fetch_github_profile(
 }
 
 /// Query the highest `ToS` version the user has accepted, or `None`.
-async fn get_accepted_tos_version(state: &AppState, user_id: i64) -> Result<Option<i32>, AppError> {
-    let version: Option<i32> =
+async fn get_accepted_tos_version(state: &AppState, user_id: i64) -> Result<Option<i64>, AppError> {
+    let version: Option<i64> =
         sqlx::query_scalar("SELECT MAX(tos_version) FROM tos_acceptances WHERE user_id = $1")
             .bind(user_id)
             .fetch_one(&state.db)
@@ -388,7 +388,7 @@ async fn get_accepted_tos_version(state: &AppState, user_id: i64) -> Result<Opti
 async fn record_tos_acceptance(
     state: &AppState,
     user_id: i64,
-    version: i32,
+    version: i64,
 ) -> Result<(), AppError> {
     sqlx::query("INSERT INTO tos_acceptances (user_id, tos_version) VALUES ($1, $2)")
         .bind(user_id)

--- a/crates/tokf-server/src/routes/tos.rs
+++ b/crates/tokf-server/src/routes/tos.rs
@@ -24,7 +24,7 @@ pub async fn get_terms() -> impl IntoResponse {
 
 #[derive(Debug, Serialize)]
 pub struct TosInfoResponse {
-    pub version: i32,
+    pub version: i64,
     pub url: String,
 }
 
@@ -40,12 +40,12 @@ pub async fn get_tos_info(State(state): State<AppState>) -> Json<TosInfoResponse
 
 #[derive(Debug, Deserialize)]
 pub struct AcceptTosRequest {
-    pub version: i32,
+    pub version: i64,
 }
 
 #[derive(Debug, Serialize)]
 pub struct AcceptTosResponse {
-    pub accepted_version: i32,
+    pub accepted_version: i64,
     pub accepted_at: String,
 }
 

--- a/crates/tokf-server/src/tos.rs
+++ b/crates/tokf-server/src/tos.rs
@@ -1,6 +1,6 @@
 /// Current Terms of Service version. Bump this when the terms change;
 /// users will be prompted to re-accept on their next `tokf auth login`.
-pub const CURRENT_TOS_VERSION: i32 = 1;
+pub const CURRENT_TOS_VERSION: i64 = 1;
 
 /// The full Terms of Service text (Markdown), embedded at compile time.
 pub const TOS_CONTENT_MD: &str = include_str!("tos/content.md");


### PR DESCRIPTION
## Summary

- Change all ToS version types from `i32` to `i64` across server and CLI
- CockroachDB maps `INT` to `INT8` (i64), causing a type mismatch error when querying `tos_acceptances.tos_version`

## Test plan

- [x] `cargo test --workspace` — 1435 tests pass
- [x] `just test-db` — 115 DB integration tests pass
- [x] `just test-e2e` — 33 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)