### PR TITLE
fix(rewrite): heredoc with unmatched parens + debug config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -85,7 +85,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -751,7 +751,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -958,7 +958,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1041,7 +1041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2121,7 +2121,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2559,9 +2559,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rable"
-version = "0.1.8"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce365873d8ca60e686ae332a9837290f99c4dc52eb989c7caa07f69ec9cbd913"
+checksum = "679b78f33031279e255713d47eb80e438aea5347b7f7c28e6ff2d0cf9ba49c13"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2885,7 +2885,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2943,7 +2943,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3595,7 +3595,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4426,7 +4426,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/tokf-cli/Cargo.toml
+++ b/crates/tokf-cli/Cargo.toml
@@ -41,7 +41,7 @@ clap_complete = "4.5"
 clap_complete_nushell = "4.5"
 dialoguer = { version = "0.12", default-features = false }
 which = "8"
-rable = "0.1.8"
+rable = "0.1.14"
 opentelemetry     = { version = "0.31", optional = true, features = ["metrics"] }
 opentelemetry_sdk = { version = "0.31", optional = true, features = ["metrics"] }
 opentelemetry-otlp = { version = "0.31", optional = true }

--- a/crates/tokf-cli/src/rewrite/bash_ast_tests.rs
+++ b/crates/tokf-cli/src/rewrite/bash_ast_tests.rs
@@ -442,3 +442,56 @@ fn command_words_with_env() {
     assert_eq!(words[0], "git");
     assert_eq!(words[1], "commit");
 }
+
+#[test]
+fn parse_unmatched_double_quote_succeeds() {
+    // rable treats unmatched quotes as implicit close-at-end, so parse succeeds.
+    let result = ParsedCommand::parse(r#"git commit -m "unfinished"#);
+    assert!(result.is_some());
+}
+
+#[test]
+fn parse_unmatched_single_quote_succeeds() {
+    // Same as double quote — rable is lenient.
+    let result = ParsedCommand::parse("git commit -m 'unfinished");
+    assert!(result.is_some());
+}
+
+// Regression tests for rable#26: unmatched parens in heredoc body inside $(...)
+// were corrupting the AST and causing has_substitution_heredoc() to miss the
+// heredoc, leading to destructive rewrites of git commit commands.
+
+#[test]
+fn substitution_heredoc_with_unmatched_paren_detected() {
+    let input = "git commit -m \"$(cat <<'EOF'\nfoo\n(bar\nEOF\n)\"";
+    let p = ParsedCommand::parse(input).unwrap();
+    assert!(
+        p.has_substitution_heredoc(),
+        "heredoc inside $() must be detected even with unmatched ( in body"
+    );
+}
+
+#[test]
+fn substitution_heredoc_with_unmatched_paren_skipped() {
+    assert!(has_substitution_heredoc(
+        "git commit -m \"$(cat <<'EOF'\nfoo\n(bar\nEOF\n)\""
+    ));
+}
+
+#[test]
+fn compound_with_heredoc_unmatched_paren_skipped() {
+    assert!(has_substitution_heredoc(
+        "git add . && git commit -m \"$(cat <<'EOF'\ndocs: test\n(see issue\nEOF\n)\""
+    ));
+}
+
+#[test]
+fn parse_malformed_syntax_returns_none() {
+    // Exercise inputs where rable actually returns Err.
+    // Bare `(` without closing `)` is a syntax error.
+    let result = ParsedCommand::parse("git commit (");
+    assert!(
+        result.is_none(),
+        "expected parse failure for malformed syntax"
+    );
+}

--- a/crates/tokf-cli/src/rewrite/mod.rs
+++ b/crates/tokf-cli/src/rewrite/mod.rs
@@ -115,6 +115,8 @@ struct SegmentRules<'a> {
     filter_patterns: &'a [String],
     /// Options controlling `tokf run` generation (e.g. `--no-mask-exit-code`).
     options: &'a RewriteOptions,
+    /// When true, log to stderr when the bash parser fails to parse a command.
+    log_parse_failures: bool,
 }
 
 /// Rewrite a single command segment, handling pipe stripping and env var
