### PR TITLE
feat(filter): add token estimates to filter examples

### DIFF
--- a/crates/tokf-common/src/examples.rs
+++ b/crates/tokf-common/src/examples.rs
@@ -2,8 +2,27 @@ use serde::{Deserialize, Serialize};
 
 use crate::safety::SafetyWarning;
 
+/// Estimate token count from a string using the bytes/4 heuristic.
+///
+/// This matches the estimation used by the tracking module.
+pub const fn estimate_tokens(s: &str) -> usize {
+    s.len() / 4
+}
+
+/// Compute the reduction percentage between raw and filtered token estimates.
+///
+/// Returns 0.0 when `raw_tokens` is zero.
+#[allow(clippy::cast_precision_loss)]
+pub fn reduction_pct(raw_tokens: usize, filtered_tokens: usize) -> f64 {
+    if raw_tokens == 0 {
+        0.0
+    } else {
+        (1.0 - filtered_tokens as f64 / raw_tokens as f64) * 100.0
+    }
+}
+
 /// A single before/after example for a filter.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(
     test,
     derive(ts_rs::TS),
@@ -25,10 +44,21 @@ pub struct FilterExample {
     /// Number of lines in filtered output.
     #[cfg_attr(test, ts(type = "number"))]
     pub filtered_line_count: usize,
+    /// Estimated tokens in raw input (bytes / 4).
+    #[serde(default)]
+    #[cfg_attr(test, ts(type = "number"))]
+    pub raw_tokens_est: usize,
+    /// Estimated tokens in filtered output (bytes / 4).
+    #[serde(default)]
+    #[cfg_attr(test, ts(type = "number"))]
+    pub filtered_tokens_est: usize,
+    /// Percentage reduction in estimated tokens.
+    #[serde(default)]
+    pub reduction_pct: f64,
 }
 
 /// Collection of examples with aggregated safety results.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(
     test,
     derive(ts_rs::TS),
