### PR TITLE
refactor(cli,server): consolidate publish and stdlib-publish paths

### DIFF
--- a/crates/tokf-cli/src/lib.rs
+++ b/crates/tokf-cli/src/lib.rs
@@ -5,6 +5,7 @@ pub mod fs;
 pub mod history;
 pub mod hook;
 pub mod paths;
+pub mod publish_shared;
 pub mod remote;
 pub mod rewrite;
 pub mod runner;

--- a/crates/tokf-cli/src/publish_cmd.rs
+++ b/crates/tokf-cli/src/publish_cmd.rs
@@ -1,8 +1,8 @@
 use std::io::BufRead as _;
-use std::path::Path;
 
 use tokf::auth::credentials;
 use tokf::config;
+use tokf::publish_shared::{collect_test_files_resolved, hash_filter, inline_lua_script};
 use tokf::remote::http::Client;
 use tokf::remote::publish_client;
 
@@ -43,76 +43,6 @@ fn resolve_local_filter(filter_name: &str) -> anyhow::Result<config::ResolvedFil
     Ok(resolved_filter)
 }
 
-/// Parse filter bytes and return `(content_hash, command_pattern)`.
-fn hash_filter(filter_bytes: &[u8]) -> anyhow::Result<(String, String)> {
-    let toml_str = std::str::from_utf8(filter_bytes)
-        .map_err(|_| anyhow::anyhow!("filter TOML is not valid UTF-8"))?;
-    let cfg: tokf_common::config::types::FilterConfig =
-        toml::from_str(toml_str).map_err(|e| anyhow::anyhow!("invalid filter TOML: {e}"))?;
-    let hash =
-        tokf_common::hash::canonical_hash(&cfg).map_err(|e| anyhow::anyhow!("hash error: {e}"))?;
-    Ok((hash, cfg.command.first().to_string()))
-}
-
-/// If `lua_script.file` is set, read the external file and embed its content
-/// as `lua_script.source` so the filter TOML is self-contained for publishing.
-///
-/// Returns the (possibly modified) filter bytes. When no `lua_script.file` is
-/// present, the original bytes are returned unchanged.
-///
-/// The script path is canonicalized and must reside within (or under) the
-/// filter file's parent directory to prevent path-traversal attacks.
-fn inline_lua_script(filter_bytes: Vec<u8>, filter_path: &Path) -> anyhow::Result<Vec<u8>> {
-    let toml_str = std::str::from_utf8(&filter_bytes)
-        .map_err(|_| anyhow::anyhow!("filter TOML is not valid UTF-8"))?;
-    let mut cfg: tokf_common::config::types::FilterConfig =
-        toml::from_str(toml_str).map_err(|e| anyhow::anyhow!("invalid filter TOML: {e}"))?;
-
-    let script_file = match cfg.lua_script.as_ref().and_then(|s| s.file.as_ref()) {
-        Some(f) => f.clone(),
-        None => return Ok(filter_bytes),
-    };
-
-    let base_dir = filter_path
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
-        .canonicalize()
-        .map_err(|e| anyhow::anyhow!("cannot resolve filter directory: {e}"))?;
-    let script_path = base_dir.join(&script_file);
-    let canonical_script = script_path.canonicalize().map_err(|e| {
-        anyhow::anyhow!(
-            "cannot resolve lua_script.file '{}': {e}",
-            script_path.display()
-        )
-    })?;
-
-    if !canonical_script.starts_with(&base_dir) {
-        anyhow::bail!(
-            "lua_script.file '{}' escapes the filter directory — \
-             the script must reside within '{}'",
-            script_file,
-            base_dir.display()
-        );
-    }
-
-    let source = std::fs::read_to_string(&canonical_script).map_err(|e| {
-        anyhow::anyhow!(
-            "cannot read lua_script.file '{}': {e}",
-            canonical_script.display()
-        )
-    })?;
-
-    if let Some(script_cfg) = cfg.lua_script.as_mut() {
-        script_cfg.source = Some(source);
-        script_cfg.file = None;
-    }
-
-    eprintln!("[tokf] inlined lua_script.file '{script_file}' into filter source");
-    let serialized =
-        toml::to_string_pretty(&cfg).map_err(|e| anyhow::anyhow!("TOML serialize error: {e}"))?;
-    Ok(serialized.into_bytes())
-}
-
 // ── Publish flow ────────────────────────────────────────────────────────────
 
 fn publish(filter_name: &str, dry_run: bool) -> anyhow::Result<i32> {
@@ -122,7 +52,7 @@ fn publish(filter_name: &str, dry_run: bool) -> anyhow::Result<i32> {
     let filter_bytes = std::fs::read(&resolved_filter.source_path)?;
     let filter_bytes = inline_lua_script(filter_bytes, &resolved_filter.source_path)?;
     let (content_hash, command_pattern) = hash_filter(&filter_bytes)?;
-    let test_files = collect_test_files(&resolved_filter)?;
+    let test_files = collect_test_files_resolved(&resolved_filter.source_path)?;
 
     eprintln!("[tokf] publishing filter: {filter_name}");
     eprintln!("  Command: {command_pattern}");
@@ -160,7 +90,7 @@ fn publish_update_tests(filter_name: &str, dry_run: bool) -> anyhow::Result<i32>
 
     let filter_bytes = std::fs::read(&resolved_filter.source_path)?;
     let (content_hash, _) = hash_filter(&filter_bytes)?;
-    let test_files = collect_test_files(&resolved_filter)?;
+    let test_files = collect_test_files_resolved(&resolved_filter.source_path)?;
 
     if test_files.is_empty() {
         anyhow::bail!("no test files found for {filter_name}");
@@ -195,39 +125,6 @@ fn publish_update_tests(filter_name: &str, dry_run: bool) -> anyhow::Result<i32>
     );
     eprintln!("URL: {}", resp.registry_url);
     Ok(0)
-}
-
-fn collect_test_files(
-    resolved_filter: &config::ResolvedFilter,
-) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
-    let stem = resolved_filter
-        .relative_path
-        .file_stem()
-        .unwrap_or_default()
-        .to_string_lossy();
-    let test_dir_name = format!("{stem}_test");
-    let source_test_dir = resolved_filter
-        .source_path
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
-        .join(&test_dir_name);
-
-    if !source_test_dir.is_dir() {
-        return Ok(Vec::new());
-    }
-
-    let mut files = Vec::new();
-    for entry in std::fs::read_dir(&source_test_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_file() {
-            let filename = entry.file_name().to_string_lossy().to_string();
-            let bytes = std::fs::read(&path)?;
-            files.push((filename, bytes));
-        }
-    }
-    files.sort_by(|a, b| a.0.cmp(&b.0));
-    Ok(files)
 }
 
 fn ensure_license_accepted() -> anyhow::Result<()> {
@@ -271,205 +168,5 @@ mod tests {
             .iter()
             .find(|f| f.matches_name("nonexistent/xyz-abc-filter-99"));
         assert!(found.is_none(), "expected no match for nonexistent filter");
-    }
-
-    #[test]
-    fn collect_test_files_from_adjacent_dir() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let filter_dir = dir.path().join("myns");
-        std::fs::create_dir_all(&filter_dir).unwrap();
-
-        // Create filter
-        let filter_path = filter_dir.join("my-filter.toml");
-        std::fs::write(&filter_path, r#"command = "my-cmd""#).unwrap();
-
-        // Create adjacent _test/ dir with test files
-        let test_dir = filter_dir.join("my-filter_test");
-        std::fs::create_dir_all(&test_dir).unwrap();
-        std::fs::write(test_dir.join("basic.toml"), b"name = \"basic\"").unwrap();
-        std::fs::write(test_dir.join("edge.toml"), b"name = \"edge\"").unwrap();
-
-        // Build a minimal ResolvedFilter pointing to our temp file
-        let cfg: tokf_common::config::types::FilterConfig =
-            toml::from_str(r#"command = "my-cmd""#).unwrap();
-        let hash = tokf_common::hash::canonical_hash(&cfg).unwrap_or_default();
-        let resolved = config::ResolvedFilter {
-            config: cfg,
-            hash,
-            source_path: filter_path,
-            relative_path: std::path::PathBuf::from("myns/my-filter.toml"),
-            priority: 0,
-        };
-
-        let files = collect_test_files(&resolved).unwrap();
-        assert_eq!(files.len(), 2, "expected 2 test files");
-        let names: std::collections::HashSet<_> = files.iter().map(|(n, _)| n.as_str()).collect();
-        assert!(names.contains("basic.toml"));
-        assert!(names.contains("edge.toml"));
-    }
-
-    #[test]
-    fn inline_lua_script_embeds_file_content() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let filter_path = dir.path().join("my-filter.toml");
-        let script_path = dir.path().join("transform.luau");
-
-        std::fs::write(&script_path, "return output:upper()").unwrap();
-        std::fs::write(
-            &filter_path,
-            r#"command = "my-cmd"
-
-[lua_script]
-lang = "luau"
-file = "transform.luau"
-"#,
-        )
-        .unwrap();
-
-        let filter_bytes = std::fs::read(&filter_path).unwrap();
-        let result = inline_lua_script(filter_bytes, &filter_path).unwrap();
-
-        let cfg: tokf_common::config::types::FilterConfig =
-            toml::from_str(std::str::from_utf8(&result).unwrap()).unwrap();
-        let script = cfg.lua_script.unwrap();
-        assert!(script.file.is_none(), "file should be removed");
-        assert_eq!(script.source.unwrap(), "return output:upper()");
-    }
-
-    #[test]
-    fn inline_lua_script_rejects_path_traversal() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let subdir = dir.path().join("filters");
-        std::fs::create_dir_all(&subdir).unwrap();
-
-        // Create a file outside the filter directory
-        let secret = dir.path().join("secret.txt");
-        std::fs::write(&secret, "sensitive data").unwrap();
-
-        let filter_path = subdir.join("my-filter.toml");
-        std::fs::write(
-            &filter_path,
-            r#"command = "my-cmd"
-
-[lua_script]
-lang = "luau"
-file = "../secret.txt"
-"#,
-        )
-        .unwrap();
-
-        let filter_bytes = std::fs::read(&filter_path).unwrap();
-        let result = inline_lua_script(filter_bytes, &filter_path);
-        assert!(result.is_err(), "path traversal should be rejected");
-        let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("escapes the filter directory"),
-            "expected traversal error, got: {msg}"
-        );
-    }
-
-    #[test]
-    fn inline_lua_script_allows_subdirectory() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let scripts_dir = dir.path().join("scripts");
-        std::fs::create_dir_all(&scripts_dir).unwrap();
-
-        std::fs::write(scripts_dir.join("helper.luau"), "return 'ok'").unwrap();
-
-        let filter_path = dir.path().join("my-filter.toml");
-        std::fs::write(
-            &filter_path,
-            r#"command = "my-cmd"
-
-[lua_script]
-lang = "luau"
-file = "scripts/helper.luau"
-"#,
-        )
-        .unwrap();
-
-        let filter_bytes = std::fs::read(&filter_path).unwrap();
-        let result = inline_lua_script(filter_bytes, &filter_path).unwrap();
-
-        let cfg: tokf_common::config::types::FilterConfig =
-            toml::from_str(std::str::from_utf8(&result).unwrap()).unwrap();
-        let script = cfg.lua_script.unwrap();
-        assert!(script.file.is_none());
-        assert_eq!(script.source.unwrap(), "return 'ok'");
-    }
-
-    #[test]
-    fn inline_lua_script_empty_file_produces_empty_source() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let filter_path = dir.path().join("my-filter.toml");
-        std::fs::write(dir.path().join("empty.luau"), "").unwrap();
-        std::fs::write(
-            &filter_path,
-            r#"command = "my-cmd"
-
-[lua_script]
-lang = "luau"
-file = "empty.luau"
-"#,
-        )
-        .unwrap();
-
-        let filter_bytes = std::fs::read(&filter_path).unwrap();
-        let result = inline_lua_script(filter_bytes, &filter_path).unwrap();
-
-        let cfg: tokf_common::config::types::FilterConfig =
-            toml::from_str(std::str::from_utf8(&result).unwrap()).unwrap();
-        let script = cfg.lua_script.unwrap();
-        assert_eq!(script.source.unwrap(), "");
-    }
-
-    #[test]
-    fn inline_lua_script_hash_stable_when_no_file() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let filter_path = dir.path().join("my-filter.toml");
-        let toml_str = r#"command = "my-cmd""#;
-        std::fs::write(&filter_path, toml_str).unwrap();
-
-        let filter_bytes = toml_str.as_bytes().to_vec();
-        let (hash_before, _) = hash_filter(&filter_bytes).unwrap();
-        let result = inline_lua_script(filter_bytes, &filter_path).unwrap();
-        let (hash_after, _) = hash_filter(&result).unwrap();
-        assert_eq!(
-            hash_before, hash_after,
-            "hash should be stable when no inlining occurs"
-        );
-    }
-
-    #[test]
-    fn inline_lua_script_noop_without_file() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let filter_path = dir.path().join("my-filter.toml");
-        let toml_str = r#"command = "my-cmd""#;
-        std::fs::write(&filter_path, toml_str).unwrap();
-
-        let filter_bytes = toml_str.as_bytes().to_vec();
-        let result = inline_lua_script(filter_bytes.clone(), &filter_path).unwrap();
-        assert_eq!(result, filter_bytes, "should return unchanged bytes");
-    }
-
-    #[test]
-    fn collect_test_files_returns_empty_when_no_test_dir() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let filter_path = dir.path().join("my-filter.toml");
-        std::fs::write(&filter_path, r#"command = "my-cmd""#).unwrap();
-
-        let cfg: tokf_common::config::types::FilterConfig =
-            toml::from_str(r#"command = "my-cmd""#).unwrap();
-        let hash = tokf_common::hash::canonical_hash(&cfg).unwrap_or_default();
-        let resolved = config::ResolvedFilter {
-            config: cfg,
-            hash,
-            source_path: filter_path,
-            relative_path: std::path::PathBuf::from("my-filter.toml"),
-            priority: 0,
-        };
-
-        let files = collect_test_files(&resolved).unwrap();
-        assert!(files.is_empty());
     }
 }

