### PR TITLE
fix(rewrite): skip commands with heredocs nested in $() substitutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1769,7 +1769,7 @@ patterns = ["(?:^|\\s)cargo\\s"]   # matches "cargo" anywhere after start or whi
 
 ## Implicit skip rules
 
-Two implicit skip rules are always active and can't be disabled. They cover cases where rewriting would silently corrupt the agent's data, so there's no plausible reading under which the rewrite would be correct.
+Three implicit skip rules are always active and can't be disabled. They cover cases where rewriting would silently corrupt the agent's data, so there's no plausible reading under which the rewrite would be correct.
 
 ### Heredocs
 
@@ -1781,6 +1781,28 @@ cat <<EOF > /tmp/cfg.yaml
 key: value
 EOF
 ```
+
+### Heredocs inside command substitution
+
+Commands that contain a heredoc anywhere inside a `$(...)` (or backtick) command substitution are also skipped — even when the substitution is buried deep inside an argument like `git commit -m "$(cat <<'EOF' … EOF)"`. The heredoc body lives in a logically-separate region of the source from the surrounding command, and downstream re-tokenization (clap argv parsing in `tokf run`, second-pass shell parsers, byte-offset pipe stripping) can slice through it. The canonical failure mode this prevents is `git commit -m "$(cat <<'EOF' … EOF)" 2>&1 | tail -10` mangling `-m`'s value into `git: error: switch 'm' requires a value`.
+
+```sh
+# Not rewritten — multi-line commit messages, gh PR bodies, etc.:
+git add foo && git commit -m "$(cat <<'EOF'
+feat: a thing
+
+with multi-line body
+EOF
+)" && git push
+
+gh pr create -b "$(cat <<EOF
+## Summary
+…
+EOF
+)"
+```
+
+Unlike the output-redirect skip below, this rule fires for the **whole compound**: if any segment contains a substitution-nested heredoc, sibling `git add` / `git push` segments are also passed through. This is intentionally conservative — re-emitting *any* part of a compound that contains this construct risks downstream byte-offset slicing into the heredoc body.
 
 ### Output redirection
 

--- a/crates/tokf-cli/src/rewrite/bash_ast.rs
+++ b/crates/tokf-cli/src/rewrite/bash_ast.rs
@@ -39,6 +39,20 @@ pub fn has_toplevel_heredoc(command: &str) -> bool {
     ParsedCommand::parse(command).is_some_and(|p| p.has_toplevel_heredoc())
 }
 
+/// Returns `true` if the command has a heredoc nested inside a `$(...)`
+/// command substitution.
+///
+/// These are structurally fragile to re-emit through the rewrite engine:
+/// pipe positions and argv splits are computed against the source byte
+/// range, but the heredoc body lives in a logically-separate region of
+/// the source, and downstream re-tokenization (clap argv parsing, pipe
+/// stripping by byte offset) can slice through it. The canonical failure
+/// is `git commit -m "$(cat <<'EOF'…EOF)" 2>&1 | tail -10` mangling
+/// `-m`'s value into `git: error: switch 'm' requires a value`.
+pub fn has_substitution_heredoc(command: &str) -> bool {
+    ParsedCommand::parse(command).is_some_and(|p| p.has_substitution_heredoc())
+}
+
 /// Returns `true` if the command has an output redirect to a file at the
 /// top level (not inside a substitution, function body, or list segment).
 ///
@@ -66,29 +80,18 @@ impl ParsedCommand {
         })
     }
 
-    fn text(&self, node: &Node) -> &str {
-        node.source_text(&self.source)
-    }
-
     /// Split a compound command at chain operators.
+    ///
+    /// rable parses chain operators left-associatively, so `A && B && C`
+    /// becomes `((A && B) && C)`. We recursively flatten nested `List`
+    /// nodes so each leaf command becomes its own segment. The **last**
+    /// child of an inner list inherits its parent's operator, because in
+    /// source order that operator is what visually follows it.
     pub fn compound_segments(&self) -> Vec<(String, String)> {
         let mut result = Vec::new();
-
         for node in &self.nodes {
-            if let NodeKind::List { items } = &node.kind {
-                for item in items {
-                    let text = self.text(&item.command).to_string();
-                    let sep = item
-                        .operator
-                        .map(|op| format_operator(&self.source, op, &item.command))
-                        .unwrap_or_default();
-                    result.push((text, sep));
-                }
-            } else {
-                result.push((self.text(node).to_string(), String::new()));
-            }
+            flatten_segments(node, &self.source, String::new(), &mut result);
         }
-
         if result.is_empty() {
             return vec![(self.source.clone(), String::new())];
         }
@@ -158,7 +161,18 @@ impl ParsedCommand {
 
     /// Detect whether the command has a top-level heredoc redirect.
     pub fn has_toplevel_heredoc(&self) -> bool {
-        self.nodes.iter().any(|n| has_heredoc(n, false))
+        self.nodes
+            .iter()
+            .any(|n| has_heredoc(n, false, HeredocScope::TopLevel))
+    }
+
+    /// Detect whether the command has a heredoc nested inside a `$(...)`
+    /// command substitution. See [`has_substitution_heredoc`] for *why*
+    /// this is a structural skip rule.
+    pub fn has_substitution_heredoc(&self) -> bool {
+        self.nodes
+            .iter()
+            .any(|n| has_heredoc(n, false, HeredocScope::InSubstitution))
     }
 
     /// Detect whether the command has a top-level output-to-file redirect.
@@ -193,6 +207,43 @@ impl ParsedCommand {
 }
 
 // --- AST walking helpers ---
+
+/// Recursively flatten a node into `(segment_text, separator)` pairs.
+///
+/// When descending into a nested `List`, the **last** item inherits the
+/// `parent_sep` because in source order that's what visually follows it.
+/// For example, `A && B || C` parses as `((A && B) || C)`:
+/// - outer items: `[(InnerList, "||"), (C, None)]`
+/// - inner items: `[(A, "&&"), (B, None)]` — descended with `parent_sep` `"||"`
+///   - i=0 (A) not last → emit `(A, "&&")`
+///   - i=1 (B) last → inherit `"||"` → emit `(B, "||")`
+/// - back to outer, i=1 (C) last → emit `(C, "")`
+///
+/// Result: `[(A, "&&"), (B, "||"), (C, "")]`.
+fn flatten_segments(
+    node: &Node,
+    source: &str,
+    parent_sep: String,
+    out: &mut Vec<(String, String)>,
+) {
+    if let NodeKind::List { items } = &node.kind {
+        let last = items.len().saturating_sub(1);
+        for (i, item) in items.iter().enumerate() {
+            let local_sep = item
+                .operator
+                .map(|op| format_operator(source, op, &item.command))
+                .unwrap_or_default();
+            let sep = if i == last {
+                parent_sep.clone()
+            } else {
+                local_sep
+            };
+            flatten_segments(&item.command, source, sep, out);
+        }
+    } else {
+        out.push((node.source_text(source).to_string(), parent_sep));
+    }
+}
 
 /// Format the operator after a list item, preserving surrounding whitespace.
 fn format_operator(source: &str, op: ListOperator, cmd: &Node) -> String {
@@ -273,25 +324,59 @@ fn has_pipeline(kind: &NodeKind) -> bool {
     }
 }
 
-/// Recursively check for top-level heredoc redirects.
-fn has_heredoc(node: &Node, inside_substitution: bool) -> bool {
+/// Which heredoc population to look for in [`has_heredoc`].
+#[derive(Clone, Copy)]
+enum HeredocScope {
+    /// Heredocs that are NOT inside a `$(...)` command substitution.
+    /// Catches the `cat <<EOF` shape — the heredoc body is lexically
+    /// bound to the top-level command and a `tokf run` wrapper would
+    /// break that binding.
+    TopLevel,
+    /// Heredocs nested INSIDE a command substitution. Catches the
+    /// `cmd -m "$(cat <<EOF…)"` shape — see [`has_substitution_heredoc`]
+    /// for the failure mode this prevents.
+    InSubstitution,
+}
+
+/// Recursively walk the AST looking for a heredoc in the requested scope.
+///
+/// We always descend into `Command.words` and `Word.parts` because that's
+/// where rable parks `CommandSubstitution` nodes for the `cmd "$(...)"`
+/// shape (verified empirically via an AST dump). For `TopLevel` queries
+/// the extra walking is harmless: the predicate guard prevents matches on
+/// heredocs that turn out to live inside a substitution.
+fn has_heredoc(node: &Node, inside_substitution: bool, scope: HeredocScope) -> bool {
+    let fires = match scope {
+        HeredocScope::TopLevel => !inside_substitution,
+        HeredocScope::InSubstitution => inside_substitution,
+    };
     match &node.kind {
-        NodeKind::HereDoc { .. } if !inside_substitution => true,
+        NodeKind::HereDoc { .. } if fires => true,
         NodeKind::Redirect { op, .. }
-            if !inside_substitution && op.starts_with("<<") && !op.starts_with("<<<") =>
+            if fires && op.starts_with("<<") && !op.starts_with("<<<") =>
         {
             true
         }
-        NodeKind::CommandSubstitution { command, .. } => has_heredoc(command, true),
-        NodeKind::Command { redirects, .. } => redirects
-            .iter()
-            .any(|r| has_heredoc(r, inside_substitution)),
-        NodeKind::Pipeline { commands, .. } => {
-            commands.iter().any(|c| has_heredoc(c, inside_substitution))
+        NodeKind::CommandSubstitution { command, .. } => has_heredoc(command, true, scope),
+        NodeKind::Command {
+            redirects, words, ..
+        } => {
+            redirects
+                .iter()
+                .any(|r| has_heredoc(r, inside_substitution, scope))
+                || words
+                    .iter()
+                    .any(|w| has_heredoc(w, inside_substitution, scope))
         }
+        NodeKind::Word { parts, .. } => parts
+            .iter()
+            .any(|p| has_heredoc(p, inside_substitution, scope)),
+        NodeKind::Pipeline { commands, .. } => commands
+            .iter()
+            .any(|c| has_heredoc(c, inside_substitution, scope)),
         NodeKind::List { items } => items
             .iter()
-            .any(|item| has_heredoc(&item.command, inside_substitution)),
+            .any(|item| has_heredoc(&item.command, inside_substitution, scope)),
         _ => false,
     }
 }

--- a/crates/tokf-cli/src/rewrite/bash_ast_tests.rs
+++ b/crates/tokf-cli/src/rewrite/bash_ast_tests.rs
@@ -48,6 +48,38 @@ fn pipe_not_a_separator() {
     assert_eq!(segs[0].0, "git diff HEAD | head -5");
 }
 
+#[test]
+fn three_segment_and_chain() {
+    // Regression: rable parses left-associatively as ((A && B) && C),
+    // so without recursive flattening this returned 2 segments and
+    // glued the middle command into the first. Verify we now get 3.
+    let p = ParsedCommand::parse("git add a && git commit -m x && git push").unwrap();
+    let segs = p.compound_segments();
+    assert_eq!(segs.len(), 3);
+    assert_eq!(segs[0].0, "git add a");
+    assert!(segs[0].1.contains("&&"));
+    assert_eq!(segs[1].0, "git commit -m x");
+    assert!(segs[1].1.contains("&&"));
+    assert_eq!(segs[2].0, "git push");
+    assert!(segs[2].1.is_empty());
+}
+
+#[test]
+fn mixed_and_or_chain() {
+    // Locks in operator inheritance for the recursive flattener:
+    // parsed as ((a && b) || c), the last child of the inner list (b)
+    // must inherit the outer "||" — not its own None operator.
+    let p = ParsedCommand::parse("a && b || c").unwrap();
+    let segs = p.compound_segments();
+    assert_eq!(segs.len(), 3);
+    assert_eq!(segs[0].0, "a");
+    assert!(segs[0].1.contains("&&"));
+    assert_eq!(segs[1].0, "b");
+    assert!(segs[1].1.contains("||"));
+    assert_eq!(segs[2].0, "c");
+    assert!(segs[2].1.is_empty());
+}
+
 // --- pipe detection ---
 
 #[test]
@@ -160,6 +192,33 @@ fn toplevel_heredoc() {
 fn no_heredoc_plain() {
     let p = ParsedCommand::parse("git status").unwrap();
     assert!(!p.has_toplevel_heredoc());
+}
+
+// --- has_substitution_heredoc ---
+
+#[test]
+fn substitution_heredoc_basic() {
+    assert!(has_substitution_heredoc(
+        "git commit -m \"$(cat <<'EOF'\nmsg\nEOF\n)\""
+    ));
+}
+
+#[test]
+fn substitution_heredoc_in_compound() {
+    assert!(has_substitution_heredoc(
+        "git add a && git commit -m \"$(cat <<'EOF'\nmsg\nEOF\n)\" && git push"
+    ));
+}
+
+#[test]
+fn no_substitution_heredoc_for_toplevel() {
+    // A bare top-level heredoc is caught by has_toplevel_heredoc, not this.
+    assert!(!has_substitution_heredoc("cat <<EOF\nhi\nEOF"));
+}
+
+#[test]
+fn no_substitution_heredoc_plain_command() {
+    assert!(!has_substitution_heredoc("git status"));
 }
 
 // --- output redirect ---

--- a/crates/tokf-cli/src/rewrite/rules.rs
+++ b/crates/tokf-cli/src/rewrite/rules.rs
@@ -6,9 +6,10 @@ use super::types::RewriteRule;
 ///
 /// - `^tokf ` prevents double-wrapping
 ///
-/// Two implicit AST-based skip rules are also enforced (separate from the
+/// Three implicit AST-based skip rules are also enforced (separate from the
 /// regex patterns above):
 /// - Top-level heredocs via [`super::bash_ast::has_toplevel_heredoc`].
+/// - Heredocs nested inside `$(...)` via [`super::bash_ast::has_substitution_heredoc`].
 /// - Top-level output redirects to a file via
 ///   [`super::bash_ast::has_toplevel_output_redirect`]. When an agent uses
 ///   `>`, `>>`, `&>`, etc., they explicitly want raw output for downstream
@@ -27,6 +28,10 @@ pub fn should_skip(command: &str, user_patterns: &[String]) -> bool {
     }
 
     if super::bash_ast::has_toplevel_heredoc(command) {
+        return true;
+    }
+
+    if super::bash_ast::has_substitution_heredoc(command) {
         return true;
     }
 
@@ -105,9 +110,8 @@ mod tests {
     }
 
     #[test]
-    fn no_skip_heredoc_inside_subshell() {
-        // << inside $() is a nested heredoc — safe to rewrite
-        assert!(!should_skip(
+    fn skip_heredoc_inside_subshell() {
+        assert!(should_skip(
             r#"git commit -m "$(cat <<'EOF'
 feat: test
 EOF
@@ -136,9 +140,9 @@ EOF
     }
 
     #[test]
-    fn no_skip_heredoc_parens_in_quotes() {
-        // Parentheses inside quotes should not affect depth tracking
-        assert!(!should_skip(
+    fn skip_heredoc_parens_in_quotes() {
+        // Literal `()` in single quotes must not throw off the walker.
+        assert!(should_skip(
             r#"git commit -m "$(echo '()' <<'EOF'
 msg
 EOF
@@ -154,9 +158,24 @@ EOF
     }
 
     #[test]
-    fn no_skip_nested_subshell_heredoc() {
-        // Multiple levels of nesting
-        assert!(!should_skip("echo $(echo $(cat <<EOF\ntest\nEOF\n))", &[]));
+    fn skip_nested_subshell_heredoc() {
+        // Walker descends through multiple substitution layers.
+        assert!(should_skip("echo $(echo $(cat <<EOF\ntest\nEOF\n))", &[]));
+    }
+
+    #[test]
+    fn skip_heredoc_in_substitution_compound() {
+        // The skip must fire both for the whole compound and for the
+        // offending segment in isolation, since `should_skip_effective`
+        // calls us at both checkpoints.
+        assert!(should_skip(
+            "git add f && git commit -m \"$(cat <<'EOF'\nmsg\nEOF\n)\" && git push",
+            &[],
+        ));
+        assert!(should_skip(
+            "git commit -m \"$(cat <<'EOF'\nmsg\nEOF\n)\"",
+            &[],
+        ));
     }
 
     #[test]

--- a/crates/tokf-cli/tests/cli_hook_handle.rs
+++ b/crates/tokf-cli/tests/cli_hook_handle.rs
@@ -140,6 +140,31 @@ fn hook_handle_tokf_command_silent() {
 }
 
 #[test]
+fn hook_handle_passthroughs_compound_with_substitution_heredoc() {
+    // Regression for the `git: error: switch 'm' requires a value` bug.
+    let json = r#"{"tool_name":"Bash","tool_input":{"command":"git add foo && git commit -m \"$(cat <<'EOF'\nfeat: x\n\nbody\nEOF\n)\" && git push"}}"#;
+    let (stdout, success) = hook_handle_with_stdlib(json);
+    assert!(success);
+    assert!(
+        stdout.trim().is_empty(),
+        "expected passthrough (empty stdout), got: {stdout}"
+    );
+}
+
+#[test]
+fn hook_handle_passthroughs_substitution_heredoc_with_pipe() {
+    // Locks in that the substitution-heredoc skip fires *before* pipe
+    // stripping. Without the skip, byte-offset slicing would mangle `-m`.
+    let json = r#"{"tool_name":"Bash","tool_input":{"command":"git add foo && git commit -m \"$(cat <<'EOF'\nfeat: x\nEOF\n)\" 2>&1 | tail -10"}}"#;
+    let (stdout, success) = hook_handle_with_stdlib(json);
+    assert!(success);
+    assert!(
+        stdout.trim().is_empty(),
+        "expected passthrough (empty stdout), got: {stdout}"
+    );
+}
+
+#[test]
 fn hook_handle_unmatched_command_silent() {
     // Use a command that has no filter in stdlib
     let json = r#"{"tool_name":"Bash","tool_input":{"command":"unknown-xyz-cmd-99"}}"#;

--- a/docs/rewrites-config.md
+++ b/docs/rewrites-config.md
@@ -345,7 +345,7 @@ patterns = ["(?:^|\\s)cargo\\s"]   # matches "cargo" anywhere after start or whi
 
 ## Implicit skip rules
 
-Two implicit skip rules are always active and can't be disabled. They cover cases where rewriting would silently corrupt the agent's data, so there's no plausible reading under which the rewrite would be correct.
+Three implicit skip rules are always active and can't be disabled. They cover cases where rewriting would silently corrupt the agent's data, so there's no plausible reading under which the rewrite would be correct.
 
 ### Heredocs
 
@@ -357,6 +357,28 @@ cat <<EOF > /tmp/cfg.yaml
 key: value
 EOF
 ```
