### PR TITLE
feat(cli): add `tokf completions` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "4.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685bc86fd34b7467e0532a4f8435ab107960d69a243785ef0275e571b35b641a"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3306,6 +3325,8 @@ version = "0.2.18"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
+ "clap_complete_nushell",
  "dirs",
  "filetime",
  "gethostname",

--- a/README.md
+++ b/README.md
@@ -1166,6 +1166,52 @@ tokf cache info    # show cache location, size, and validity
 tokf cache clear   # delete the cache, forcing a rebuild on next run
 ```
 
+## Shell completions
+
+Generate tab-completion scripts for your shell:
+
+```sh
+tokf completions bash
+tokf completions zsh
+tokf completions fish
+tokf completions powershell
+tokf completions elvish
+tokf completions nushell
+```
+
+### Installation
+
+**Bash** — add to `~/.bashrc`:
+```sh
+eval "$(tokf completions bash)"
+```
+
+**Zsh** — add to `~/.zshrc`:
+```sh
+eval "$(tokf completions zsh)"
+```
+
+**Fish** — save to completions directory:
+```sh
+tokf completions fish > ~/.config/fish/completions/tokf.fish
+```
+
+**PowerShell** — add to your profile:
+```powershell
+tokf completions powershell | Out-String | Invoke-Expression
+```
+
+**Elvish** — add to `~/.elvish/rc.elv`:
+```sh
+eval (tokf completions elvish | slurp)
+```
+
+**Nushell** — save and source in your config:
+```sh
+tokf completions nushell | save -f ~/.config/nushell/tokf.nu
+source ~/.config/nushell/tokf.nu
+```
+
 ---
 
 

--- a/crates/tokf-cli/Cargo.toml
+++ b/crates/tokf-cli/Cargo.toml
@@ -36,6 +36,8 @@ keyring = { version = "3", features = ["apple-native", "windows-native", "linux-
 open = "5"
 uuid = { version = "1", features = ["v4"] }
 gethostname = "1"
+clap_complete = "4.5"
+clap_complete_nushell = "4.5"
 
 [features]
 stdlib-publish = []

--- a/crates/tokf-cli/src/completions_cmd.rs
+++ b/crates/tokf-cli/src/completions_cmd.rs
@@ -1,0 +1,102 @@
+use std::io;
+
+use clap::CommandFactory;
+use clap_complete::Generator;
+
+use crate::Cli;
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug)]
+pub enum ShellChoice {
+    Bash,
+    Zsh,
+    Fish,
+    #[value(name = "powershell")]
+    PowerShell,
+    Elvish,
+    Nushell,
+}
+
+pub fn cmd_completions(shell: ShellChoice) -> i32 {
+    let mut cmd = Cli::command();
+    let bin_name = "tokf";
+    generate_to_writer(shell, &mut cmd, bin_name, &mut io::stdout());
+    print_install_hint(shell);
+    0
+}
+
+fn generate_to_writer(
+    shell: ShellChoice,
+    cmd: &mut clap::Command,
+    name: &str,
+    out: &mut dyn io::Write,
+) {
+    match shell {
+        ShellChoice::Bash => clap_complete::generate(clap_complete::Shell::Bash, cmd, name, out),
+        ShellChoice::Zsh => clap_complete::generate(clap_complete::Shell::Zsh, cmd, name, out),
+        ShellChoice::Fish => clap_complete::generate(clap_complete::Shell::Fish, cmd, name, out),
+        ShellChoice::PowerShell => {
+            clap_complete::generate(clap_complete::Shell::PowerShell, cmd, name, out);
+        }
+        ShellChoice::Elvish => {
+            clap_complete::generate(clap_complete::Shell::Elvish, cmd, name, out);
+        }
+        ShellChoice::Nushell => {
+            cmd.set_bin_name(name);
+            cmd.build();
+            clap_complete_nushell::Nushell.generate(cmd, out);
+        }
+    }
+}
+
+fn print_install_hint(shell: ShellChoice) {
+    let hint = match shell {
+        ShellChoice::Bash => "# Add to ~/.bashrc:\n#   eval \"$(tokf completions bash)\"",
+        ShellChoice::Zsh => "# Add to ~/.zshrc:\n#   eval \"$(tokf completions zsh)\"",
+        ShellChoice::Fish => {
+            "# Save to fish completions dir:\n#   tokf completions fish > ~/.config/fish/completions/tokf.fish"
+        }
+        ShellChoice::PowerShell => {
+            "# Add to your PowerShell profile:\n#   tokf completions powershell | Out-String | Invoke-Expression"
+        }
+        ShellChoice::Elvish => {
+            "# Add to ~/.elvish/rc.elv:\n#   eval (tokf completions elvish | slurp)"
+        }
+        ShellChoice::Nushell => {
+            "# Save and source in your config:\n#   tokf completions nushell | save -f ~/.config/nushell/tokf.nu\n#   source ~/.config/nushell/tokf.nu"
+        }
+    };
+    eprintln!("\n{hint}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn generate_completions(shell: ShellChoice) -> Vec<u8> {
+        let mut cmd = Cli::command();
+        let mut buf = Vec::new();
+        generate_to_writer(shell, &mut cmd, "tokf", &mut buf);
+        buf
+    }
+
+    #[test]
+    fn all_shells_produce_output() {
+        let shells = [
+            ShellChoice::Bash,
+            ShellChoice::Zsh,
+            ShellChoice::Fish,
+            ShellChoice::PowerShell,
+            ShellChoice::Elvish,
+            ShellChoice::Nushell,
+        ];
+        for shell in shells {
+            let buf = generate_completions(shell);
+            assert!(!buf.is_empty(), "expected non-empty output for {shell:?}");
+            let output = String::from_utf8_lossy(&buf);
+            assert!(
+                output.contains("tokf"),
+                "expected 'tokf' in completion output for {shell:?}, got:\n{output}"
+            );
+        }
+    }
+}

--- a/crates/tokf-cli/src/main.rs
+++ b/crates/tokf-cli/src/main.rs
@@ -1,6 +1,7 @@
 mod auth_cmd;
 mod cache_cmd;
 mod commands;
+mod completions_cmd;
 mod eject_cmd;
 mod gain;
 mod history_cmd;
@@ -76,6 +77,11 @@ enum Commands {
         prefer_less: bool,
         #[arg(trailing_var_arg = true, required = true)]
         command_args: Vec<String>,
+    },
+    /// Generate shell completion scripts
+    Completions {
+        /// Target shell (bash, zsh, fish, powershell, elvish, nushell)
+        shell: completions_cmd::ShellChoice,
     },
     /// Validate a filter TOML file
     Check {
@@ -392,6 +398,7 @@ fn main() {
             *prefer_less,
             &cli,
         )),
+        Commands::Completions { shell } => completions_cmd::cmd_completions(*shell),
         Commands::Check { filter_path } => cmd_check(Path::new(filter_path)),
         Commands::Test {
             filter_path,

--- a/crates/tokf-cli/tests/cli_completions.rs
+++ b/crates/tokf-cli/tests/cli_completions.rs
@@ -1,0 +1,124 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::process::Command;
+
+fn tokf() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_tokf"))
+}
+
+#[test]
+fn completions_bash_produces_output() {
+    let output = tokf().args(["completions", "bash"]).output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty(), "expected non-empty output");
+    assert!(
+        stdout.contains("tokf"),
+        "expected 'tokf' in bash completions:\n{stdout}"
+    );
+}
+
+#[test]
+fn completions_zsh_produces_output() {
+    let output = tokf().args(["completions", "zsh"]).output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty(), "expected non-empty output");
+    assert!(
+        stdout.contains("tokf"),
+        "expected 'tokf' in zsh completions:\n{stdout}"
+    );
+}
+
+#[test]
+fn completions_fish_produces_output() {
+    let output = tokf().args(["completions", "fish"]).output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty(), "expected non-empty output");
+    assert!(
+        stdout.contains("tokf"),
+        "expected 'tokf' in fish completions:\n{stdout}"
+    );
+}
+
+#[test]
+fn completions_nushell_produces_output() {
+    let output = tokf().args(["completions", "nushell"]).output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty(), "expected non-empty output");
+    assert!(
+        stdout.contains("tokf"),
+        "expected 'tokf' in nushell completions:\n{stdout}"
+    );
+}
+
+#[test]
+fn completions_powershell_produces_output() {
+    let output = tokf().args(["completions", "powershell"]).output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty(), "expected non-empty output");
+    assert!(
+        stdout.contains("tokf"),
+        "expected 'tokf' in powershell completions:\n{stdout}"
+    );
+}
+
+#[test]
+fn completions_elvish_produces_output() {
+    let output = tokf().args(["completions", "elvish"]).output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty(), "expected non-empty output");
+    assert!(
+        stdout.contains("tokf"),
+        "expected 'tokf' in elvish completions:\n{stdout}"
+    );
+}
+
+#[test]
+fn completions_invalid_shell_fails() {
+    let output = tokf()
+        .args(["completions", "invalidshell"])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "expected failure for invalid shell name"
+    );
+}
+
+#[test]
+fn completions_missing_shell_arg_fails() {
+    let output = tokf().arg("completions").output().unwrap();
+    assert!(
+        !output.status.success(),
+        "expected failure when shell arg is missing"
+    );
+}

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -84,3 +84,49 @@ tokf caches the filter discovery index for faster startup. The cache rebuilds au
 tokf cache info    # show cache location, size, and validity
 tokf cache clear   # delete the cache, forcing a rebuild on next run
 ```