@@ -143,6 +145,11 @@ fn rewrite_segment(
 ) -> String {
     // Parse once — reuse the AST for env_prefix, pipe detection, and stripping.
     let parsed = bash_ast::ParsedCommand::parse(segment);
+    if parsed.is_none() && rules.log_parse_failures {
+        eprintln!(
+            "[tokf] debug: bash parser failed to parse command, falling back to string matching: {segment}"
+        );
+    }
     let (env_prefix, cmd_owned) = parsed
         .as_ref()
         .and_then(bash_ast::ParsedCommand::env_prefix)
@@ -163,7 +170,11 @@ fn rewrite_segment(
     let cmd_parsed = if env_prefix.is_empty() {
         parsed
     } else {
-        bash_ast::ParsedCommand::parse(cmd)
+        let p = bash_ast::ParsedCommand::parse(cmd);
+        if p.is_none() && rules.log_parse_failures {
+            eprintln!("[tokf] debug: bash parser failed to parse env-stripped command: {cmd}");
+        }
+        p
     };
 
     if cmd_parsed
@@ -289,10 +300,15 @@ pub(crate) fn rewrite_with_config_and_options(
 
     let wrapper_rules = build_wrapper_rules();
     let filter_patterns = collect_filter_patterns(search_dirs);
+    let log_parse_failures = user_config
+        .debug
+        .as_ref()
+        .is_some_and(|d| d.log_parse_failures);
     let rules = SegmentRules {
         wrapper: &wrapper_rules,
         filter_patterns: &filter_patterns,
         options,
+        log_parse_failures,
     };
     let segments = split_compound(command);
 

--- a/crates/tokf-cli/src/rewrite/tests.rs
+++ b/crates/tokf-cli/src/rewrite/tests.rs
@@ -203,6 +203,7 @@ fn rewrite_user_rule_takes_priority() {
             replace: "custom-wrapper {0}".to_string(),
         }],
         permissions: None,
+        debug: None,
     };
     let result = rewrite_with_config("git status", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(result, "custom-wrapper git status");
@@ -224,6 +225,7 @@ fn rewrite_user_skip_prevents_rewrite() {
         pipe: None,
         rewrite: vec![],
         permissions: None,
+        debug: None,
     };
     let result = rewrite_with_config("git status", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(result, "git status");
@@ -394,6 +396,7 @@ fn wrapper_user_rule_overrides_builtin_wrapper() {
             replace: "custom-make{1}".to_string(),
         }],
         permissions: None,
+        debug: None,
     };
     let r = rewrite_with_config("make check", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(r, "custom-make check");
@@ -409,6 +412,7 @@ fn wrapper_skip_pattern_prevents_wrapper() {
         pipe: None,
         rewrite: vec![],
         permissions: None,
+        debug: None,
     };
     let r = rewrite_with_config("make check", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(r, "make check");

--- a/crates/tokf-cli/src/rewrite/tests_compound.rs
+++ b/crates/tokf-cli/src/rewrite/tests_compound.rs
@@ -200,6 +200,7 @@ fn rewrite_user_rule_wraps_piped_command() {
             replace: "my-wrapper {0}{rest}".to_string(),
         }],
         permissions: None,
+        debug: None,
     };
     let r = rewrite_with_config(
         "cargo test | grep FAILED",
@@ -222,6 +223,7 @@ fn rewrite_skip_pattern_wins_over_pipe_guard() {
         pipe: None,
         rewrite: vec![],
         permissions: None,
+        debug: None,
     };
     let r = rewrite_with_config(
         "git status | grep M",

--- a/crates/tokf-cli/src/rewrite/tests_env.rs
+++ b/crates/tokf-cli/src/rewrite/tests_env.rs
@@ -229,6 +229,7 @@ fn rewrite_user_skip_pattern_matches_env_stripped_command() {
         pipe: None,
         rewrite: vec![],
         permissions: None,
+        debug: None,
     };
     // "FOO=bar git status" does NOT start with "git", so skip does not fire
     // and the command IS rewritten.

--- a/crates/tokf-cli/src/rewrite/tests_pipe.rs
+++ b/crates/tokf-cli/src/rewrite/tests_pipe.rs
@@ -27,6 +27,7 @@ fn rewrite_pipe_strip_disabled_preserves_pipe() {
         }),
         rewrite: vec![],
         permissions: None,
+        debug: None,
     };
     let r = rewrite_with_config(
         "cargo test | tail -5",
@@ -55,6 +56,7 @@ fn rewrite_pipe_strip_disabled_non_piped_still_rewritten() {
         }),
         rewrite: vec![],
         permissions: None,
+        debug: None,
     };
     let r = rewrite_with_config(
         "cargo test --lib",
@@ -85,6 +87,7 @@ fn rewrite_prefer_less_injects_flag() {
         }),
         rewrite: vec![],
         permissions: None,