--- a/crates/tokf-cli/src/publish_shared.rs
+++ b/crates/tokf-cli/src/publish_shared.rs
@@ -1,0 +1,495 @@
+use std::path::Path;
+
+/// Parse filter bytes and return `(content_hash, command_pattern)`.
+///
+/// # Errors
+///
+/// Returns an error if the bytes are not valid UTF-8, the TOML is invalid, or
+/// the canonical hash cannot be computed.
+pub fn hash_filter(filter_bytes: &[u8]) -> anyhow::Result<(String, String)> {
+    let toml_str = std::str::from_utf8(filter_bytes)
+        .map_err(|_| anyhow::anyhow!("filter TOML is not valid UTF-8"))?;
+    let cfg: tokf_common::config::types::FilterConfig =
+        toml::from_str(toml_str).map_err(|e| anyhow::anyhow!("invalid filter TOML: {e}"))?;
+    let hash =
+        tokf_common::hash::canonical_hash(&cfg).map_err(|e| anyhow::anyhow!("hash error: {e}"))?;
+    Ok((hash, cfg.command.first().to_string()))
+}
+
+/// If `lua_script.file` is set, read the external file and embed its content
+/// as `lua_script.source` so the filter TOML is self-contained for publishing.
+///
+/// Returns the (possibly modified) filter bytes. When no `lua_script.file` is
+/// present, the original bytes are returned unchanged.
+///
+/// The script path is canonicalized and must reside within (or under) the
+/// filter file's parent directory to prevent path-traversal attacks.
+///
+/// # Errors
+///
+/// Returns an error if the TOML is invalid, the script file cannot be read,
+/// or the script path escapes the filter directory.
+pub fn inline_lua_script(filter_bytes: Vec<u8>, filter_path: &Path) -> anyhow::Result<Vec<u8>> {
+    let toml_str = std::str::from_utf8(&filter_bytes)
+        .map_err(|_| anyhow::anyhow!("filter TOML is not valid UTF-8"))?;
+    let mut cfg: tokf_common::config::types::FilterConfig =
+        toml::from_str(toml_str).map_err(|e| anyhow::anyhow!("invalid filter TOML: {e}"))?;
+
+    let script_file = match cfg.lua_script.as_ref().and_then(|s| s.file.as_ref()) {
+        Some(f) => f.clone(),
+        None => return Ok(filter_bytes),
+    };
+
+    let base_dir = filter_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .canonicalize()
+        .map_err(|e| anyhow::anyhow!("cannot resolve filter directory: {e}"))?;
+    let script_path = base_dir.join(&script_file);
+    let canonical_script = script_path.canonicalize().map_err(|e| {
+        anyhow::anyhow!(
+            "cannot resolve lua_script.file '{}': {e}",
+            script_path.display()
+        )
+    })?;
+
+    if !canonical_script.starts_with(&base_dir) {
+        anyhow::bail!(
+            "lua_script.file '{}' escapes the filter directory — \
+             the script must reside within '{}'",
+            script_file,
+            base_dir.display()
+        );
+    }
+
+    let source = std::fs::read_to_string(&canonical_script).map_err(|e| {
+        anyhow::anyhow!(
+            "cannot read lua_script.file '{}': {e}",
+            canonical_script.display()
+        )
+    })?;
+
+    if let Some(script_cfg) = cfg.lua_script.as_mut() {
+        script_cfg.source = Some(source);
+        script_cfg.file = None;
+    }
+
+    eprintln!("[tokf] inlined lua_script.file '{script_file}' into filter source");
+    let serialized =
+        toml::to_string_pretty(&cfg).map_err(|e| anyhow::anyhow!("TOML serialize error: {e}"))?;
+    Ok(serialized.into_bytes())
+}
+
+/// Replace `fixture = "file.txt"` with `inline = "<file contents>"` in a test
+/// TOML string. Fixture files are resolved relative to `test_dir`.
+///
+/// # Errors
+///
+/// Returns an error if the test TOML is invalid or a referenced fixture file
+/// cannot be read.
+pub fn resolve_fixtures_in_test(content: &str, test_dir: &Path) -> anyhow::Result<String> {
+    let case: tokf_common::test_case::TestCase =
+        toml::from_str(content).map_err(|e| anyhow::anyhow!("invalid test TOML: {e}"))?;
+
+    let Some(fixture_name) = case.fixture else {
+        return Ok(content.to_string());
+    };
+
+    if case.inline.is_some() {
+        return Ok(content.to_string());
+    }
+
+    let fixture_path = test_dir.join(&fixture_name);
+    let fixture_content = std::fs::read_to_string(&fixture_path)
+        .map_err(|e| anyhow::anyhow!("cannot read fixture '{fixture_name}': {e}"))?;
+    let fixture_content = fixture_content.trim_end();
+
+    let mut result = String::new();
+    let mut skipped_fixture = false;
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("fixture") && trimmed.contains('=') {
+            skipped_fixture = true;
+            continue;
+        }
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    if !skipped_fixture {
+        anyhow::bail!("expected fixture line but did not find it");
+    }
+
+    let insert_pos = result.find("[[expect]]").unwrap_or(result.len());
+    let inline_value = format!("inline = '''\n{fixture_content}\n'''\n");
+    result.insert_str(insert_pos, &inline_value);
+
+    Ok(result)
+}
+
+/// Collect `.toml` test files from the `{stem}_test/` directory adjacent to
+/// `filter_path`, resolving `fixture = "file.txt"` references to inline content.
+///
+/// Returns `(filename, bytes)` pairs sorted by filename. Non-TOML files are
+/// excluded from the result.
+///
+/// # Errors
+///
+/// Returns an error if the test directory cannot be read or fixture resolution
+/// fails for any test file.
+pub fn collect_test_files_resolved(filter_path: &Path) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
+    let stem = filter_path
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy();
+    let test_dir = filter_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!("{stem}_test"));
+
+    if !test_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut files = Vec::new();
+    for entry in std::fs::read_dir(&test_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().is_none_or(|e| e != "toml") {
+            continue;
+        }
+
+        let filename = entry.file_name().to_string_lossy().to_string();
+        let content = std::fs::read_to_string(&path)?;
+        let resolved = resolve_fixtures_in_test(&content, &test_dir)
+            .map_err(|e| anyhow::anyhow!("{}: {e}", path.display()))?;
+
+        files.push((filename, resolved.into_bytes()));
+    }
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(files)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    // ── hash_filter ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn hash_filter_returns_command_pattern() {
+        let bytes = b"command = \"git push\"\n";
+        let (hash, cmd) = hash_filter(bytes).unwrap();
+        assert!(!hash.is_empty());
+        assert_eq!(cmd, "git push");
+    }
+
+    // ── inline_lua_script ────────────────────────────────────────────────────
+
+    #[test]
+    fn inline_lua_script_embeds_file_content() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let filter_path = dir.path().join("my-filter.toml");
+        let script_path = dir.path().join("transform.luau");
+
+        std::fs::write(&script_path, "return output:upper()").unwrap();
+        std::fs::write(
+            &filter_path,
+            r#"command = "my-cmd"
+
+[lua_script]
+lang = "luau"
+file = "transform.luau"
+"#,
+        )
+        .unwrap();
+
+        let filter_bytes = std::fs::read(&filter_path).unwrap();
+        let result = inline_lua_script(filter_bytes, &filter_path).unwrap();
+
+        let cfg: tokf_common::config::types::FilterConfig =
+            toml::from_str(std::str::from_utf8(&result).unwrap()).unwrap();
+        let script = cfg.lua_script.unwrap();
+        assert!(script.file.is_none(), "file should be removed");
+        assert_eq!(script.source.unwrap(), "return output:upper()");
+    }
+
+    #[test]
+    fn inline_lua_script_rejects_path_traversal() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let subdir = dir.path().join("filters");
+        std::fs::create_dir_all(&subdir).unwrap();
+
+        let secret = dir.path().join("secret.txt");
+        std::fs::write(&secret, "sensitive data").unwrap();
+
+        let filter_path = subdir.join("my-filter.toml");
+        std::fs::write(
+            &filter_path,
+            r#"command = "my-cmd"
+
+[lua_script]
+lang = "luau"
+file = "../secret.txt"
+"#,
+        )
+        .unwrap();
+
+        let filter_bytes = std::fs::read(&filter_path).unwrap();
+        let result = inline_lua_script(filter_bytes, &filter_path);
+        assert!(result.is_err(), "path traversal should be rejected");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("escapes the filter directory"),
+            "expected traversal error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn inline_lua_script_allows_subdirectory() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let scripts_dir = dir.path().join("scripts");
+        std::fs::create_dir_all(&scripts_dir).unwrap();
+
+        std::fs::write(scripts_dir.join("helper.luau"), "return 'ok'").unwrap();
+
+        let filter_path = dir.path().join("my-filter.toml");
+        std::fs::write(
+            &filter_path,
+            r#"command = "my-cmd"
+
+[lua_script]
+lang = "luau"
+file = "scripts/helper.luau"
+"#,
+        )
+        .unwrap();
+
+        let filter_bytes = std::fs::read(&filter_path).unwrap();
+        let result = inline_lua_script(filter_bytes, &filter_path).unwrap();
+
+        let cfg: tokf_common::config::types::FilterConfig =
+            toml::from_str(std::str::from_utf8(&result).unwrap()).unwrap();
+        let script = cfg.lua_script.unwrap();
+        assert!(script.file.is_none());
+        assert_eq!(script.source.unwrap(), "return 'ok'");
+    }
+
+    #[test]
+    fn inline_lua_script_empty_file_produces_empty_source() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let filter_path = dir.path().join("my-filter.toml");
+        std::fs::write(dir.path().join("empty.luau"), "").unwrap();
+        std::fs::write(
+            &filter_path,
+            r#"command = "my-cmd"
+
+[lua_script]
+lang = "luau"
+file = "empty.luau"
+"#,
+        )
+        .unwrap();
+
+        let filter_bytes = std::fs::read(&filter_path).unwrap();
+        let result = inline_lua_script(filter_bytes, &filter_path).unwrap();
+
+        let cfg: tokf_common::config::types::FilterConfig =
+            toml::from_str(std::str::from_utf8(&result).unwrap()).unwrap();
+        let script = cfg.lua_script.unwrap();
+        assert_eq!(script.source.unwrap(), "");
+    }
+
+    #[test]
+    fn inline_lua_script_hash_stable_when_no_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let filter_path = dir.path().join("my-filter.toml");
+        let toml_str = r#"command = "my-cmd""#;
+        std::fs::write(&filter_path, toml_str).unwrap();
+
+        let filter_bytes = toml_str.as_bytes().to_vec();
+        let (hash_before, _) = hash_filter(&filter_bytes).unwrap();
+        let result = inline_lua_script(filter_bytes, &filter_path).unwrap();
+        let (hash_after, _) = hash_filter(&result).unwrap();
+        assert_eq!(
+            hash_before, hash_after,
+            "hash should be stable when no inlining occurs"
+        );
+    }
+
+    #[test]
+    fn inline_lua_script_noop_without_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let filter_path = dir.path().join("my-filter.toml");
+        let toml_str = r#"command = "my-cmd""#;
+        std::fs::write(&filter_path, toml_str).unwrap();
+
+        let filter_bytes = toml_str.as_bytes().to_vec();
+        let result = inline_lua_script(filter_bytes.clone(), &filter_path).unwrap();
+        assert_eq!(result, filter_bytes, "should return unchanged bytes");
+    }
+
+    // ── resolve_fixtures_in_test ─────────────────────────────────────────────
+
+    #[test]
+    fn resolve_fixtures_replaces_fixture_with_inline() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("output.txt"), "hello world\n").unwrap();
+
+        let toml = r#"name = "test"
+fixture = "output.txt"
+exit_code = 0
+
+[[expect]]
+contains = "hello"
+"#;
+        let resolved = resolve_fixtures_in_test(toml, dir.path()).unwrap();
+        assert!(!resolved.contains("fixture"), "fixture should be removed");
+        assert!(resolved.contains("inline"), "should contain inline");
+        assert!(
+            resolved.contains("hello world"),
+            "should contain fixture content"
+        );
+    }
+
+    #[test]
+    fn resolve_fixtures_preserves_inline() {
+        let toml = r#"name = "test"
+inline = "already inline"
+
+[[expect]]
+equals = "already inline"
+"#;
+        let resolved = resolve_fixtures_in_test(toml, Path::new("/nonexistent")).unwrap();
+        assert_eq!(resolved, toml, "should be unchanged");
+    }
+
+    #[test]
+    fn resolve_fixtures_uses_literal_strings_for_backslashes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("output.txt"), "\\--- foo\n\\--- bar\n").unwrap();
+
+        let toml = r#"name = "test"
+fixture = "output.txt"
+exit_code = 0
+
+[[expect]]
+contains = "foo"
+"#;
+        let resolved = resolve_fixtures_in_test(toml, dir.path()).unwrap();
+        assert!(
+            resolved.contains("'''"),
+            "should use literal string quotes, got:\n{resolved}"
+        );
+        assert!(
+            !resolved.contains(r#"""""#),
+            "should NOT use basic string quotes"
+        );
+        assert!(
+            resolved.contains("\\--- foo"),
+            "backslashes should be preserved literally"
+        );
+    }
+
+    #[test]
+    fn resolve_fixtures_errors_on_missing_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let toml = r#"name = "test"
+fixture = "missing.txt"
+
+[[expect]]
+contains = "x"
+"#;
+        let result = resolve_fixtures_in_test(toml, dir.path());
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("missing.txt"),
+            "error should mention the file"
+        );
+    }
+
+    // ── collect_test_files_resolved ──────────────────────────────────────────
+
+    #[test]
+    fn collect_test_files_returns_empty_when_no_test_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let filter_path = dir.path().join("my-filter.toml");
+        std::fs::write(&filter_path, r#"command = "my-cmd""#).unwrap();
+
+        let files = collect_test_files_resolved(&filter_path).unwrap();
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn collect_test_files_from_adjacent_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let filter_path = dir.path().join("my-filter.toml");
+        std::fs::write(&filter_path, r#"command = "my-cmd""#).unwrap();
+
+        let test_dir = dir.path().join("my-filter_test");
+        std::fs::create_dir_all(&test_dir).unwrap();
+        std::fs::write(
+            test_dir.join("basic.toml"),
+            "name = \"basic\"\ninline = \"\"\n\n[[expect]]\nequals = \"\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            test_dir.join("edge.toml"),
+            "name = \"edge\"\ninline = \"\"\n\n[[expect]]\nequals = \"\"\n",
+        )
+        .unwrap();
+
+        let files = collect_test_files_resolved(&filter_path).unwrap();
+        assert_eq!(files.len(), 2, "expected 2 test files");
+        let names: std::collections::HashSet<_> = files.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains("basic.toml"));
+        assert!(names.contains("edge.toml"));
+    }
+
+    #[test]
+    fn collect_test_files_resolved_inlines_fixtures() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let filter_path = dir.path().join("my-filter.toml");
+        std::fs::write(&filter_path, r#"command = "my-cmd""#).unwrap();
+
+        let test_dir = dir.path().join("my-filter_test");
+        std::fs::create_dir_all(&test_dir).unwrap();
+
+        // Create a fixture file
+        std::fs::write(test_dir.join("sample_output.txt"), "hello world\n").unwrap();
+
+        // Create a test TOML referencing the fixture
+        std::fs::write(
+            test_dir.join("with_fixture.toml"),
+            "name = \"fixture test\"\nfixture = \"sample_output.txt\"\n\n[[expect]]\ncontains = \"hello\"\n",
+        )
+        .unwrap();
+
+        // Create a non-TOML file that should be excluded
+        std::fs::write(test_dir.join("notes.txt"), "not a test").unwrap();
+
+        let files = collect_test_files_resolved(&filter_path).unwrap();
+        assert_eq!(files.len(), 1, "only .toml files should be included");
+
+        let (name, bytes) = &files[0];
+        assert_eq!(name, "with_fixture.toml");
+
+        let content = std::str::from_utf8(bytes).unwrap();
+        assert!(
+            !content.contains("fixture ="),
+            "fixture reference should be resolved"
+        );
+        assert!(
+            content.contains("inline"),
+            "should contain inline instead of fixture"
+        );
+        assert!(
+            content.contains("hello world"),
+            "should contain the fixture content"
+        );
+    }
+}

