### PR TITLE
feat(filter): add passthrough_args to skip filters on flag conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ collapse_empty_lines = true   # collapse consecutive blank lines into one
 show_history_hint = true      # append a hint line pointing to the full output in history
 inject_path = true            # inject shims into PATH so sub-processes (e.g. git hooks) are filtered
 
+passthrough_args = ["--watch", "--web", "-w"]  # skip filter when user passes these flags
+
 # Lua escape hatch — for logic TOML can't express (see Lua Escape Hatch section)
 [lua_script]
 lang = "luau"
@@ -346,6 +348,27 @@ output = "ok ✓ {2}"          # template; {output} = pre-filtered output
 
 [on_failure]                  # branch for non-zero exit
 tail = 10                     # keep the last N lines
+```
+
+## Passthrough args
+
+Some filters inject flags like `--json` or `--format` via the `run` field. When users pass conflicting flags (e.g. `--watch`), the combined command fails. The `passthrough_args` field declares flag prefixes that trigger passthrough mode — tokf skips the filter entirely and runs the original command as-is.
+
+```toml
+command = "gh pr checks *"
+run = "gh pr checks {args} --json name,state,workflow"
+passthrough_args = ["--watch", "--web", "-w"]
+```
+
+**Matching semantics**: each user arg is checked with `starts_with` against each prefix. This handles `--format=table` matching `--format`, while `-w` does **not** match `--watch` (correct — they are different flags). Short-flag prefixes like `-o` also match concatenated forms like `-oyaml` (common in tools like `kubectl`). Empty-string prefixes are ignored. When any arg matches, no `run` override is applied and no filter pipeline runs.
+
+**Variant interaction**: passthrough is checked on the resolved filter config after file-based variant detection. If a parent filter delegates to a variant via file detection, the variant's own `passthrough_args` apply. Output-pattern variants (post-execution) are not resolved when passthrough is active.
+
+Use `--verbose` to see when passthrough activates:
+
+```
+$ tokf run gh pr checks 142 --watch --verbose
+[tokf] passthrough: user args match passthrough_args, skipping filter
 ```
 
 ## Template pipes

--- a/crates/tokf-cli/filters/docker/images.toml
+++ b/crates/tokf-cli/filters/docker/images.toml
@@ -1,5 +1,6 @@
 command = "docker images"
 run = "docker images --format '{{.Repository}}:{{.Tag}}\t{{.Size}}' {args}"
+passthrough_args = ["--format"]
 skip = ["^<none>:<none>"]
 
 [lua_script]

--- a/crates/tokf-cli/filters/docker/ps.toml
+++ b/crates/tokf-cli/filters/docker/ps.toml
@@ -1,5 +1,6 @@
 command = "docker ps"
 run = "docker ps --format json {args}"
+passthrough_args = ["--format"]
 
 match_output = [
   { contains = "Cannot connect to the Docker daemon", output = "Docker daemon not running" },

--- a/crates/tokf-cli/filters/gh/issue/list.toml
+++ b/crates/tokf-cli/filters/gh/issue/list.toml
@@ -1,5 +1,6 @@
 command = "gh issue list"
 run = "gh issue list --json number,title,state,labels {args}"
+passthrough_args = ["--web", "-w"]
 
 [json]
 

--- a/crates/tokf-cli/filters/gh/issue/view.toml
+++ b/crates/tokf-cli/filters/gh/issue/view.toml
@@ -1,5 +1,6 @@
 command = "gh issue view *"
 run = "gh issue view {args} --json number,title,state,author,labels,assignees,milestone,body"
+passthrough_args = ["--web", "-w"]
 
 [json]
 

--- a/crates/tokf-cli/filters/gh/pr/checks.toml
+++ b/crates/tokf-cli/filters/gh/pr/checks.toml
@@ -1,5 +1,6 @@
 command = "gh pr checks *"
 run = "gh pr checks {args} --json name,state,workflow"
+passthrough_args = ["--watch", "--web", "-w"]
 
 [json]
 

--- a/crates/tokf-cli/filters/gh/pr/list.toml
+++ b/crates/tokf-cli/filters/gh/pr/list.toml
@@ -1,5 +1,6 @@
 command = "gh pr list"
 run = "gh pr list --json number,title,state,headRefName {args}"
+passthrough_args = ["--web", "-w"]
 
 [json]
 

--- a/crates/tokf-cli/filters/gh/pr/view.toml
+++ b/crates/tokf-cli/filters/gh/pr/view.toml
@@ -1,5 +1,6 @@
 command = "gh pr view *"
 run = "gh pr view {args} --json number,title,state,author,headRefName,baseRefName,reviewDecision,labels,assignees,milestone,body"
+passthrough_args = ["--web", "-w"]
 
 [json]
 

--- a/crates/tokf-cli/filters/git/log.toml
+++ b/crates/tokf-cli/filters/git/log.toml
@@ -6,6 +6,7 @@ command = "git log"
 
 # Override to get compact output directly from git
 run = "git log --oneline --no-decorate -n 20 {args}"
+passthrough_args = ["-p", "--patch", "--format", "--pretty", "--graph", "--stat"]
 
 # Nothing to filter — the override command already produces compact output
 # But if args include --stat or --patch, passthrough

--- a/crates/tokf-cli/filters/git/show.toml
+++ b/crates/tokf-cli/filters/git/show.toml
@@ -2,6 +2,7 @@ command = "git show"
 
 # Override: use --stat for compact summary; full diff can be thousands of lines
 run = "git show --stat {args}"
+passthrough_args = ["-p", "--patch", "--format", "--pretty"]
 
 [on_success]
 output = "{output}"

--- a/crates/tokf-cli/filters/kubectl/get/pods.toml
+++ b/crates/tokf-cli/filters/kubectl/get/pods.toml
@@ -2,6 +2,7 @@ command = ["kubectl get pods", "kubectl get pod", "kubectl get po"]
 
 # Override to get JSON output for structured extraction
 run = "kubectl get pods -o json {args}"
+passthrough_args = ["-o", "--output"]
 
 match_output = [
   { contains = "the server doesn't have a resource type", output = "Error: {line_containing}" },

--- a/crates/tokf-cli/src/commands.rs
+++ b/crates/tokf-cli/src/commands.rs
@@ -46,10 +46,21 @@ pub fn cmd_run(
         vec![]
     };
 
-    let filter_cfg = filter_match.as_ref().map(|m| &m.config);
+    let passthrough = filter_match
+        .as_ref()
+        .is_some_and(|m| m.config.should_passthrough(&remaining_args));
+    if passthrough && cli.verbose {
+        eprintln!("[tokf] passthrough: user args match passthrough_args, skipping filter");
+    }
+    let filter_cfg = if passthrough {
+        None
+    } else {
+        filter_match.as_ref().map(|m| &m.config)
+    };
     let cmd_result =
         resolve::run_command(filter_cfg, words_consumed, command_args, &remaining_args)?;
 
+    let filter_match = if passthrough { None } else { filter_match };
     let Some(filter_match) = filter_match else {
         if prefer_less && cli.verbose {
             eprintln!("[tokf] --prefer-less has no effect: no matching filter found");

--- a/crates/tokf-cli/tests/cli_run.rs
+++ b/crates/tokf-cli/tests/cli_run.rs
@@ -241,6 +241,78 @@ fn mask_exit_code_empty_output_on_failure() {
 }
 
 #[test]
+fn passthrough_args_skips_run_override() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let filters_dir = dir.path().join(".tokf/filters");
+    std::fs::create_dir_all(&filters_dir).unwrap();
+    // Filter with `run` override that would change the output, plus passthrough_args
+    std::fs::write(
+        filters_dir.join("echo.toml"),
+        r#"command = "echo"
+run = "echo FILTERED"
+passthrough_args = ["--skip"]
+
+[on_success]
+output = "FILTERED_OUTPUT"
+"#,
+    )
+    .unwrap();
+
+    // Without passthrough arg: filter applies, we get "FILTERED_OUTPUT"
+    let output = tokf()
+        .args(["run", "echo", "hello"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("FILTERED_OUTPUT"),
+        "expected filter to apply without passthrough arg, got: {stdout}"
+    );
+
+    // With passthrough arg: filter skipped, original command runs
+    let output = tokf()
+        .args(["run", "echo", "--skip", "hello"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("--skip hello"),
+        "expected original command output with passthrough, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("FILTERED"),
+        "filter should be skipped with passthrough arg, got: {stdout}"
+    );
+}
+
+#[test]
+fn passthrough_args_verbose_shows_message() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let filters_dir = dir.path().join(".tokf/filters");
+    std::fs::create_dir_all(&filters_dir).unwrap();
+    std::fs::write(
+        filters_dir.join("echo.toml"),
+        "command = \"echo\"\npassthrough_args = [\"--skip\"]\n[on_success]\noutput = \"FILTERED\"",
+    )
+    .unwrap();
+
+    let output = tokf()
+        .args(["run", "--verbose", "echo", "--skip"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("passthrough"),
+        "expected passthrough message in verbose output, got: {stderr}"
+    );
+}
+
+#[test]
 fn no_mask_exit_code_propagates_exit_code() {
     let output = tokf()
         .args([

--- a/crates/tokf-common/src/config/types.rs
+++ b/crates/tokf-common/src/config/types.rs
@@ -171,6 +171,28 @@ pub struct FilterConfig {
     /// by sub-processes (e.g. git hooks) are automatically filtered.
     #[serde(default)]
     pub inject_path: bool,
+
+    /// Argument prefixes that trigger passthrough mode (skip filter entirely).
+    ///
+    /// When any element in the user's remaining args starts with any prefix in
+    /// this list, tokf runs the original command as-is without applying the
+    /// `run` override or filter pipeline.
+    #[serde(default)]
+    pub passthrough_args: Vec<String>,
+}
+
+impl FilterConfig {
+    /// Returns `true` if any user arg matches a prefix in `passthrough_args`.
+    pub fn should_passthrough(&self, remaining_args: &[String]) -> bool {
+        if self.passthrough_args.is_empty() || remaining_args.is_empty() {
+            return false;
+        }
+        remaining_args.iter().any(|arg| {
+            self.passthrough_args
+                .iter()
+                .any(|prefix| !prefix.is_empty() && arg.starts_with(prefix.as_str()))
+        })
+    }
 }
 
 /// A pipeline step that runs a sub-command and captures its output.
@@ -489,4 +511,107 @@ pub struct JsonFieldExtract {
     /// Variable name for the extracted value.
     #[serde(rename = "as")]
     pub as_name: String,
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(toml: &str) -> FilterConfig {
+        toml::from_str(toml).unwrap()
+    }
+
+    fn s(v: &str) -> String {
+        v.to_string()
+    }
+
+    #[test]
+    fn passthrough_empty_list_never_triggers() {
+        let cfg = parse(r#"command = "gh pr checks *""#);
+        assert!(!cfg.should_passthrough(&[s("--watch")]));
+    }
+
+    #[test]
+    fn passthrough_exact_match() {
+        let cfg = parse(
+            r#"
+command = "gh pr checks *"
+passthrough_args = ["--watch", "--web", "-w"]
+"#,
+        );
+        assert!(cfg.should_passthrough(&[s("142"), s("--watch")]));
+    }
+
+    #[test]
+    fn passthrough_prefix_match() {
+        let cfg = parse(
+            r#"
+command = "docker ps"
+passthrough_args = ["--format"]
+"#,
+        );
+        assert!(cfg.should_passthrough(&[s("--format=table")]));
+    }
+
+    #[test]
+    fn passthrough_short_flag_does_not_match_long() {
+        let cfg = parse(
+            r#"
+command = "gh pr checks *"
+passthrough_args = ["--watch"]
+"#,
+        );
+        assert!(!cfg.should_passthrough(&[s("-w")]));
+    }
+
+    #[test]
+    fn passthrough_no_match_returns_false() {
+        let cfg = parse(
+            r#"
+command = "gh pr checks *"
+passthrough_args = ["--watch", "--web"]
+"#,
+        );
+        assert!(!cfg.should_passthrough(&[s("142"), s("--json")]));
+    }
+
+    #[test]
+    fn passthrough_empty_args_never_triggers() {
+        let cfg = parse(
+            r#"
+command = "gh pr checks *"
+passthrough_args = ["--watch"]
+"#,
+        );
+        assert!(!cfg.should_passthrough(&[]));
+    }
+
+    #[test]
+    fn passthrough_args_deserializes_from_toml() {
+        let cfg = parse(
+            r#"
+command = "gh pr checks *"
+passthrough_args = ["--watch", "--web", "-w"]
+"#,
+        );
+        assert_eq!(cfg.passthrough_args, vec!["--watch", "--web", "-w"]);
+    }
+
+    #[test]
+    fn passthrough_args_defaults_to_empty() {
+        let cfg = parse(r#"command = "git push""#);
+        assert!(cfg.passthrough_args.is_empty());
+    }
+
+    #[test]
+    fn passthrough_empty_string_prefix_ignored() {
+        let cfg = parse(
+            r#"
+command = "test"
+passthrough_args = [""]
+"#,
+        );
+        assert!(!cfg.should_passthrough(&[s("--anything")]));
+    }
 }

--- a/crates/tokf-common/src/safety/checks.rs
+++ b/crates/tokf-common/src/safety/checks.rs
@@ -142,6 +142,18 @@ impl SafetyCheck for HiddenUnicodeCheck {
                 });
             }
         }
+        for prefix in &config.passthrough_args {
+            for c in find_hidden_unicode(prefix) {
+                warnings.push(SafetyWarning {
+                    kind: WarningKind::HiddenUnicode,
+                    message: format!(
+                        "passthrough_args prefix contains hidden Unicode character U+{:04X}",
+                        c as u32
+                    ),
+                    detail: Some(format!("U+{:04X}", c as u32)),
+                });
+            }
+        }
         warnings
     }
 

--- a/crates/tokf-common/src/safety/mod.rs
+++ b/crates/tokf-common/src/safety/mod.rs
@@ -186,6 +186,7 @@ mod tests {
             variant: vec![],
             show_history_hint: false,
             inject_path: false,
+            passthrough_args: vec![],
         }
     }
 
@@ -311,6 +312,20 @@ mod tests {
         config.command = CommandPattern::Single("git\u{200B}push".to_string());
         let report = check_config(&config);
         assert!(!report.passed);
+    }
+
+    #[test]
+    fn config_detects_hidden_unicode_in_passthrough_args() {
+        let mut config = minimal_config();
+        config.passthrough_args = vec!["--watch\u{200B}".to_string()];
+        let report = check_config(&config);
+        assert!(!report.passed);
+        assert_eq!(report.warnings[0].kind, WarningKind::HiddenUnicode);
+        assert!(
+            report.warnings[0]
+                .message
+                .contains("passthrough_args prefix")
+        );
     }
 
     #[test]

--- a/crates/tokf-filter/src/filter/tests_json.rs
+++ b/crates/tokf-filter/src/filter/tests_json.rs
@@ -35,6 +35,7 @@ fn default_config() -> FilterConfig {
         variant: vec![],
         show_history_hint: false,
         inject_path: false,
+        passthrough_args: vec![],
     }
 }
 

--- a/docs/writing-filters.md
+++ b/docs/writing-filters.md
@@ -63,6 +63,8 @@ collapse_empty_lines = true   # collapse consecutive blank lines into one
 show_history_hint = true      # append a hint line pointing to the full output in history
 inject_path = true            # inject shims into PATH so sub-processes (e.g. git hooks) are filtered
 
+passthrough_args = ["--watch", "--web", "-w"]  # skip filter when user passes these flags
+
 # Lua escape hatch — for logic TOML can't express (see Lua Escape Hatch section)
 [lua_script]
 lang = "luau"
@@ -78,6 +80,27 @@ output = "ok ✓ {2}"          # template; {output} = pre-filtered output
 
 [on_failure]                  # branch for non-zero exit
 tail = 10                     # keep the last N lines
+```
+
+## Passthrough args
+
+Some filters inject flags like `--json` or `--format` via the `run` field. When users pass conflicting flags (e.g. `--watch`), the combined command fails. The `passthrough_args` field declares flag prefixes that trigger passthrough mode — tokf skips the filter entirely and runs the original command as-is.
+
+```toml
+command = "gh pr checks *"
+run = "gh pr checks {args} --json name,state,workflow"
+passthrough_args = ["--watch", "--web", "-w"]
+```
+
+**Matching semantics**: each user arg is checked with `starts_with` against each prefix. This handles `--format=table` matching `--format`, while `-w` does **not** match `--watch` (correct — they are different flags). Short-flag prefixes like `-o` also match concatenated forms like `-oyaml` (common in tools like `kubectl`). Empty-string prefixes are ignored. When any arg matches, no `run` override is applied and no filter pipeline runs.
+
+**Variant interaction**: passthrough is checked on the resolved filter config after file-based variant detection. If a parent filter delegates to a variant via file detection, the variant's own `passthrough_args` apply. Output-pattern variants (post-execution) are not resolved when passthrough is active.
+
+Use `--verbose` to see when passthrough activates:
+
+```
+$ tokf run gh pr checks 142 --watch --verbose
+[tokf] passthrough: user args match passthrough_args, skipping filter
 ```
 
 ## Template pipes