+        debug: None,
     };
     let r = rewrite_with_config(
         "cargo test | tail -5",
@@ -115,6 +118,7 @@ fn rewrite_prefer_less_without_pipe_no_effect() {
         }),
         rewrite: vec![],
         permissions: None,
+        debug: None,
     };
     let r = rewrite_with_config(
         "cargo test --lib",
@@ -143,6 +147,7 @@ fn rewrite_strip_false_overrides_prefer_less() {
         }),
         rewrite: vec![],
         permissions: None,
+        debug: None,
     };
     let r = rewrite_with_config(
         "cargo test | tail -5",
@@ -168,6 +173,7 @@ fn rewrite_compound_prefer_less_per_segment() {
         }),
         rewrite: vec![],
         permissions: None,
+        debug: None,
     };
     let r = rewrite_with_config(
         "git add . && git diff | head -5",

--- a/crates/tokf-cli/src/rewrite/types.rs
+++ b/crates/tokf-cli/src/rewrite/types.rs
@@ -217,4 +217,31 @@ command = "my-engine"
             crate::hook::permission_engine::ErrorFallback::Ask
         );
     }
+
+    #[test]
+    fn deserialize_debug_section() {
+        let toml_str = r"
+[debug]
+log_parse_failures = true
+";
+        let config: RewriteConfig = toml::from_str(toml_str).unwrap();
+        let debug = config.debug.unwrap();
+        assert!(debug.log_parse_failures);
+    }
+
+    #[test]
+    fn deserialize_debug_defaults() {
+        let toml_str = r"
+[debug]
+";
+        let config: RewriteConfig = toml::from_str(toml_str).unwrap();
+        let debug = config.debug.unwrap();
+        assert!(!debug.log_parse_failures);
+    }
+
+    #[test]
+    fn deserialize_no_debug_section() {
+        let config: RewriteConfig = toml::from_str("").unwrap();
+        assert!(config.debug.is_none());
+    }
 }

--- a/crates/tokf-cli/tests/cli_rewrite.rs
+++ b/crates/tokf-cli/tests/cli_rewrite.rs
@@ -596,3 +596,91 @@ fn rewrite_always_exits_zero() {
     assert!(output.status.success());
     assert_eq!(output.status.code(), Some(0));
 }