--- a/crates/tokf-cli/src/publish_stdlib_cmd.rs
+++ b/crates/tokf-cli/src/publish_stdlib_cmd.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use tokf::publish_shared::collect_test_files_resolved;
 use tokf::remote::http::Client;
 
 /// Entry point for the `tokf publish-stdlib` subcommand.
@@ -161,13 +162,21 @@ fn collect_stdlib_entries(filters_dir: &Path) -> anyhow::Result<Vec<StdlibFilter
     for path in &filter_paths {
         let filter_toml = std::fs::read_to_string(path)?;
         let author = resolve_author(path).unwrap_or_else(|| fallback_author.clone());
-        let test_files = collect_and_resolve_tests(path)?;
+
+        let raw_tests = collect_test_files_resolved(path)?;
+        let test_files = raw_tests
+            .into_iter()
+            .map(|(filename, bytes)| StdlibTestFile {
+                filename,
+                content: String::from_utf8_lossy(&bytes).to_string(),
+            })
+            .collect();
 
         eprintln!(
             "[publish-stdlib]   {} (author: {}, tests: {})",
             path.display(),
             author,
-            test_files.len()
+            count_test_files(&test_files),
         );
 
         entries.push(StdlibFilterEntry {
@@ -178,6 +187,10 @@ fn collect_stdlib_entries(filters_dir: &Path) -> anyhow::Result<Vec<StdlibFilter
     }
 
     Ok(entries)
+}
+
+fn count_test_files(files: &[StdlibTestFile]) -> usize {
+    files.len()
 }
 
 /// Recursively find all *.toml files that aren't inside _test/ directories.
@@ -195,96 +208,6 @@ fn collect_filter_files(dir: &Path, out: &mut Vec<PathBuf>) -> anyhow::Result<()
         }
     }
     Ok(())
