### PR TITLE
fix(server): use >= for R2 put_count assertions to prevent flaky tests

### DIFF
--- a/crates/tokf-server/src/routes/filters/publish/stdlib/tests.rs
+++ b/crates/tokf-server/src/routes/filters/publish/stdlib/tests.rs
@@ -164,8 +164,14 @@ async fn publish_stdlib_stores_tests_in_storage(pool: PgPool) {
     let resp = post_stdlib(app, &token, &req).await;
     assert_eq!(resp.status(), StatusCode::CREATED);
 
-    // 1 filter + 1 test file = 2 puts
-    assert_eq!(storage.put_count(), 2, "expected 2 R2 put calls");
+    // The publish handler does 2 synchronous puts (filter + 1 test file).
+    // spawn_batch_catalog_update() may add more (metadata.json + catalog/index.json)
+    // before this assertion runs, so use >= to avoid flakiness.
+    assert!(
+        storage.put_count() >= 2,
+        "expected at least 2 R2 put calls (filter + 1 test), got {}",
+        storage.put_count()
+    );
 }
 
 #[crdb_test_macro::crdb_test(migrations = "./migrations")]

--- a/crates/tokf-server/src/routes/filters/publish/tests.rs
+++ b/crates/tokf-server/src/routes/filters/publish/tests.rs
@@ -88,8 +88,14 @@ async fn publish_filter_with_tests_creates_filter_test_rows(pool: PgPool) {
         .unwrap();
     assert_eq!(count, 2, "expected 2 filter_tests rows");
 
-    // Verify R2 received filter + 2 test files = 3 puts
-    assert_eq!(storage.put_count(), 3, "expected 3 R2 put calls");
+    // The publish handler does 3 synchronous puts (filter + 2 test files).
+    // spawn_catalog_update() may add more (metadata.json + catalog/index.json)
+    // before this assertion runs, so use >= to avoid flakiness.
+    assert!(
+        storage.put_count() >= 3,
+        "expected at least 3 R2 put calls (filter + 2 tests), got {}",
+        storage.put_count()
+    );
 }
 
 #[crdb_test_macro::crdb_test(migrations = "./migrations")]


### PR DESCRIPTION
## Summary
- Changed `publish_filter_with_tests_creates_filter_test_rows` and `publish_stdlib_stores_tests_in_storage` tests to use `>=` instead of `==` for R2 `put_count()` assertions
- The `spawn_catalog_update()` / `spawn_batch_catalog_update()` background tasks can write `metadata.json` + `catalog/index.json` before the assertion runs, causing intermittent failures (observed: expected 3, got 4)

## Test plan
- [x] `just test-db` — all 115 tests pass
- [x] Verified `storage/mod.rs` unit tests are unaffected (no background catalog tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)