+
+### Heredocs inside command substitution
+
+Commands that contain a heredoc anywhere inside a `$(...)` (or backtick) command substitution are also skipped — even when the substitution is buried deep inside an argument like `git commit -m "$(cat <<'EOF' … EOF)"`. The heredoc body lives in a logically-separate region of the source from the surrounding command, and downstream re-tokenization (clap argv parsing in `tokf run`, second-pass shell parsers, byte-offset pipe stripping) can slice through it. The canonical failure mode this prevents is `git commit -m "$(cat <<'EOF' … EOF)" 2>&1 | tail -10` mangling `-m`'s value into `git: error: switch 'm' requires a value`.
+
+```sh
+# Not rewritten — multi-line commit messages, gh PR bodies, etc.:
+git add foo && git commit -m "$(cat <<'EOF'
+feat: a thing
+
+with multi-line body
+EOF
+)" && git push
+
+gh pr create -b "$(cat <<EOF
+## Summary
+…
+EOF
+)"
+```
+
+Unlike the output-redirect skip below, this rule fires for the **whole compound**: if any segment contains a substitution-nested heredoc, sibling `git add` / `git push` segments are also passed through. This is intentionally conservative — re-emitting *any* part of a compound that contains this construct risks downstream byte-offset slicing into the heredoc body.
 
 ### Output redirection
 