-}
-
-/// Collect test TOML files from the adjacent `{stem}_test/` directory,
-/// resolving `fixture = "file.txt"` references to `inline` content.
-fn collect_and_resolve_tests(filter_path: &Path) -> anyhow::Result<Vec<StdlibTestFile>> {
-    let stem = filter_path
-        .file_stem()
-        .unwrap_or_default()
-        .to_string_lossy();
-    let test_dir = filter_path
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
-        .join(format!("{stem}_test"));
-
-    if !test_dir.is_dir() {
-        return Ok(Vec::new());
-    }
-
-    let mut files = Vec::new();
-    for entry in std::fs::read_dir(&test_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        let filename = entry.file_name().to_string_lossy().to_string();
-        if path.extension().is_none_or(|e| e != "toml") {
-            continue;
-        }
-
-        let content = std::fs::read_to_string(&path)?;
-        let resolved = resolve_fixtures_in_test(&content, &test_dir)
-            .map_err(|e| anyhow::anyhow!("{}: {e}", path.display()))?;
-
-        files.push(StdlibTestFile {
-            filename,
-            content: resolved,
-        });
-    }
-    files.sort_by(|a, b| a.filename.cmp(&b.filename));
-    Ok(files)
-}
-
-/// Replace `fixture = "file.txt"` with `inline = "<file contents>"` in a test
-/// TOML string. Fixture files are resolved relative to `test_dir`.
-fn resolve_fixtures_in_test(content: &str, test_dir: &Path) -> anyhow::Result<String> {
-    // Parse to check if there's a fixture reference
-    let case: tokf_common::test_case::TestCase =
-        toml::from_str(content).map_err(|e| anyhow::anyhow!("invalid test TOML: {e}"))?;
-
-    let Some(fixture_name) = case.fixture else {
-        // No fixture — return as-is
-        return Ok(content.to_string());
-    };
-
-    if case.inline.is_some() {
-        // Has both — inline takes priority, return as-is
-        return Ok(content.to_string());
-    }
-
-    let fixture_path = test_dir.join(&fixture_name);
-    let fixture_content = std::fs::read_to_string(&fixture_path)
-        .map_err(|e| anyhow::anyhow!("cannot read fixture '{fixture_name}': {e}"))?;
-    let fixture_content = fixture_content.trim_end();
-
-    // Rebuild the TOML with inline instead of fixture
-    let mut result = String::new();
-    let mut skipped_fixture = false;
-    for line in content.lines() {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("fixture") && trimmed.contains('=') {
-            skipped_fixture = true;
-            continue;
-        }
-        result.push_str(line);
-        result.push('\n');
-    }
-
-    if !skipped_fixture {
-        anyhow::bail!("expected fixture line but did not find it");
-    }
-
-    // Insert inline using TOML multi-line literal string (triple single-quotes).
-    // Literal strings don't interpret backslashes, which is critical for fixture
-    // content that may contain paths, regex patterns, or separator lines like \---.
-    let insert_pos = result.find("[[expect]]").unwrap_or(result.len());
-    let inline_value = format!("inline = '''\n{fixture_content}\n'''\n");
-    result.insert_str(insert_pos, &inline_value);
-
-    Ok(result)
 }
 
 /// Best-effort: resolve the GitHub username of the last committer for a file.