+
+## Shell completions
+
+Generate tab-completion scripts for your shell:
+
+```sh
+tokf completions bash
+tokf completions zsh
+tokf completions fish
+tokf completions powershell
+tokf completions elvish
+tokf completions nushell
+```
+
+### Installation
+
+**Bash** — add to `~/.bashrc`:
+```sh
+eval "$(tokf completions bash)"
+```
+
+**Zsh** — add to `~/.zshrc`:
+```sh
+eval "$(tokf completions zsh)"
+```
+
+**Fish** — save to completions directory:
+```sh
+tokf completions fish > ~/.config/fish/completions/tokf.fish
+```
+
+**PowerShell** — add to your profile:
+```powershell
+tokf completions powershell | Out-String | Invoke-Expression
+```
+
+**Elvish** — add to `~/.elvish/rc.elv`:
+```sh
+eval (tokf completions elvish | slurp)
+```
+
+**Nushell** — save and source in your config:
+```sh
+tokf completions nushell | save -f ~/.config/nushell/tokf.nu
+source ~/.config/nushell/tokf.nu
+```


### PR DESCRIPTION
## Summary

- Add `tokf completions <shell>` subcommand that generates tab-completion scripts for **bash, zsh, fish, powershell, elvish, and nushell**
- Uses `clap_complete` and `clap_complete_nushell` to generate scripts from the existing derive-based CLI definition
- Prints install hints to stderr for each shell (aligns with project visibility philosophy)
- Documents usage and per-shell install instructions in `docs/diagnostics.md`

## Test plan

- [x] Unit test verifies all 6 shells produce non-empty output containing "tokf"
- [x] Integration tests for each shell (bash, zsh, fish, powershell, elvish, nushell)
- [x] Integration tests for invalid shell name and missing argument (error cases)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes clean
- [x] `cargo fmt -- --check` passes clean
- [x] Manual verification: `cargo run -p tokf -- completions bash` and `completions nushell` produce valid scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)