### PR TITLE
chore(deps): update rust crate rable to v0.1.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,9 +2559,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rable"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "679b78f33031279e255713d47eb80e438aea5347b7f7c28e6ff2d0cf9ba49c13"
+checksum = "010fe03c7c468f7eea6ba5a41e4907b2b56bc90f560dffb79d4527b58d6520f3"
 dependencies = [
  "thiserror 2.0.18",
 ]

--- a/crates/tokf-cli/Cargo.toml
+++ b/crates/tokf-cli/Cargo.toml
@@ -41,7 +41,7 @@ clap_complete = "4.5"
 clap_complete_nushell = "4.5"
 dialoguer = { version = "0.12", default-features = false }
 which = "8"
-rable = "0.1.14"
+rable = "0.1.15"
 opentelemetry     = { version = "0.31", optional = true, features = ["metrics"] }
 opentelemetry_sdk = { version = "0.31", optional = true, features = ["metrics"] }
 opentelemetry-otlp = { version = "0.31", optional = true }


### PR DESCRIPTION
## Summary
- Update rable from 0.1.14 to 0.1.15
- All 2136 workspace tests pass (2 pre-existing R2 TLS failures unrelated to this change)

## Test plan
- [x] `cargo test --workspace` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)