@@ -333,89 +256,4 @@ fn resolve_fallback_author() -> String {
         }
     }
     "mpecan".to_string()
-}
-
-#[cfg(test)]
-#[allow(clippy::unwrap_used)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn resolve_fixtures_replaces_fixture_with_inline() {
-        let dir = tempfile::TempDir::new().unwrap();
-        std::fs::write(dir.path().join("output.txt"), "hello world\n").unwrap();
-
-        let toml = r#"name = "test"
-fixture = "output.txt"
-exit_code = 0
-
-[[expect]]
-contains = "hello"
-"#;
-        let resolved = resolve_fixtures_in_test(toml, dir.path()).unwrap();
-        assert!(!resolved.contains("fixture"), "fixture should be removed");
-        assert!(resolved.contains("inline"), "should contain inline");
-        assert!(
-            resolved.contains("hello world"),
-            "should contain fixture content"
-        );
-    }
-
-    #[test]
-    fn resolve_fixtures_preserves_inline() {
-        let toml = r#"name = "test"
-inline = "already inline"
-
-[[expect]]
-equals = "already inline"
-"#;
-        let resolved = resolve_fixtures_in_test(toml, Path::new("/nonexistent")).unwrap();
-        assert_eq!(resolved, toml, "should be unchanged");
-    }
-
-    #[test]
-    fn resolve_fixtures_uses_literal_strings_for_backslashes() {
-        let dir = tempfile::TempDir::new().unwrap();
-        // Fixture content with backslashes (like gradle's \--- separators)
-        std::fs::write(dir.path().join("output.txt"), "\\--- foo\n\\--- bar\n").unwrap();
-
-        let toml = r#"name = "test"
-fixture = "output.txt"
-exit_code = 0
-
-[[expect]]
-contains = "foo"
-"#;
-        let resolved = resolve_fixtures_in_test(toml, dir.path()).unwrap();
-        // Must use ''' (literal string) so backslashes aren't interpreted
-        assert!(
-            resolved.contains("'''"),
-            "should use literal string quotes, got:\n{resolved}"
-        );
-        assert!(
-            !resolved.contains(r#"""""#),
-            "should NOT use basic string quotes"
-        );
-        assert!(
-            resolved.contains("\\--- foo"),
-            "backslashes should be preserved literally"
-        );
-    }
-
-    #[test]
-    fn resolve_fixtures_errors_on_missing_file() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let toml = r#"name = "test"
-fixture = "missing.txt"
-
-[[expect]]
-contains = "x"
-"#;
-        let result = resolve_fixtures_in_test(toml, dir.path());
-        assert!(result.is_err());
-        assert!(
-            result.unwrap_err().to_string().contains("missing.txt"),
-            "error should mention the file"
-        );
-    }
 }

