### PR TITLE
fix(cli): add explicit type annotation for stdlib-publish collect

### DIFF
--- a/crates/tokf-cli/src/publish_stdlib_cmd.rs
+++ b/crates/tokf-cli/src/publish_stdlib_cmd.rs
@@ -164,7 +164,7 @@ fn collect_stdlib_entries(filters_dir: &Path) -> anyhow::Result<Vec<StdlibFilter
         let author = resolve_author(path).unwrap_or_else(|| fallback_author.clone());
 
         let raw_tests = collect_test_files_resolved(path)?;
-        let test_files = raw_tests
+        let test_files: Vec<StdlibTestFile> = raw_tests
             .into_iter()
             .map(|(filename, bytes)| StdlibTestFile {
                 filename,


### PR DESCRIPTION
## Summary
- Add explicit `Vec<StdlibTestFile>` type annotation on `.collect()` in `publish_stdlib_cmd.rs` to fix compilation failure when the `stdlib-publish` feature is enabled.

## Test plan
- [x] `cargo check -p tokf --features stdlib-publish` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)