### PR DESCRIPTION
## Summary

- Adds `passthrough_args` field to `FilterConfig` — a list of arg prefixes that trigger passthrough mode, skipping the `run` override and filter pipeline entirely when user args conflict with injected flags (e.g. `--json`, `--format`)
- Wires passthrough check into `cmd_run` before command execution; guards against empty-string prefixes
- Adds `passthrough_args` to 10 stdlib filters: `gh pr/issue checks/list/view`, `docker ps/images`, `kubectl get pods`, `git log`, `git show`
- Adds hidden Unicode scanning for `passthrough_args` in the safety checker (`tokf verify --safety`)
- Documents field, prefix matching semantics, short-flag behavior, and variant interaction in `docs/writing-filters.md`

## Motivation

The `gh pr checks` filter injects `--json name,state,workflow` via its `run` field. When users pass `--watch`, the command becomes `gh pr checks 142 --watch --json ...` which `gh` rejects. This affects 10 filters that inject structured output flags. `passthrough_args` lets filter authors declare which user flags should cause tokf to step aside.

## Test plan

- [x] 9 unit tests for `should_passthrough()` — empty list, exact match, prefix match, short vs long flag, no match, empty args, deserialization, default, empty-string guard
- [x] 2 integration tests in `cli_run.rs` — verifies filter applies normally, then is skipped with matching arg; verifies verbose passthrough message
- [x] 1 safety test — hidden Unicode detection in `passthrough_args` prefixes
- [x] `cargo test --workspace` — 1777 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `tokf verify --require-all` — 126/126 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)