+
+// --- Debug: log_parse_failures ---
+
+/// Helper: run `tokf rewrite` with a `rewrites.toml` that enables
+/// `[debug] log_parse_failures = true`.
+fn rewrite_with_debug_logging(command: &str) -> (String, String) {
+    let dir = tempfile::TempDir::new().unwrap();
+    let tokf_dir = dir.path().join(".tokf");
+    std::fs::create_dir_all(&tokf_dir).unwrap();
+    std::fs::write(
+        tokf_dir.join("rewrites.toml"),
+        "[debug]\nlog_parse_failures = true\n",
+    )
+    .unwrap();
+
+    let output = tokf()
+        .args(["rewrite", command])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "tokf rewrite failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    (stdout, stderr)
+}
+
+#[test]
+fn debug_log_parse_failure_on_malformed_syntax() {
+    // A bare `(` is a syntax error that makes rable fail.
+    let (stdout, stderr) = rewrite_with_debug_logging("git commit (");
+    assert!(
+        stderr.contains("bash parser failed to parse"),
+        "expected parse failure log, got stderr: {stderr}"
+    );
+    // The command should still be rewritten via string fallback.
+    assert!(stdout.starts_with("tokf run"));
+}
+
+#[test]
+fn debug_log_silent_when_disabled() {
+    // Without the debug flag, parse failures should be silent.
+    let dir = tempfile::TempDir::new().unwrap();
+    let output = tokf()
+        .args(["rewrite", "git commit ("])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("bash parser failed"),
+        "expected no parse failure log without debug flag, got stderr: {stderr}"
+    );
+}
+
+#[test]
+fn debug_log_no_false_positive_on_valid_command() {
+    // A valid command should not trigger a parse failure log.
+    let (_stdout, stderr) = rewrite_with_debug_logging("git status");
+    assert!(
+        !stderr.contains("bash parser failed"),
+        "valid command should not trigger parse failure log, got stderr: {stderr}"
+    );
+}
+
+// --- Regression: rable#26 heredoc with unmatched parens in body ---
+
+#[test]
+fn rewrite_heredoc_commit_with_unmatched_parens_not_mangled() {
+    // Real-world command that was destructively rewritten before rable 0.1.14:
+    // the `(recommended, review, autopilot)` line has parens that previously
+    // confused the paren-depth tracker, producing `tokf run git commit -m`
+    // without the message value.
+    let cmd = "git add . && git commit -m \"$(cat <<'EOF'\n\
+               docs: test\n\
+               \n\
+               (see issue for details\n\
+               EOF\n\
+               )\"";
+    let result = rewrite_with_stdlib(cmd);
+    assert!(
+        !result.contains("tokf run git commit"),
+        "heredoc commit must not be wrapped with tokf run, got: {result}"
+    );
+}

--- a/crates/tokf-hook-types/src/config.rs
+++ b/crates/tokf-hook-types/src/config.rs
@@ -21,6 +21,19 @@ pub struct RewriteConfig {
 
     /// Permission engine configuration (external sub-hook delegation).
     pub permissions: Option<PermissionsConfig>,
+
+    /// Debug/diagnostic settings (all off by default).
+    pub debug: Option<DebugConfig>,
+}
+
+/// Debug and diagnostic settings for the rewrite system.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct DebugConfig {
+    /// When true, log to stderr when the bash parser (rable) fails to parse a
+    /// command. This helps diagnose "unmatched quote" errors by showing whether
+    /// tokf fell back to simple string matching because the AST parse failed.
+    #[serde(default)]
+    pub log_parse_failures: bool,
 }
 
 /// Configuration for the permission decision engine.


### PR DESCRIPTION
## Summary

- **Bump rable 0.1.8 → 0.1.14** — fixes mpecan/rable#26 where unmatched `(` in heredoc bodies inside `$(...)` corrupted the AST, causing `has_substitution_heredoc()` to miss the heredoc. This led to destructive rewrites producing `tokf run git commit -m` without the message value (`error: switch 'm' requires a value`).
- **Add `[debug] log_parse_failures` config flag** — opt-in stderr logging when rable fails to parse a command entirely, helping diagnose future rewrite issues.

## Test plan

- [x] 4 new regression tests for the heredoc/unmatched-parens fix (3 unit, 1 integration)
- [x] 3 new tests for debug config deserialization
- [x] 3 new integration tests for debug logging behavior
- [x] Full suite: 1514 passed, 0 failed
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)