### PR TITLE
feat(filter): condense cargo clippy error output with grouping

### DIFF
--- a/crates/tokf-cli/filters/cargo/clippy.toml
+++ b/crates/tokf-cli/filters/cargo/clippy.toml
@@ -1,12 +1,85 @@
 command = "cargo clippy"
+strip_empty_lines = true
+
+# First, skip removes noise summary lines.
+# Then, keep retains only the essential diagnostic lines:
+#   error: <description>         — what went wrong
+#   warning: <description>       — lint warnings
+#   --> <file>:<line>:<col>      — where it is
+#   help: <suggestion>           — how to fix it
+# Everything else (source code, gutter lines, URLs, notes) is stripped.
+# Finally, the Lua script groups identical errors together.
 skip = [
-  "^   Compiling ",
-  "^    Checking ",
-  "^     Locking ",
+  "^error: could not compile",
+  "^warning: build failed",
+  "^warning: \\d+ warnings?\\b",
 ]
+
+keep = [
+  "^error:",
+  "^warning:",
+  "^\\s+-->",
+  "^help:",
+]
+
+[lua_script]
+lang = "luau"
+source = '''
+if exit_code == 0 then return nil end
+
+-- Parse keep-filtered output into error/warning blocks
+local blocks = {}
+local cur = nil
+for line in output:gmatch("[^\n]+") do
+  if line:match("^error:") or line:match("^warning:") then
+    if cur then table.insert(blocks, cur) end
+    cur = { desc = line, locs = {}, help = nil }
+  elseif cur and line:match("^%s+%-%->[%s]") then
+    local loc = line:match("^%s+%-%->[%s]+(.+)")
+    if loc then table.insert(cur.locs, loc) end
+  elseif cur and line:match("^help:") then
+    cur.help = line
+  end
+end
+if cur then table.insert(blocks, cur) end
+if #blocks == 0 then return nil end
+
+-- Group by (description, help text)
+local groups = {}
+local order = {}
+for _, b in ipairs(blocks) do
+  local key = b.desc .. "|" .. (b.help or "")
+  if not groups[key] then
+    groups[key] = { desc = b.desc, help = b.help, locs = {}, count = 0 }
+    table.insert(order, key)
+  end
+  groups[key].count = groups[key].count + 1
+  for _, loc in ipairs(b.locs) do
+    table.insert(groups[key].locs, loc)
+  end
+end
+
+-- Format grouped output
+local out = {}
+for _, key in ipairs(order) do
+  local g = groups[key]
+  if g.count > 1 then
+    table.insert(out, g.desc .. " (" .. g.count .. " occurrences)")
+  else
+    table.insert(out, g.desc)
+  end
+  for _, loc in ipairs(g.locs) do
+    table.insert(out, "  --> " .. loc)
+  end
+  if g.help then
+    table.insert(out, g.help)
+  end
+end
+
+return table.concat(out, "\n")
+'''
 
 [on_success]
 output = "ok ✓ no warnings"
 
 [on_failure]
-tail = 30

--- a/crates/tokf-cli/filters/cargo/clippy_test/clippy_full.toml
+++ b/crates/tokf-cli/filters/cargo/clippy_test/clippy_full.toml
@@ -1,0 +1,34 @@
+name = "full clippy output grouped by lint rule"
+fixture = "clippy_full.txt"
+exit_code = 1
+
+# Duplicate pub(crate) errors are grouped
+[[expect]]
+contains = "error: pub(crate) module inside private module (2 occurrences)"
+
+[[expect]]
+contains = "error: pub(crate) function inside private module (2 occurrences)"
+
+# Unique errors shown without count
+[[expect]]
+contains = "error: redundant clone"
+
+[[expect]]
+contains = "error: this function has too many lines (80/60)"
+
+[[expect]]
+contains = "error: called `map(<f>).unwrap_or_else(<g>)`"
+
+# Locations preserved
+[[expect]]
+contains = "--> crates/tokf-server/src/routes/filters/mod.rs:1:1"
+
+# Noise is stripped
+[[expect]]
+not_contains = "Checking"
+
+[[expect]]
+not_contains = "could not compile"
+
+[[expect]]
+not_contains = "for further information visit"