--- a/crates/tokf-cli/tests/cli_publish.rs
+++ b/crates/tokf-cli/tests/cli_publish.rs
@@ -87,6 +87,93 @@ fn publish_help_shows_flags() {
     );
 }
 
+/// `tokf publish --dry-run` resolves fixture references in test files.
+///
+/// Before the consolidation, regular publish sent raw test bytes without
+/// inlining `fixture = "file.txt"` references. This test verifies the fix:
+/// a filter with a `_test/` dir containing a fixture-referencing test TOML
+/// should succeed in dry-run (fixtures resolved) and report the correct count.
+#[test]
+fn publish_dry_run_resolves_fixtures_in_tests() {
+    let home = tempfile::tempdir().unwrap();
+
+    // Create filter
+    let filter_dir = home.path().join(".tokf").join("filters").join("myns");
+    std::fs::create_dir_all(&filter_dir).unwrap();
+    std::fs::write(
+        filter_dir.join("fix-filter.toml"),
+        r#"command = "my-fixture-cmd""#,
+    )
+    .unwrap();
+
+    // Create adjacent _test/ dir with a test that references a fixture
+    let test_dir = filter_dir.join("fix-filter_test");
+    std::fs::create_dir_all(&test_dir).unwrap();
+    std::fs::write(test_dir.join("sample_output.txt"), "hello world\n").unwrap();
+    std::fs::write(
+        test_dir.join("with_fixture.toml"),
+        "name = \"fixture test\"\nfixture = \"sample_output.txt\"\n\n[[expect]]\ncontains = \"hello\"\n",
+    )
+    .unwrap();
+
+    let output = tokf()
+        .env("HOME", home.path())
+        .current_dir(home.path())
+        .args(["publish", "myns/fix-filter", "--dry-run"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "fixture resolution should succeed in dry-run, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Tests:   1 file(s)"),
+        "expected 1 test file (only .toml, not .txt), got: {stderr}"
+    );
+}
+
+/// `tokf publish --dry-run` fails when a fixture file is missing.
+#[test]
+fn publish_dry_run_fails_on_missing_fixture() {
+    let home = tempfile::tempdir().unwrap();
+
+    let filter_dir = home.path().join(".tokf").join("filters").join("myns");
+    std::fs::create_dir_all(&filter_dir).unwrap();
+    std::fs::write(
+        filter_dir.join("bad-filter.toml"),
+        r#"command = "my-bad-cmd""#,
+    )
+    .unwrap();
+
+    // Create _test/ dir with a test referencing a non-existent fixture
+    let test_dir = filter_dir.join("bad-filter_test");
+    std::fs::create_dir_all(&test_dir).unwrap();
+    std::fs::write(
+        test_dir.join("broken.toml"),
+        "name = \"broken\"\nfixture = \"does_not_exist.txt\"\n\n[[expect]]\ncontains = \"x\"\n",
+    )
+    .unwrap();
+
+    let output = tokf()
+        .env("HOME", home.path())
+        .current_dir(home.path())
+        .args(["publish", "myns/bad-filter", "--dry-run"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected failure when fixture is missing"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("does_not_exist.txt"),
+        "error should mention the missing fixture, got: {stderr}"
+    );
+}
+
 /// `tokf publish` with a nonexistent filter should fail with a "not found" error.
 #[test]
 fn publish_nonexistent_filter_fails() {

--- a/crates/tokf-server/src/routes/filters/publish/mod.rs
+++ b/crates/tokf-server/src/routes/filters/publish/mod.rs
@@ -164,49 +164,41 @@ pub async fn insert_filter_tests(
 }
 
 /// Validated, hashed filter ready for storage.
-struct PreparedFilter {
-    content_hash: String,
-    command_pattern: String,
-    canonical_command: String,
-    config: FilterConfig,
-    filter_bytes: Vec<u8>,
-    test_files: Vec<(String, Vec<u8>)>,
-    test_cases: Vec<TestCase>,
+pub(super) struct PreparedFilter {
+    pub(super) content_hash: String,
+    pub(super) command_pattern: String,
+    pub(super) canonical_command: String,
+    pub(super) config: FilterConfig,
+    pub(super) filter_bytes: Vec<u8>,
+    pub(super) test_files: Vec<(String, Vec<u8>)>,
+    pub(super) test_cases: Vec<TestCase>,
 }
 
-/// Validate the multipart fields, check server-side constraints, and compute
-/// the content hash.
+/// Validate filter TOML and test files, compute the canonical content hash.
 ///
-/// Rejects filters with `lua_script.file` early — before hashing or
-/// storage — so invalid uploads never reach R2.
-fn prepare_filter(fields: MultipartFields) -> Result<PreparedFilter, AppError> {
-    if !fields.mit_license_accepted {
-        return Err(AppError::BadRequest(
-            "MIT license not accepted — set 'mit_license_accepted' to 'true'".to_string(),
-        ));
-    }
-    let toml_str = std::str::from_utf8(&fields.filter_bytes)
-        .map_err(|_| AppError::BadRequest("filter TOML is not valid UTF-8".to_string()))?;
-    let config: FilterConfig = toml::from_str(toml_str)
-        .map_err(|e| AppError::BadRequest(format!("invalid filter TOML: {e}")))?;
+/// Shared by both regular publish and stdlib publish. Rejects filters with
+/// `lua_script.file`, empty commands, or missing tests.
+pub(super) fn validate_and_prepare(
+    filter_toml: &[u8],
+    test_files: Vec<(String, Vec<u8>)>,
+) -> Result<PreparedFilter, String> {
+    let toml_str = std::str::from_utf8(filter_toml)
+        .map_err(|_| "filter TOML is not valid UTF-8".to_string())?;
+    let config: FilterConfig =
+        toml::from_str(toml_str).map_err(|e| format!("invalid filter TOML: {e}"))?;
 
-    // Fail fast: reject lua_script.file before computing hash or uploading.
     if let Some(ref script) = config.lua_script
         && script.file.is_some()
     {
-        return Err(AppError::BadRequest(
-            "lua_script.file is not supported for published filters; \
+        return Err("lua_script.file is not supported for published filters; \
              use inline 'source' instead (Hint: `tokf publish` inlines \
              file references automatically)"
-                .to_string(),
-        ));
+            .to_string());
     }
 
     let command_pattern = config.command.first().to_string();
     if command_pattern.is_empty() {
-        return Err(AppError::BadRequest(
-            "filter must have at least one non-empty command".to_string(),
-        ));
+        return Err("filter must have at least one non-empty command".to_string());
     }
     let canonical_command = command_pattern
         .split_whitespace()
@@ -214,32 +206,37 @@ fn prepare_filter(fields: MultipartFields) -> Result<PreparedFilter, AppError> {
         .unwrap_or(&command_pattern)
         .to_string();
 
-    // Require at least one test file
-    if fields.test_files.is_empty() {
-        return Err(AppError::BadRequest(
-            "at least one test file is required to publish a filter".to_string(),
-        ));
+    if test_files.is_empty() {
+        return Err("at least one test file is required to publish a filter".to_string());
     }
 
-    // Validate and parse test files
-    let mut test_cases = Vec::with_capacity(fields.test_files.len());
-    for (filename, bytes) in &fields.test_files {
-        let tc = tokf_common::test_case::validate(bytes)
-            .map_err(|e| AppError::BadRequest(format!("{filename}: {e}")))?;
+    let mut test_cases = Vec::with_capacity(test_files.len());
+    for (filename, bytes) in &test_files {
+        let tc = tokf_common::test_case::validate(bytes).map_err(|e| format!("{filename}: {e}"))?;
         test_cases.push(tc);
     }
 
-    let content_hash =
-        canonical_hash(&config).map_err(|e| AppError::Internal(format!("hash error: {e}")))?;
+    let content_hash = canonical_hash(&config).map_err(|e| format!("hash error: {e}"))?;
     Ok(PreparedFilter {
         content_hash,
         command_pattern,
         canonical_command,
         config,
-        filter_bytes: fields.filter_bytes,
-        test_files: fields.test_files,
+        filter_bytes: filter_toml.to_vec(),
+        test_files,
         test_cases,
     })
+}
+
+/// Validate the multipart fields, check server-side constraints, and compute
+/// the content hash. Delegates to `validate_and_prepare` after MIT license check.
+fn prepare_filter(fields: MultipartFields) -> Result<PreparedFilter, AppError> {
+    if !fields.mit_license_accepted {
+        return Err(AppError::BadRequest(
+            "MIT license not accepted — set 'mit_license_accepted' to 'true'".to_string(),
+        ));
+    }
+    validate_and_prepare(&fields.filter_bytes, fields.test_files).map_err(AppError::BadRequest)
 }
 
 // ── POST /api/filters ─────────────────────────────────────────────────────────

--- a/crates/tokf-server/src/routes/filters/publish/stdlib/mod.rs
+++ b/crates/tokf-server/src/routes/filters/publish/stdlib/mod.rs
@@ -1,15 +1,13 @@
 use axum::{Json, extract::State, http::StatusCode};
 use serde::{Deserialize, Serialize};
 use tokf_common::config::types::FilterConfig;
-use tokf_common::hash::canonical_hash;
-use tokf_common::test_case::TestCase;
 
 use crate::auth::service_token::ServiceAuth;
 use crate::error::AppError;
 use crate::state::AppState;
 use crate::storage;
 
-use super::{insert_filter_tests, run_verification, upload_tests};
+use super::{PreparedFilter, insert_filter_tests, run_verification, upload_tests};
 
 // ── Request types ────────────────────────────────────────────────────────────
 
@@ -51,17 +49,7 @@ pub struct StdlibFailure {
 /// Maximum number of filters in a single publish-stdlib request.
 const MAX_BATCH_SIZE: usize = 200;
 
-// ── Internal types ───────────────────────────────────────────────────────────
-
-struct PreparedStdlibFilter {
-    content_hash: String,
-    command_pattern: String,
-    canonical_command: String,
-    filter_bytes: Vec<u8>,
-    test_files: Vec<(String, Vec<u8>)>,
-    config: FilterConfig,
-    test_cases: Vec<TestCase>,
-}
+// ── Internal helpers ─────────────────────────────────────────────────────────
 
 /// GitHub usernames: alphanumeric + hyphens, 1-39 chars, no leading/trailing hyphens.
 fn validate_github_username(username: &str) -> Result<(), String> {
@@ -86,55 +74,14 @@ fn validate_github_username(username: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn prepare_stdlib_filter(entry: &StdlibFilterEntry) -> Result<PreparedStdlibFilter, String> {
+fn prepare_stdlib_filter(entry: &StdlibFilterEntry) -> Result<PreparedFilter, String> {
     validate_github_username(&entry.author_github_username)?;
-
-    let config: FilterConfig =
-        toml::from_str(&entry.filter_toml).map_err(|e| format!("invalid filter TOML: {e}"))?;
-
-    if let Some(ref script) = config.lua_script
-        && script.file.is_some()
-    {
-        return Err(
-            "lua_script.file is not supported for published filters; use inline 'source' instead"
-                .to_string(),
-        );
-    }
-
-    let command_pattern = config.command.first().to_string();
-    if command_pattern.is_empty() {
-        return Err("filter must have at least one non-empty command".to_string());
-    }
-    let canonical_command = command_pattern
-        .split_whitespace()
-        .next()
-        .unwrap_or(&command_pattern)
-        .to_string();
-
-    if entry.test_files.is_empty() {
-        return Err("at least one test file is required".to_string());
-    }
-
-    let mut test_cases = Vec::with_capacity(entry.test_files.len());
-    let mut test_file_bytes = Vec::with_capacity(entry.test_files.len());
-    for tf in &entry.test_files {
-        let tc = tokf_common::test_case::validate(tf.content.as_bytes())
-            .map_err(|e| format!("{}: {e}", tf.filename))?;
-        test_cases.push(tc);
-        test_file_bytes.push((tf.filename.clone(), tf.content.as_bytes().to_vec()));
-    }
-
-    let content_hash = canonical_hash(&config).map_err(|e| format!("hash error: {e}"))?;
-
-    Ok(PreparedStdlibFilter {
-        content_hash,
-        command_pattern,
-        canonical_command,
-        filter_bytes: entry.filter_toml.as_bytes().to_vec(),
-        test_files: test_file_bytes,
-        config,
-        test_cases,
-    })
+    let test_file_bytes: Vec<_> = entry
+        .test_files
+        .iter()
+        .map(|tf| (tf.filename.clone(), tf.content.as_bytes().to_vec()))
+        .collect();
+    super::validate_and_prepare(entry.filter_toml.as_bytes(), test_file_bytes)
 }
 
 /// Find or create a user by GitHub username for stdlib attribution.
@@ -315,7 +262,7 @@ fn fail(command_pattern: &str, phase: &str, error: String) -> StdlibFailure {
 /// Returns `Ok(true)` if the filter already exists (and updates `is_stdlib`).
 async fn check_existing(
     state: &AppState,
-    prepared: &PreparedStdlibFilter,
+    prepared: &PreparedFilter,
     skipped: &mut usize,
 ) -> Result<bool, StdlibFailure> {
     let existing: Option<String> =
@@ -343,7 +290,7 @@ async fn check_existing(
 /// Upload to storage and insert DB records for a validated stdlib filter.
 async fn persist_filter(
     state: &AppState,
-    prepared: &PreparedStdlibFilter,
+    prepared: &PreparedFilter,
     author_username: &str,
 ) -> Result<(), AppError> {
     let author_id = upsert_user_by_username(&state.db, author_username).await?;


### PR DESCRIPTION
## Summary

- **Fix:** regular `tokf publish` now inlines `fixture = "file.txt"` references in test files before uploading, matching `tokf publish-stdlib` behavior. Previously, regular publish sent raw test bytes with unresolved fixture references the server can't access.
- **Extract** shared CLI helpers into `publish_shared.rs` (`hash_filter`, `inline_lua_script`, `resolve_fixtures_in_test`, `collect_test_files_resolved`)
- **Unify** server-side validation via `validate_and_prepare()`, eliminating the duplicated `PreparedStdlibFilter` struct

## Test plan

- [x] `cargo test --workspace` — 1441 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] New CLI tests: `publish_dry_run_resolves_fixtures_in_tests` and `publish_dry_run_fails_on_missing_fixture`
- [x] New unit test: `collect_test_files_resolved_inlines_fixtures`
- [ ] DB tests (`cargo test -p tokf-server -- --ignored`) if DB available
- [ ] E2E tests (`cargo test -p e2e-tests -- --ignored`) if DB available

🤖 Generated with [Claude Code](https://claude.com/claude-code)