@@ -83,14 +113,19 @@ mod tests {
 
     #[test]
     fn serialize_round_trip() {
+        let raw = "line1\nline2\nline3";
+        let filtered = "line1";
         let examples = FilterExamples {
             examples: vec![FilterExample {
                 name: "basic".to_string(),
                 exit_code: 0,
-                raw: "line1\nline2\nline3".to_string(),
-                filtered: "line1".to_string(),
+                raw: raw.to_string(),
+                filtered: filtered.to_string(),
                 raw_line_count: 3,
                 filtered_line_count: 1,
+                raw_tokens_est: estimate_tokens(raw),
+                filtered_tokens_est: estimate_tokens(filtered),
+                reduction_pct: reduction_pct(estimate_tokens(raw), estimate_tokens(filtered)),
             }],
             safety: ExamplesSafety {
                 passed: true,
@@ -103,6 +138,32 @@ mod tests {
         assert_eq!(parsed.examples.len(), 1);
         assert_eq!(parsed.examples[0].name, "basic");
         assert!(parsed.safety.passed);
+    }
+
+    #[test]
+    fn deserialize_without_token_fields_defaults_to_zero() {
+        let json = r#"{"examples":[{"name":"old","exit_code":0,"raw":"abc","filtered":"a","raw_line_count":1,"filtered_line_count":1}],"safety":{"passed":true,"warnings":[]}}"#;
+        let parsed: FilterExamples = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.examples[0].raw_tokens_est, 0);
+        assert_eq!(parsed.examples[0].filtered_tokens_est, 0);
+        assert!((parsed.examples[0].reduction_pct).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn estimate_tokens_basic() {
+        assert_eq!(estimate_tokens(""), 0);
+        assert_eq!(estimate_tokens("abcd"), 1);
+        assert_eq!(estimate_tokens("abcdefgh"), 2);
+        // 3 chars rounds down to 0
+        assert_eq!(estimate_tokens("abc"), 0);
+    }
+
+    #[test]
+    fn reduction_pct_basic() {
+        assert!((reduction_pct(100, 25) - 75.0).abs() < 0.01);
+        assert!((reduction_pct(100, 0) - 100.0).abs() < 0.01);
+        assert!((reduction_pct(100, 100)).abs() < 0.01);
+        assert!((reduction_pct(0, 0)).abs() < 0.01);
     }
 
     #[test]

--- a/crates/tokf-filter/src/examples.rs
+++ b/crates/tokf-filter/src/examples.rs
@@ -1,5 +1,7 @@
 use tokf_common::config::types::FilterConfig;
-use tokf_common::examples::{ExamplesSafety, FilterExample, FilterExamples, SafetyWarningDto};
+use tokf_common::examples::{
+    ExamplesSafety, FilterExample, FilterExamples, SafetyWarningDto, estimate_tokens, reduction_pct,
+};
 use tokf_common::safety::{self, SafetyReport};
 use tokf_common::test_case::TestCase;
 
@@ -34,11 +36,17 @@ fn build_example(
 
     let pair_report = safety::check_output_pair(&raw, &filtered.output);
 
+    let raw_tok = estimate_tokens(&raw);
+    let filtered_tok = estimate_tokens(&filtered.output);
+
     let example = FilterExample {
         name: case.name.clone(),
         exit_code: case.exit_code,
         raw_line_count: line_count(&raw),
         filtered_line_count: line_count(&filtered.output),
+        raw_tokens_est: raw_tok,
+        filtered_tokens_est: filtered_tok,
+        reduction_pct: reduction_pct(raw_tok, filtered_tok),
         raw,
         filtered: filtered.output,
     };
@@ -134,7 +142,8 @@ command = "test"
 skip = ["^noise"]
 "#,
         );
-        let cases = vec![make_case("basic", "noise line\nkeep this\nnoise again", 0)];
+        let raw_input = "noise line\nkeep this\nnoise again";
+        let cases = vec![make_case("basic", raw_input, 0)];
         let result = generate_examples(&config, &cases);
 
         assert_eq!(result.examples.len(), 1);
@@ -145,6 +154,10 @@ skip = ["^noise"]
         assert_eq!(ex.filtered, "keep this");
         assert_eq!(ex.raw_line_count, 3);
         assert_eq!(ex.filtered_line_count, 1);
+        // Token estimates: raw = 31 bytes / 4 = 7, filtered = 9 bytes / 4 = 2
+        assert_eq!(ex.raw_tokens_est, estimate_tokens(raw_input));
+        assert_eq!(ex.filtered_tokens_est, estimate_tokens("keep this"));
+        assert!(ex.reduction_pct > 0.0);
         assert!(result.safety.passed);
     }
 
@@ -240,5 +253,8 @@ skip = [".*"]
 
         assert_eq!(result.examples[0].filtered_line_count, 0);
         assert_eq!(result.examples[0].filtered, "");
+        assert_eq!(result.examples[0].filtered_tokens_est, 0);
+        assert!(result.examples[0].raw_tokens_est > 0);
+        assert!((result.examples[0].reduction_pct - 100.0).abs() < 0.01);
     }
 }

--- a/crates/tokf-server/generated/FilterExample.ts
+++ b/crates/tokf-server/generated/FilterExample.ts
@@ -27,4 +27,16 @@ raw_line_count: number,
 /**
  * Number of lines in filtered output.
  */
-filtered_line_count: number, };
+filtered_line_count: number, 
+/**
+ * Estimated tokens in raw input (bytes / 4).
+ */
+raw_tokens_est: number, 
+/**
+ * Estimated tokens in filtered output (bytes / 4).
+ */
+filtered_tokens_est: number, 
+/**
+ * Percentage reduction in estimated tokens.
+ */
+reduction_pct: number, };


### PR DESCRIPTION
## Summary
- Added `raw_tokens_est`, `filtered_tokens_est`, and `reduction_pct` fields to `FilterExample`
- Token estimation uses the same `bytes / 4` heuristic as the tracking module
- New fields use `#[serde(default)]` so existing JSON without these fields deserializes correctly (backward compatible)
- Removed `Eq` derive from `FilterExample` and `FilterExamples` (required because `f64` doesn't implement `Eq`)
- Added `estimate_tokens()` and `reduction_pct()` helpers to `tokf-common::examples`
- Updated TypeScript generated types

## Test plan
- [x] Unit tests for `estimate_tokens` and `reduction_pct` helpers
- [x] Backward compatibility test: deserializing old JSON without token fields defaults to zero
- [x] Existing filter example tests updated with token estimate assertions
- [x] Empty filtered output correctly produces 100% reduction
- [x] Full workspace clippy clean
- [x] `cargo test -p tokf-common -p tokf-filter` — 319 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)