### PR TITLE
fix(hook): exit 0 for Ask so Claude Code reads JSON verdict

### DIFF
--- a/crates/tokf-cli/src/commands.rs
+++ b/crates/tokf-cli/src/commands.rs
@@ -595,9 +595,19 @@ pub fn cmd_hook_handle(format: &HookFormat) -> i32 {
         HookFormat::Gemini => hook::handle_gemini(),
         HookFormat::Cursor => hook::handle_cursor(),
     };
+    hook_outcome_exit_code(outcome)
+}
+
+/// Map a `HookOutcome` to the process exit code expected by the host AI tool.
+///
+/// `Ask` must exit 0 so Claude Code reads the JSON `permissionDecision: "ask"`
+/// from stdout and shows the user the native prompt. Exit 2 would short-circuit
+/// that path and trigger an unconditional block. `Deny` keeps exit 2 because
+/// the JSON is already paired with a hard block in every supported host.
+const fn hook_outcome_exit_code(outcome: hook::HookOutcome) -> i32 {
     match outcome {
-        hook::HookOutcome::Deny | hook::HookOutcome::Ask => 2,
-        hook::HookOutcome::Allow | hook::HookOutcome::PassThrough => 0,
+        hook::HookOutcome::Deny => 2,
+        hook::HookOutcome::Ask | hook::HookOutcome::Allow | hook::HookOutcome::PassThrough => 0,
     }
 }
 
@@ -625,5 +635,32 @@ pub fn cmd_hook_install(
             eprintln!("[tokf] hook install failed: {e:#}");
             1
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ask_outcome_exits_zero_so_claude_reads_json_decision() {
+        // Regression for #343: exit 2 short-circuits the JSON path and turns
+        // an "ask" verdict into an unconditional block.
+        assert_eq!(hook_outcome_exit_code(hook::HookOutcome::Ask), 0);
+    }
+
+    #[test]
+    fn allow_outcome_exits_zero() {
+        assert_eq!(hook_outcome_exit_code(hook::HookOutcome::Allow), 0);
+    }
+
+    #[test]
+    fn passthrough_outcome_exits_zero() {
+        assert_eq!(hook_outcome_exit_code(hook::HookOutcome::PassThrough), 0);
+    }
+
+    #[test]
+    fn deny_outcome_exits_two() {
+        assert_eq!(hook_outcome_exit_code(hook::HookOutcome::Deny), 2);
     }
 }

--- a/crates/tokf-cli/tests/cli_hook_handle.rs
+++ b/crates/tokf-cli/tests/cli_hook_handle.rs
@@ -374,3 +374,68 @@ fn hook_handle_stdlib_yarn_test_rewrites() {
         "tokf run yarn test"
     );
 }
+
+// --- External permission engine ask verdict (regression for #343) ---
+
+/// Regression for #343: when the external permission engine returns an "ask"
+/// verdict, the binary must exit 0 so Claude Code reads the JSON
+/// `permissionDecision: "ask"` and shows the native prompt. Exit 2 would
+/// short-circuit that path and turn ask into an unconditional block.
+#[cfg(unix)]
+#[test]
+fn hook_handle_ask_verdict_exits_zero_and_emits_ask_json() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::TempDir::new().unwrap();
+
+    // Mock external permission engine: always returns an "ask" verdict.
+    let engine = dir.path().join("engine.sh");
+    std::fs::write(
+        &engine,
+        "#!/bin/sh\ncat >/dev/null\necho '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"needs confirmation\",\"updatedInput\":{\"command\":\"git push\"}}}'\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&engine, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    // Project-local rewrites.toml wires the engine in.
+    let rewrites_dir = dir.path().join(".tokf");
+    std::fs::create_dir_all(&rewrites_dir).unwrap();
+    let rewrites = format!(
+        "[permissions]\nengine = \"external\"\n\n[permissions.external]\ncommand = \"{}\"\n",
+        engine.display(),
+    );
+    std::fs::write(rewrites_dir.join("rewrites.toml"), rewrites).unwrap();
+
+    let json = r#"{"tool_name":"Bash","tool_input":{"command":"git push"}}"#;
+    let mut child = tokf()
+        .args(["hook", "handle"])
+        .current_dir(dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    {
+        use std::io::Write;
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(json.as_bytes())
+            .unwrap();
+    }
+    let output = child.wait_with_output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "expected exit 0 for ask verdict (issue #343), got status {:?}, stdout: {stdout}, stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let response: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(
+        response["hookSpecificOutput"]["permissionDecision"], "ask",
+        "exit 0 alone is not enough — the JSON ask verdict must reach Claude Code"
+    );
+}


### PR DESCRIPTION
Closes #343

## Summary
- `cmd_hook_handle` was mapping `HookOutcome::Ask` to exit code 2, which Claude Code interprets as an unconditional block. The stdout JSON (`permissionDecision: "ask"`) was correct, but exit 2 short-circuited the path and the user never saw the native prompt.
- Extract the outcome→exit-code mapping into a documented `const fn` and map `Ask` to 0. `Deny` keeps exit 2 — existing block behaviour is unchanged.
- Add unit tests for all four `HookOutcome` variants, with the `Ask` test explicitly named as a regression for #343.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test` (2156 passed, 0 failed)
- [x] New `commands::tests::*` unit tests cover all four outcome variants
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)