### PR DESCRIPTION
## Summary

Multi-line commit messages of the canonical form

```sh
git add foo && git commit -m "$(cat <<'EOF'
feat: a thing

with a multi-line body
EOF
)" 2>&1 | tail -10
```

were failing with `git: error: switch 'm' requires a value`. The hook
was rewriting the command in a way that downstream byte-offset pipe
stripping then sliced through the heredoc body, mangling `-m`'s value.

Follow-up to the asymmetry deliberately left open by #323
("Compound commands with mixed segments and a heredoc — current heredoc
handling skips the whole compound; this PR keeps that asymmetry").

## Two complementary fixes

### 1. `compound_segments()` recurses into nested `List` nodes

rable parses chain operators left-associatively, so `A && B && C` becomes
`((A && B) && C)`:

```
List
├── List              ← nested!
│   ├── git add a
│   └── git commit -m "$(cat <<'EOF'…EOF\n)"
└── git push
```

The previous implementation only iterated the **top-level** items and
returned 2 segments instead of 3, gluing the first two commands together.
`try_filter_match` then matched the leading `git add` words and wrapped
the entire glued blob with `tokf run`, leaving `git commit` unwrapped
and exposed to the byte-offset pipe-stripping bug.

The recursive `flatten_segments` helper walks nested Lists and inherits
the **parent's** operator on the **last child** of each inner list, so
source order is preserved:

```
A && B || C   →   parsed as ((A && B) || C)
```

| step | i | item | sep emitted |
|---|---|---|---|
| descend outer with parent_sep=`""` | 0 | InnerList | (descend with parent_sep=`"\|\|"`) |
| descend inner with parent_sep=`"\|\|"` | 0 | A | `"&&"` (own operator) |
| | 1 (last) | B | `"\|\|"` (inherits parent) |
| back to outer | 1 (last) | C | `""` (inherits empty parent) |

Result: `[(A, "&&"), (B, "||"), (C, "")]` ✓

### 2. Skip commands with heredocs nested in `$(...)`

New structural skip rule `has_substitution_heredoc()` refuses to rewrite
any command containing a heredoc inside a `$(...)` (or backtick)
command substitution. The heredoc body lives in a logically-separate
region of the source from the surrounding command, and downstream
re-tokenization (clap argv parsing in `tokf run`, second-pass shell
parsers, byte-offset pipe stripping in `strip_simple_pipe`) can slice
through it.

This is the **third** implicit skip rule alongside top-level heredocs
(#323's `has_toplevel_heredoc`) and output redirects (#323's
`has_toplevel_output_redirect`).

### Walker unification

The two heredoc walkers (`has_heredoc` and the new `has_heredoc_in_sub`)
were structurally near-identical. They are unified into one parameterised
`has_heredoc(node, inside_substitution, scope)` walker via a
`HeredocScope` enum:

```rust
enum HeredocScope {
    /// Heredocs OUTSIDE any command substitution.
    TopLevel,
    /// Heredocs INSIDE a command substitution.
    InSubstitution,
}
```

The unified walker always descends into `Command.words` and `Word.parts`
(which the previous `has_heredoc` did **not**), because that's where
rable parks `CommandSubstitution` nodes for the `cmd "$(...)"` shape.
For `TopLevel` queries the wider walk is harmless: the predicate guard
prevents matches on heredocs that turn out to live inside a substitution.

Net change: ~30 lines of structural duplication eliminated.

## Headline behaviour

```sh
$ tokf rewrite 'git add a && git commit -m "$(cat <<'"'"'EOF'"'"'
hi
EOF
)" && git push'
git add a && git commit -m "$(cat <<'EOF'
hi
EOF
)" && git push
# whole compound passed through — agent's literal command runs as-is

$ tokf rewrite 'git add a && git commit -m foo && git push'
tokf run git add a && tokf run git commit -m foo && tokf run git push
# 3-segment compound now correctly splits and wraps each segment
# (previously the middle one was glued to git add)
```

## Test plan

- [x] **5 new bash_ast unit tests** in `bash_ast_tests.rs`:
  - `three_segment_and_chain` — recursion regression
  - `mixed_and_or_chain` — operator inheritance lock-in
  - `substitution_heredoc_basic` / `_in_compound`
  - `no_substitution_heredoc_for_toplevel` / `_plain_command`
- [x] **1 new `should_skip` test** in `rules.rs`:
  - `skip_heredoc_in_substitution_compound` — both whole-compound and
    isolated-segment skip checks
- [x] **3 existing tests in `rules.rs` flipped** (previously asserted
  the opposite, now correct):
  - `no_skip_heredoc_inside_subshell` → `skip_heredoc_inside_subshell`
  - `no_skip_heredoc_parens_in_quotes` → `skip_heredoc_parens_in_quotes`
  - `no_skip_nested_subshell_heredoc` → `skip_nested_subshell_heredoc`
- [x] **2 new end-to-end hook regression tests** in `cli_hook_handle.rs`
  using the existing `hook_handle_with_stdlib()` helper:
  - `hook_handle_passthroughs_compound_with_substitution_heredoc`
  - `hook_handle_passthroughs_substitution_heredoc_with_pipe`
- [x] `cargo test -p tokf` → **1421 passed, 0 failed, 2 ignored**
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → clean
- [x] `cargo fmt --check` → clean
- [x] Manual repro of the original failing command piped through
  `tokf hook handle` → empty stdout (passthrough)

## Files

- `crates/tokf-cli/src/rewrite/bash_ast.rs` — recursive `flatten_segments`,
  new `has_substitution_heredoc` API, unified `has_heredoc` walker, new
  `HeredocScope` enum, new `has_substitution_heredoc()` method on
  `ParsedCommand`
- `crates/tokf-cli/src/rewrite/rules.rs` — wired `has_substitution_heredoc`
  into `should_skip` after the existing heredoc check; flipped 3 stale
  tests; added 1 new test
- `crates/tokf-cli/src/rewrite/bash_ast_tests.rs` — 6 new unit tests
- `crates/tokf-cli/tests/cli_hook_handle.rs` — 2 new end-to-end regression
  tests
- `docs/rewrites-config.md` — new "Heredocs inside command substitution"
  section under "Implicit skip rules"
- `README.md` — regenerated from `docs/`

## Out of scope

- **Per-segment skipping for substitution-nested heredocs.** This PR
  intentionally treats the whole compound as ineligible (unlike output
  redirects, which are skipped per-segment). Re-emitting *any* part of a
  compound that contains a substitution-nested heredoc risks downstream
  byte-offset slicing into the heredoc body, so the conservative
  whole-compound skip is the safer default. Documented in
  `docs/rewrites-config.md`.
- **Parse-once optimization in `should_skip`.** `should_skip` still
  parses the AST 3 times (once per skip helper). A "parse once, query
  many" refactor was attempted but cascaded into a sizable test refactor
  for ~30 unrelated `bash_ast_tests.rs` call sites. Deferred — the parse
  cost is small relative to the existing parses already done by
  `compound_segments` / `rewrite_segment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
