### PR TITLE
docs(filter): add description to all 48 built-in filters

### DIFF
--- a/crates/tokf-cli/filters/cargo/build.toml
+++ b/crates/tokf-cli/filters/cargo/build.toml
@@ -1,4 +1,5 @@
 command = "cargo build"
+description = "Strip compile progress; show warnings and errors only"
 skip = [
   "^   Compiling ",
   "^    Checking ",

--- a/crates/tokf-cli/filters/cargo/check.toml
+++ b/crates/tokf-cli/filters/cargo/check.toml
@@ -1,4 +1,5 @@
 command = "cargo check"
+description = "Strip compile progress; show diagnostics only"
 skip = [
   "^\\s*Compiling ",
   "^\\s*Downloading ",

--- a/crates/tokf-cli/filters/cargo/clippy.toml
+++ b/crates/tokf-cli/filters/cargo/clippy.toml
@@ -1,4 +1,5 @@
 command = "cargo clippy"
+description = "Group lint warnings by file with counts"
 strip_empty_lines = true
 
 # First, skip removes noise summary lines.

--- a/crates/tokf-cli/filters/cargo/fmt.toml
+++ b/crates/tokf-cli/filters/cargo/fmt.toml
@@ -1,4 +1,5 @@
 command = "cargo fmt"
+description = "Confirm ok or list files needing formatting"
 
 # Auto-fixable: formatting diffs detected by "Diff in " header from rustfmt.
 # Shows file list extracted via template pipe from raw output.

--- a/crates/tokf-cli/filters/cargo/install.toml
+++ b/crates/tokf-cli/filters/cargo/install.toml
@@ -1,4 +1,5 @@
 command = "cargo install *"
+description = "Strip compile progress; show installed binary name"
 skip = [
   "^\\s*Compiling ",
   "^\\s*Downloading ",

--- a/crates/tokf-cli/filters/cargo/test.toml
+++ b/crates/tokf-cli/filters/cargo/test.toml
@@ -4,6 +4,7 @@
 # Filtered (fail): failure details + summary (no truncation)
 
 command = "cargo test"
+description = "Aggregate test results into pass/fail/ignore summary per suite"
 strip_ansi = true
 
 skip = [

--- a/crates/tokf-cli/filters/docker/build.toml
+++ b/crates/tokf-cli/filters/docker/build.toml
@@ -1,4 +1,5 @@
 command = ["docker build", "docker buildx build"]
+description = "Strip layer transfer noise; show build steps and errors"
 skip = [
   "^ +=> +=> [a-z]",      # Skip transferring, fetching, extracting
   "^ +=> +\\[internal\\]", # Skip metadata loading (noise)

--- a/crates/tokf-cli/filters/docker/compose.toml
+++ b/crates/tokf-cli/filters/docker/compose.toml
@@ -1,4 +1,5 @@
 command = ["docker compose", "docker-compose"]
+description = "Strip container lifecycle noise; show service output"
 skip = [
   "^ +⠿ (Network|Container|Volume|Config|Secret) .* (Created|Starting|Started|Healthy)",
   "^Attaching to ",

--- a/crates/tokf-cli/filters/docker/images.toml
+++ b/crates/tokf-cli/filters/docker/images.toml
@@ -1,4 +1,5 @@
 command = "docker images"
+description = "Compact repo:tag and size listing; hide dangling images"
 run = "docker images --format '{{.Repository}}:{{.Tag}}\t{{.Size}}' {args}"
 passthrough_args = ["--format"]
 skip = ["^<none>:<none>"]

--- a/crates/tokf-cli/filters/docker/ps.toml
+++ b/crates/tokf-cli/filters/docker/ps.toml
@@ -1,4 +1,5 @@
 command = "docker ps"
+description = "Structured JSON extraction of container name, image, state, and ports"
 run = "docker ps --format json {args}"
 passthrough_args = ["--format"]
 

--- a/crates/tokf-cli/filters/eslint/check.toml
+++ b/crates/tokf-cli/filters/eslint/check.toml
@@ -1,4 +1,5 @@
 command = "eslint"
+description = "Strip summary counts; show lint errors with file locations"
 strip_ansi = true
 skip = [
   "^\\s*$",

--- a/crates/tokf-cli/filters/firebase/deploy.toml
+++ b/crates/tokf-cli/filters/firebase/deploy.toml
@@ -1,4 +1,5 @@
 command = ["firebase deploy", "npx firebase deploy"]
+description = "Strip info/debug lines; show deploy targets and errors"
 strip_ansi = true
 skip = [
   "^\\s*$",

--- a/crates/tokf-cli/filters/gh/issue/list.toml
+++ b/crates/tokf-cli/filters/gh/issue/list.toml
@@ -1,4 +1,5 @@
 command = "gh issue list"
+description = "Structured JSON extraction of issue number, title, state, and labels"
 run = "gh issue list --json number,title,state,labels {args}"
 passthrough_args = ["--web", "-w"]
 

--- a/crates/tokf-cli/filters/gh/issue/view.toml
+++ b/crates/tokf-cli/filters/gh/issue/view.toml
@@ -1,4 +1,5 @@
 command = "gh issue view *"
+description = "Structured JSON extraction of issue details with body"
 run = "gh issue view {args} --json number,title,state,author,labels,assignees,milestone,body"
 passthrough_args = ["--web", "-w"]
 

--- a/crates/tokf-cli/filters/gh/pr/checks.toml
+++ b/crates/tokf-cli/filters/gh/pr/checks.toml
@@ -1,4 +1,5 @@
 command = "gh pr checks *"
+description = "Structured JSON extraction of CI check names and status"
 run = "gh pr checks {args} --json name,state,workflow"
 passthrough_args = ["--watch", "--web", "-w"]
 

--- a/crates/tokf-cli/filters/gh/pr/list.toml
+++ b/crates/tokf-cli/filters/gh/pr/list.toml
@@ -1,4 +1,5 @@
 command = "gh pr list"
+description = "Structured JSON extraction of PR number, title, state, and branch"
 run = "gh pr list --json number,title,state,headRefName {args}"
 passthrough_args = ["--web", "-w"]
 

--- a/crates/tokf-cli/filters/gh/pr/view.toml
+++ b/crates/tokf-cli/filters/gh/pr/view.toml
@@ -1,4 +1,5 @@
 command = "gh pr view *"
+description = "Structured JSON extraction of PR details with review status and body"
 run = "gh pr view {args} --json number,title,state,author,headRefName,baseRefName,reviewDecision,labels,assignees,milestone,body"
 passthrough_args = ["--web", "-w"]
 

--- a/crates/tokf-cli/filters/git/add.toml
+++ b/crates/tokf-cli/filters/git/add.toml
@@ -3,6 +3,7 @@
 # Filtered: "ok ✓" or error
 
 command = "git add"
+description = "Strip noise; confirm ok or show errors"
 
 match_output = [
   { contains = "fatal:", output = "✗ {line_containing}" },

--- a/crates/tokf-cli/filters/git/commit.toml
+++ b/crates/tokf-cli/filters/git/commit.toml
@@ -3,6 +3,7 @@
 # Filtered: "ok ✓ abc1234"
 
 command = "git commit"
+description = "Extract short SHA from commit output"
 inject_path = true
 
 [on_success]

--- a/crates/tokf-cli/filters/git/diff.toml
+++ b/crates/tokf-cli/filters/git/diff.toml
@@ -3,6 +3,7 @@
 # Filtered: compact stat summary (files changed + insertions/deletions)
 
 command = "git diff"
+description = "Show compact --stat summary instead of full diff"
 
 # Override: use --stat for compact summary output
 run = "git diff --stat {args}"

--- a/crates/tokf-cli/filters/git/log.toml
+++ b/crates/tokf-cli/filters/git/log.toml
@@ -3,6 +3,7 @@
 # Filtered: one-line-per-commit format
 
 command = "git log"
+description = "Show one-line-per-commit format, last 20 entries"
 
 # Override to get compact output directly from git
 run = "git log --oneline --no-decorate -n 20 {args}"

--- a/crates/tokf-cli/filters/git/push.toml
+++ b/crates/tokf-cli/filters/git/push.toml
@@ -3,6 +3,7 @@
 # Filtered: "ok ✓ main" (1 line)
 
 command = "git push"
+description = "Strip transfer noise; show branch name or rejection details"
 inject_path = true
 
 # Check full output for special cases first

--- a/crates/tokf-cli/filters/git/show.toml
+++ b/crates/tokf-cli/filters/git/show.toml
@@ -1,4 +1,5 @@
 command = "git show"
+description = "Show --stat summary instead of full patch"
 
 # Override: use --stat for compact summary; full diff can be thousands of lines
 run = "git show --stat {args}"

--- a/crates/tokf-cli/filters/git/status.toml
+++ b/crates/tokf-cli/filters/git/status.toml
@@ -3,6 +3,7 @@
 # Filtered: branch header transformed to name [±N]; file lines passed through unchanged
 
 command = "git status"
+description = "Compact porcelain format with branch info"
 
 # Override: use porcelain for reliable machine parsing
 run = "git status --porcelain -b"

--- a/crates/tokf-cli/filters/go/build.toml
+++ b/crates/tokf-cli/filters/go/build.toml
@@ -1,4 +1,5 @@
 command = "go build"
+description = "Show only error locations; confirm ok on success"
 keep = ["\\.go:\\d+"]
 
 [on_success]

--- a/crates/tokf-cli/filters/go/test.toml
+++ b/crates/tokf-cli/filters/go/test.toml
@@ -1,4 +1,5 @@
 command = "go test"
+description = "Strip per-test RUN/PASS noise; show failures and summary"
 skip = ["^=== RUN ", "^=== PAUSE ", "^=== CONT ", "--- PASS:", "^PASS$", "^\\?\\s+"]
 
 [on_success]

--- a/crates/tokf-cli/filters/go/vet.toml
+++ b/crates/tokf-cli/filters/go/vet.toml
@@ -1,4 +1,5 @@
 command = "go vet"
+description = "Show only diagnostic locations; confirm ok on success"
 keep = ["\\.go:\\d+"]
 
 [on_success]

--- a/crates/tokf-cli/filters/gradle/build.toml
+++ b/crates/tokf-cli/filters/gradle/build.toml
@@ -1,4 +1,5 @@
 command = ["gradle build", "./gradlew build"]
+description = "Strip task progress and daemon noise; show build result"
 strip_ansi = true
 collapse_empty_lines = true
 

--- a/crates/tokf-cli/filters/gradle/dependencies.toml
+++ b/crates/tokf-cli/filters/gradle/dependencies.toml
@@ -1,4 +1,5 @@
 command = ["gradle dependencies", "./gradlew dependencies"]
+description = "Strip task noise; show dependency tree only"
 strip_ansi = true
 
 skip = [

--- a/crates/tokf-cli/filters/gradle/test.toml
+++ b/crates/tokf-cli/filters/gradle/test.toml
@@ -1,4 +1,5 @@
 command = ["gradle test", "./gradlew test"]
+description = "Strip task progress; show test results and failures"
 strip_ansi = true
 collapse_empty_lines = true
 

--- a/crates/tokf-cli/filters/kubectl/get/pods.toml
+++ b/crates/tokf-cli/filters/kubectl/get/pods.toml
@@ -1,4 +1,5 @@
 command = ["kubectl get pods", "kubectl get pod", "kubectl get po"]
+description = "Structured JSON extraction of pod name, status, and restarts"
 
 # Override to get JSON output for structured extraction
 run = "kubectl get pods -o json {args}"

--- a/crates/tokf-cli/filters/ls.toml
+++ b/crates/tokf-cli/filters/ls.toml
@@ -1,4 +1,5 @@
 command = "ls"
+description = "Cap output at 50 lines for large directories"
 
 [on_success]
 head = 50

--- a/crates/tokf-cli/filters/next/build.toml
+++ b/crates/tokf-cli/filters/next/build.toml
@@ -1,4 +1,5 @@
 command = "next build"
+description = "Strip info lines and telemetry; show build output and errors"
 skip = [
   "^info ",
   "^Attention: Next\\.js now collects",

--- a/crates/tokf-cli/filters/npm/run.toml
+++ b/crates/tokf-cli/filters/npm/run.toml
@@ -1,4 +1,5 @@
 command = "npm run *"
+description = "Strip npm lifecycle noise; show script output only"
 skip = [
   "^> .+@",
   "^\\s*npm warn",

--- a/crates/tokf-cli/filters/npm/test-jest.toml
+++ b/crates/tokf-cli/filters/npm/test-jest.toml
@@ -1,4 +1,5 @@
 command = "jest"
+description = "Strip noise; show test suite summary and failure details"
 strip_ansi = true
 skip = [
   "^\\s*$",

--- a/crates/tokf-cli/filters/npm/test-vitest.toml
+++ b/crates/tokf-cli/filters/npm/test-vitest.toml
@@ -1,4 +1,5 @@
 command = "vitest"
+description = "Strip noise; show test suite summary and failure details"
 strip_ansi = true
 skip = [
   "^\\s*$",

--- a/crates/tokf-cli/filters/npm/test.toml
+++ b/crates/tokf-cli/filters/npm/test.toml
@@ -1,4 +1,5 @@
 command = ["npm test", "pnpm test", "yarn test"]
+description = "Strip test runner noise; delegates to vitest/jest variants"
 
 # Parent fallback — used when no variant matches
 strip_ansi = true

--- a/crates/tokf-cli/filters/playwright.toml
+++ b/crates/tokf-cli/filters/playwright.toml
@@ -1,4 +1,5 @@
 command = ["playwright test", "npx playwright test"]
+description = "Strip runner noise; show test results and failure details"
 strip_ansi = true
 skip = [
   "^\\s*$",

--- a/crates/tokf-cli/filters/pnpm/add.toml
+++ b/crates/tokf-cli/filters/pnpm/add.toml
@@ -1,4 +1,5 @@
 command = "pnpm add *"
+description = "Strip download progress; show added packages"
 skip = [
   "^\\s*Progress:",
   "^\\s*Downloading",

--- a/crates/tokf-cli/filters/pnpm/install.toml
+++ b/crates/tokf-cli/filters/pnpm/install.toml
@@ -1,4 +1,5 @@
 command = "pnpm install"
+description = "Strip download progress; show lockfile changes and warnings"
 skip = [
   "^\\s*Progress:",
   "^\\s*Downloading",

--- a/crates/tokf-cli/filters/prettier/check.toml
+++ b/crates/tokf-cli/filters/prettier/check.toml
@@ -1,4 +1,5 @@
 command = "prettier --check"
+description = "Confirm ok or list files needing formatting"
 strip_ansi = true
 skip = [
   "^Checking formatting",

--- a/crates/tokf-cli/filters/prisma/generate.toml
+++ b/crates/tokf-cli/filters/prisma/generate.toml
@@ -1,4 +1,5 @@
 command = "prisma generate"
+description = "Strip box drawing; show generated client name"
 skip = ["^[┌│└─╔╗╚╝║═]", "^Prisma schema", "Environment variables"]
 
 [on_success]

--- a/crates/tokf-cli/filters/pytest.toml
+++ b/crates/tokf-cli/filters/pytest.toml
@@ -1,4 +1,5 @@
 command = "pytest"
+description = "Run with --tb=short -q; show failures and pass/fail summary"
 run = "pytest --tb=short -q {args}"
 
 [[section]]

--- a/crates/tokf-cli/filters/ruff/check.toml
+++ b/crates/tokf-cli/filters/ruff/check.toml
@@ -1,4 +1,5 @@
 command = "ruff check"
+description = "Strip blank lines; show lint errors with locations"
 strip_ansi = true
 skip = [
   "^\\s*$",

--- a/crates/tokf-cli/filters/ruff/format.toml
+++ b/crates/tokf-cli/filters/ruff/format.toml
@@ -1,4 +1,5 @@
 command = "ruff format"
+description = "Confirm ok or list files needing formatting"
 strip_ansi = true
 skip = [
   "^\\s*$",

--- a/crates/tokf-cli/filters/tsc.toml
+++ b/crates/tokf-cli/filters/tsc.toml
@@ -1,4 +1,5 @@
 command = "tsc"
+description = "Confirm no errors or show diagnostic locations"
 
 match_output = [
   { contains = "Found 0 errors", output = "✓ TypeScript: no errors" },

--- a/crates/tokf-cli/filters/vite/build.toml
+++ b/crates/tokf-cli/filters/vite/build.toml
@@ -1,4 +1,5 @@
 command = "vite build"
+description = "Strip blank lines and script prefix; show build output and bundle sizes"
 strip_ansi = true
 skip = [
   "^\\s*$",

--- a/crates/tokf-cli/filters/vue-tsc.toml
+++ b/crates/tokf-cli/filters/vue-tsc.toml
@@ -1,4 +1,5 @@
 command = ["vue-tsc", "npx vue-tsc"]
+description = "Confirm no errors or show diagnostic locations"
 
 match_output = [
   { contains = "Found 0 errors", output = "✓ vue-tsc: no errors" },


### PR DESCRIPTION
## Summary

- Adds a `description` field to all 48 built-in stdlib filters
- Descriptions follow a consistent style: action-oriented, semicolon-separated clauses describing what the filter does to output
- Shown in `tokf ls` output via the `description` field added in #278

## Test plan

- [x] All 1795 tests pass
- [x] Verified every filter file has a `description` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)