--- a/crates/tokf-cli/filters/cargo/clippy_test/error_multi.toml
+++ b/crates/tokf-cli/filters/cargo/clippy_test/error_multi.toml
@@ -1,0 +1,45 @@
+name = "multiple errors grouped by lint rule"
+fixture = "error_multi.txt"
+exit_code = 1
+
+# Repeated errors are grouped with occurrence counts
+[[expect]]
+contains = "error: unnecessary hashes around raw string literal (9 occurrences)"
+
+[[expect]]
+contains = "error: this could be a `const fn` (5 occurrences)"
+
+[[expect]]
+contains = "error: casting `usize` to `f64` causes a loss of precision"
+
+[[expect]]
+contains = "error: this `if` statement can be collapsed (2 occurrences)"
+
+# Locations and help are preserved
+[[expect]]
+contains = "--> src/rules/text/inline_comments.rs:364:20"
+
+[[expect]]
+contains = "help: remove all the hashes around the string literal"
+
+[[expect]]
+contains = "help: make the function `const`"
+
+[[expect]]
+contains = "error: this function has too many lines (88/60)"
+
+# Noise is stripped
+[[expect]]
+not_contains = "Checking"
+
+[[expect]]
+not_contains = "could not compile"
+
+[[expect]]
+not_contains = "for further information visit"
+
+[[expect]]
+not_contains = "implied by"
+
+[[expect]]
+not_contains = "to override"

