### PR TITLE
feat(filter): add go/test filter (issue #42)

### DIFF
--- a/crates/tokf-cli/filters/go/test.toml
+++ b/crates/tokf-cli/filters/go/test.toml
@@ -1,0 +1,11 @@
+command = "go test"
+skip = ["^=== RUN ", "^=== PAUSE ", "^=== CONT ", "--- PASS:", "^PASS$", "^\\?\\s+"]
+
+[on_success]
+output = "✓ go test\n{output}"
+
+[on_failure]
+skip = ["^ok\\s+"]
+
+[fallback]
+tail = 20

--- a/crates/tokf-cli/filters/go/test_test/all_pass.toml
+++ b/crates/tokf-cli/filters/go/test_test/all_pass.toml
@@ -1,0 +1,18 @@
+name = "all passing tests collapse to summary lines"
+fixture = "all_pass.txt"
+exit_code = 0
+
+[[expect]]
+starts_with = "✓ go test"
+
+[[expect]]
+contains = "ok  \texample.com/math"
+
+[[expect]]
+contains = "ok  \texample.com/strutil"
+
+[[expect]]
+not_contains = "=== RUN"
+
+[[expect]]
+not_contains = "--- PASS:"

--- a/crates/tokf-cli/filters/go/test_test/all_pass.txt
+++ b/crates/tokf-cli/filters/go/test_test/all_pass.txt
@@ -1,0 +1,42 @@
+=== RUN   TestAdd
+--- PASS: TestAdd (0.00s)
+=== RUN   TestSubtract
+--- PASS: TestSubtract (0.00s)
+=== RUN   TestMultiply
+--- PASS: TestMultiply (0.00s)
+=== RUN   TestDivide
+--- PASS: TestDivide (0.00s)
+=== RUN   TestDivideByZero
+--- PASS: TestDivideByZero (0.00s)
+=== RUN   TestSquareRoot
+=== RUN   TestSquareRoot/positive
+=== RUN   TestSquareRoot/zero
+=== RUN   TestSquareRoot/negative_returns_error
+    --- PASS: TestSquareRoot/positive (0.00s)
+    --- PASS: TestSquareRoot/zero (0.00s)
+    --- PASS: TestSquareRoot/negative_returns_error (0.00s)
+--- PASS: TestSquareRoot (0.00s)
+=== RUN   TestParallel
+=== PAUSE TestParallel
+=== CONT  TestParallel
+--- PASS: TestParallel (0.00s)
+PASS
+ok  	example.com/math	0.005s
+=== RUN   TestTrimPrefix
+--- PASS: TestTrimPrefix (0.00s)
+=== RUN   TestTrimSuffix
+--- PASS: TestTrimSuffix (0.00s)
+=== RUN   TestContains
+--- PASS: TestContains (0.00s)
+=== RUN   TestReverse
+=== RUN   TestReverse/ascii
+=== RUN   TestReverse/unicode
+    --- PASS: TestReverse/ascii (0.00s)
+    --- PASS: TestReverse/unicode (0.00s)
+--- PASS: TestReverse (0.00s)
+=== RUN   TestJoin
+--- PASS: TestJoin (0.00s)
+=== RUN   TestSplit
+--- PASS: TestSplit (0.00s)
+PASS
+ok  	example.com/strutil	0.003s

--- a/crates/tokf-cli/filters/go/test_test/failure.toml
+++ b/crates/tokf-cli/filters/go/test_test/failure.toml
@@ -1,0 +1,21 @@
+name = "test failures show error details and FAIL lines"
+fixture = "failure.txt"
+exit_code = 1
+
+[[expect]]
+contains = "--- FAIL: TestMultiply"
+
+[[expect]]
+contains = "--- FAIL: TestDivideByZero"
+
+[[expect]]
+contains = "FAIL\texample.com/math"
+
+[[expect]]
+contains = "math_test.go:25"
+
+[[expect]]
+not_contains = "--- PASS:"
+
+[[expect]]
+not_contains = "=== RUN"

--- a/crates/tokf-cli/filters/go/test_test/failure.txt
+++ b/crates/tokf-cli/filters/go/test_test/failure.txt
@@ -1,0 +1,25 @@
+=== RUN   TestAdd
+--- PASS: TestAdd (0.00s)
+=== RUN   TestSubtract
+--- PASS: TestSubtract (0.00s)
+=== RUN   TestMultiply
+    math_test.go:25: expected 12, got 0
+--- FAIL: TestMultiply (0.00s)
+=== RUN   TestDivide
+--- PASS: TestDivide (0.00s)
+=== RUN   TestDivideByZero
+=== RUN   TestDivideByZero/returns_error
+    math_test.go:44: expected error for zero divisor, got nil
+    --- FAIL: TestDivideByZero/returns_error (0.00s)
+--- FAIL: TestDivideByZero (0.00s)
+FAIL
+FAIL	example.com/math	0.004s
+=== RUN   TestTrimPrefix
+--- PASS: TestTrimPrefix (0.00s)
+=== RUN   TestTrimSuffix
+--- PASS: TestTrimSuffix (0.00s)
+=== RUN   TestContains
+--- PASS: TestContains (0.00s)
+PASS
+ok  	example.com/strutil	0.002s
+FAIL

--- a/crates/tokf-cli/filters/go/test_test/panic.toml
+++ b/crates/tokf-cli/filters/go/test_test/panic.toml
@@ -1,0 +1,15 @@
+name = "panic preserves stack trace and FAIL line"
+fixture = "panic.txt"
+exit_code = 2
+
+[[expect]]
+contains = "panic: runtime error"
+
+[[expect]]
+contains = "store.go:42"
+
+[[expect]]
+contains = "FAIL\texample.com/myapp"
+
+[[expect]]
+not_contains = "=== RUN"

--- a/crates/tokf-cli/filters/go/test_test/panic.txt
+++ b/crates/tokf-cli/filters/go/test_test/panic.txt
@@ -1,0 +1,22 @@
+=== RUN   TestBadAccess
+--- FAIL: TestBadAccess (0.00s)
+panic: runtime error: index out of range [5] with length 3 [recovered]
+	panic: runtime error: index out of range [5] with length 3
+
+goroutine 7 [running]:
+testing.tRunner.func1.2({0x104b8a0e0, 0x104ba4480})
+	/usr/local/go/src/testing/testing.go:1632 +0x230
+testing.tRunner.func1()
+	/usr/local/go/src/testing/testing.go:1635 +0x334
+panic({0x104b8a0e0?, 0x104ba4480?})
+	/usr/local/go/src/runtime/panic.go:785 +0x124
+example.com/myapp.GetItem(...)
+	/Users/dev/myapp/store.go:42 +0x1c
+example.com/myapp.TestBadAccess(0x14000003e00)
+	/Users/dev/myapp/store_test.go:15 +0x30
+testing.tRunner(0x14000003e00, 0x104b9c7a8)
+	/usr/local/go/src/testing/testing.go:1690 +0x108
+created by testing.(*T).Run in goroutine 1
+	/usr/local/go/src/testing/testing.go:1743 +0x318
+FAIL	example.com/myapp	0.006s
+FAIL


### PR DESCRIPTION
## Summary

Adds a `go/test` stdlib filter that strips verbose `go test -v` noise, addressing #42. Pure TOML + fixtures — no Rust changes.

**On success (exit 0):** collapses output to a `✓ go test` header followed by `ok  package  time` summary lines.

```
✓ go test
ok  	example.com/math	0.005s
ok  	example.com/strutil	0.003s
```

**On failure (exit ≠ 0):** preserves assertion errors, `--- FAIL:` lines, panic/stack traces, and `FAIL	package` lines. Strips passing package `ok` lines.

### Filter design

- **Top-level skip** (both branches): `=== RUN`, `=== PAUSE`, `=== CONT`, `--- PASS:` (including indented subtests), bare `PASS`, `?  no test files`
- **on_success:** output template prepends `✓ go test`, remaining lines are just `ok` package summaries
- **on_failure:** branch skip removes `^ok\s+` passing package lines; failure details pass through
- **fallback:** `tail = 20`

### Test suite (3 cases)

| Case | Fixture | Validates |
|------|---------|-----------|
| `all_pass` | 2 packages, ~15 tests with subtests + parallel | Collapses to summary, no RUN/PASS noise |
| `failure` | Mixed pass/fail with subtest failures | Error details + FAIL lines preserved, no PASS noise |
| `panic` | Test panic with stack trace | Stack trace + FAIL line preserved |

### Verification

- `tokf verify` — 103/103 (including 3 new go/test cases)
- `cargo test` — all pass
- `cargo clippy` — clean

--- shipped from a mass of mass-less fermions mass-producing code

🤖 Generated with [Claude Code](https://claude.com/claude-code)