--- a/crates/tokf-cli/filters/cargo/clippy_test/error_multi.txt
+++ b/crates/tokf-cli/filters/cargo/clippy_test/error_multi.txt
@@ -1,0 +1,402 @@
+    Checking cargo-lint-extra v0.1.0 (/Users/mdp/src/github.com/mpecan/cargo-lint-extra)
+error: unnecessary hashes around raw string literal
+   --> src/rules/text/inline_comments.rs:364:20
+    |
+364 |           let code = r#"
+    |  ____________________^
+365 | | fn over_commented() {
+...   |
+372 | | "#;
+    | |__^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#needless_raw_string_hashes
+    = note: `-D clippy::needless-raw-string-hashes` implied by `-D warnings`
+    = help: to override `-D warnings` add `#[allow(clippy::needless_raw_string_hashes)]`
+help: remove all the hashes around the string literal
+    |
+364 ~         let code = r"
+365 | fn over_commented() {
+...
+371 | }
+372 ~ ";
+    |
+
+error: unnecessary hashes around raw string literal
+   --> src/rules/text/inline_comments.rs:383:20
+    |
+383 |           let code = r#"
+    |  ____________________^
+384 | | fn many_consecutive() {
+385 | |     let x = 1;
+...   |
+394 | | "#;
+    | |__^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#needless_raw_string_hashes
+help: remove all the hashes around the string literal
+    |
+383 ~         let code = r"
+384 | fn many_consecutive() {
+...
+393 | }
+394 ~ ";
+    |
+
+error: unnecessary hashes around raw string literal
+   --> src/rules/text/inline_comments.rs:450:20
+    |
+450 |           let code = r#"
+    |  ____________________^
+451 | | fn outer() {
+452 | |     let a = 1;
+453 | |     let b = 2;
+...   |
+465 | | "#;
+    | |__^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#needless_raw_string_hashes
+help: remove all the hashes around the string literal
+    |
+450 ~         let code = r"
+451 | fn outer() {
+...
+464 | }
+465 ~ ";
+    |
+
+error: unnecessary hashes around raw string literal
+   --> src/rules/text/inline_comments.rs:485:20
+    |
+485 |           let code = r#"
+    |  ____________________^
+486 | | fn with_closure() {
+487 | |     let f = || {
+488 | |         1 + 2
+...   |
+494 | | "#;
+    | |__^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#needless_raw_string_hashes
+help: remove all the hashes around the string literal
+    |
+485 ~         let code = r"
+486 | fn with_closure() {
+...
+493 | }
+494 ~ ";
+    |
+
+error: unnecessary hashes around raw string literal
+   --> src/rules/text/inline_comments.rs:523:20
+    |
+523 |           let code = r#"
+    |  ____________________^
+524 | | fn block_comment_braces() {
+525 | |     /* { } */
+526 | |     let x = 1;
+...   |
+530 | | "#;
+    | |__^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#needless_raw_string_hashes
+help: remove all the hashes around the string literal
+    |
+523 ~         let code = r"
+524 | fn block_comment_braces() {
+...
+529 | }
+530 ~ ";
+    |
+
+error: unnecessary hashes around raw string literal
+   --> src/rules/text/inline_comments.rs:541:20
+    |
+541 |           let code = r#"
+    |  ____________________^
+542 | | fn tiny() {
+...   |
+547 | | "#;
+    | |__^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#needless_raw_string_hashes
+help: remove all the hashes around the string literal
+    |
+541 ~         let code = r"
+542 | fn tiny() {
+...
+546 | }
+547 ~ ";
+    |
+
+error: unnecessary hashes around raw string literal
+   --> src/rules/text/inline_comments.rs:558:20
+    |
+558 |           let code = r#"
+    |  ____________________^
+559 | | trait Foo {
+560 | |     fn bar();
+561 | |     fn baz(x: i32) -> i32;
+562 | | }
+563 | | "#;
+    | |__^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#needless_raw_string_hashes
+help: remove all the hashes around the string literal
+    |
+558 ~         let code = r"
+559 | trait Foo {
+...
+562 | }
+563 ~ ";
+    |
+
+error: unnecessary hashes around raw string literal
+   --> src/rules/text/inline_comments.rs:574:20
+    |
+574 |           let code = r#"
+    |  ____________________^
+575 | | fn multi_line(
+576 | |     x: i32,
+577 | |     y: i32,
+...   |
+585 | | "#;
+    | |__^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#needless_raw_string_hashes
+help: remove all the hashes around the string literal
+    |
+574 ~         let code = r"
+575 | fn multi_line(
+...
+584 | }
+585 ~ ";
+    |
+
+error: unnecessary hashes around raw string literal
+   --> src/rules/text/inline_comments.rs:596:20
+    |
+596 |           let code = r#"
+    |  ____________________^
+597 | | struct Foo;
+598 | |
+599 | | impl Foo {
+...   |
+607 | | "#;
+    | |__^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#needless_raw_string_hashes
+help: remove all the hashes around the string literal
+    |
+596 ~         let code = r"
+597 | struct Foo;
+...
+606 | }
+607 ~ ";
+    |
+
+error: this could be a `const fn`
+  --> src/rules/text/inline_comments.rs:13:5
+   |
+13 | /     pub fn new(config: &InlineCommentsConfig) -> Self {
+14 | |         Self {
+15 | |             level: config.level,
+16 | |             max_ratio: config.max_ratio,
+...  |
+19 | |     }
+   | |_____^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#missing_const_for_fn
+   = note: `-D clippy::missing-const-for-fn` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_const_for_fn)]`
+help: make the function `const`
+   |
+13 |     pub const fn new(config: &InlineCommentsConfig) -> Self {
+   |         +++++
+
+error: this could be a `const fn`
+  --> src/rules/text/inline_comments.rs:33:5
+   |
+33 | /     fn new(fn_line: usize, entry_depth: usize) -> Self {
+34 | |         Self {
+35 | |             fn_line,
+36 | |             entry_depth,
+...  |
+43 | |     }
+   | |_____^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#missing_const_for_fn
+help: make the function `const`
+   |
+33 |     const fn new(fn_line: usize, entry_depth: usize) -> Self {
+   |     +++++
+
+error: this could be a `const fn`
+  --> src/rules/text/inline_comments.rs:45:5
+   |
+45 | /     fn add_comment(&mut self, line_number: usize, max_consecutive: usize) {
+46 | |         self.comment_lines += 1;
+47 | |         self.consecutive_comments += 1;
+48 | |         if self.consecutive_comments > self.max_consecutive_comments {
+...  |
+54 | |     }
+   | |_____^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#missing_const_for_fn
+help: make the function `const`
+   |
+45 |     const fn add_comment(&mut self, line_number: usize, max_consecutive: usize) {
+   |     +++++
+
+error: this could be a `const fn`
+  --> src/rules/text/inline_comments.rs:56:5
+   |
+56 | /     fn add_code(&mut self) {
+57 | |         self.code_lines += 1;
+58 | |         self.consecutive_comments = 0;
+59 | |     }
+   | |_____^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#missing_const_for_fn
+help: make the function `const`
+   |
+56 |     const fn add_code(&mut self) {
+   |     +++++
+
+error: this could be a `const fn`
+  --> src/rules/text/inline_comments.rs:61:5
+   |
+61 | /     fn total_meaningful(&self) -> usize {
+62 | |         self.comment_lines + self.code_lines
+63 | |     }
+   | |_____^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#missing_const_for_fn
+help: make the function `const`
+   |
+61 |     const fn total_meaningful(&self) -> usize {
+   |     +++++
+
+error: casting `usize` to `f64` causes a loss of precision on targets with 64-bit wide pointers (`usize` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
+  --> src/rules/text/inline_comments.rs:70:13
+   |
+70 |             self.comment_lines as f64 / total as f64
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#cast_precision_loss
+   = note: `-D clippy::cast-precision-loss` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::cast_precision_loss)]`
+
+error: casting `usize` to `f64` causes a loss of precision on targets with 64-bit wide pointers (`usize` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
+  --> src/rules/text/inline_comments.rs:70:41
+   |
+70 |             self.comment_lines as f64 / total as f64
+   |                                         ^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#cast_precision_loss
+
+error: this `if` statement can be collapsed
+   --> src/rules/text/inline_comments.rs:117:17
+    |
+117 | /                 if let Some(scope) = scope_stack.last() {
+118 | |                     if brace_depth == scope.entry_depth {
+119 | |                         let scope = scope_stack.pop().unwrap();
+120 | |                         self.evaluate_scope(&scope, file, &mut diagnostics);
+121 | |                     }
+122 | |                 }
+    | |_________________^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#collapsible_if
+    = note: `-D clippy::collapsible-if` implied by `-D warnings`
+    = help: to override `-D warnings` add `#[allow(clippy::collapsible_if)]`
+help: collapse nested if block
+    |
+117 ~                 if let Some(scope) = scope_stack.last()
+118 ~                     && brace_depth == scope.entry_depth {
+119 |                         let scope = scope_stack.pop().unwrap();
+120 |                         self.evaluate_scope(&scope, file, &mut diagnostics);
+121 ~                     }
+    |
+
+error: used `unwrap()` on an `Option` value
+   --> src/rules/text/inline_comments.rs:119:37
+    |
+119 |                         let scope = scope_stack.pop().unwrap();
+    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: if this value is `None`, it will panic
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#unwrap_used
+    = note: requested on the command line with `-D clippy::unwrap-used`
+
+error: casting `f64` to `usize` may truncate the value
+   --> src/rules/text/inline_comments.rs:150:23
+    |
+150 |             let pct = (ratio * 100.0).round() as usize;
+    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#cast_possible_truncation
+    = note: `-D clippy::cast-possible-truncation` implied by `-D warnings`
+    = help: to override `-D warnings` add `#[allow(clippy::cast_possible_truncation)]`
+
+error: casting `f64` to `usize` may lose the sign of the value
+   --> src/rules/text/inline_comments.rs:150:23
+    |
+150 |             let pct = (ratio * 100.0).round() as usize;
+    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#cast_sign_loss
+    = note: `-D clippy::cast-sign-loss` implied by `-D warnings`
+    = help: to override `-D warnings` add `#[allow(clippy::cast_sign_loss)]`
+
+error: casting `f64` to `usize` may truncate the value
+   --> src/rules/text/inline_comments.rs:151:27
+    |
+151 |             let max_pct = (self.max_ratio * 100.0).round() as usize;
+    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#cast_possible_truncation
+
+error: casting `f64` to `usize` may lose the sign of the value
+   --> src/rules/text/inline_comments.rs:151:27
+    |
+151 |             let max_pct = (self.max_ratio * 100.0).round() as usize;
+    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#cast_sign_loss
+
+error: this `if` statement can be collapsed
+   --> src/rules/text/inline_comments.rs:167:9
+    |
+167 | /         if scope.max_consecutive_comments > self.max_consecutive {
+168 | |             if let Some(run_start) = scope.first_long_run_line {
+169 | |                 diagnostics.push(
+170 | |                     Diagnostic::new(
+...   |
+182 | |         }
+    | |_________^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#collapsible_if
+help: collapse nested if block
+    |
+167 ~         if scope.max_consecutive_comments > self.max_consecutive
+168 ~             && let Some(run_start) = scope.first_long_run_line {
+169 |                 diagnostics.push(
+...
+180 |                 );
+181 ~             }
+    |
+
+error: this function has too many lines (88/60)
+   --> src/rules/text/inline_comments.rs:216:1
+    |
+216 | fn analyze_line(line: &str) -> (usize, usize, bool, bool) {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#too_many_lines
+    = note: `-D clippy::too-many-lines` implied by `-D warnings`
+    = help: to override `-D warnings` add `#[allow(clippy::too_many_lines)]`
+
+error: could not compile `cargo-lint-extra` (lib) due to 15 previous errors
+warning: build failed, waiting for other jobs to finish...
+error: could not compile `cargo-lint-extra` (lib test) due to 24 previous errors

--- a/crates/tokf-cli/filters/cargo/clippy_test/warning.toml
+++ b/crates/tokf-cli/filters/cargo/clippy_test/warning.toml
@@ -1,6 +1,18 @@
-name = "warnings show lint output"
+name = "single warning shows condensed diagnostic"
 fixture = "warning.txt"
 exit_code = 1
 
 [[expect]]
-contains = "warning"
+contains = "warning: unused variable"
+
+[[expect]]
+contains = "--> src/main.rs:3:5"
+
+[[expect]]
+not_contains = "Checking"
+
+[[expect]]
+not_contains = "could not compile"
+
+[[expect]]
+not_contains = "= note:"


### PR DESCRIPTION
## Summary
- Replace the naive `tail = 30` clippy failure handler with a three-stage pipeline: **skip** noise summaries → **keep** only diagnostic lines (error, location, help) → **Lua grouping** of identical errors with occurrence counts
- Achieves **86.9% token reduction** on a real-world 24-error clippy output (3486 → 457 tokens, 402 → 35 lines)
- Adds 3 new declarative test cases (single warning, multi-error grouping, full clippy output) — all 125 stdlib filter tests pass

### Before (tail = 30)
The model received a truncated blob of verbose clippy output including source code snippets, gutter lines, URLs, and redundant notes — often causing it to retry `cargo clippy` repeatedly.

### After
```
error: unnecessary hashes around raw string literal (9 occurrences)
  --> src/rules/text/inline_comments.rs:364:20
  --> src/rules/text/inline_comments.rs:383:20
  ...
help: remove all the hashes around the string literal
error: this could be a `const fn` (5 occurrences)
  --> src/rules/text/inline_comments.rs:13:5
  --> src/rules/text/inline_comments.rs:33:5
  ...
help: make the function `const`
error: this function has too many lines (88/60)
  --> src/rules/text/inline_comments.rs:216:1
```

## Test plan
- [x] `tokf verify cargo/clippy` — all 4 cases pass (success, single warning, multi-error, full output)
- [x] `tokf verify` — all 125 stdlib filter tests pass
- [x] `cargo test --workspace` — 1690 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)