### PR TITLE
fix(rewrite): protect remote-shell argv from regex rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1922,6 +1922,33 @@ git status && git diff > foo.txt  # → "tokf run git status && git diff > foo.t
 
 `tee` in a pipeline (`git diff | tee log.txt`) is **not** currently treated as an output redirect because `tee` is a command argument, not a redirect operator. The current pipe-handling behaviour is preserved. This is a known follow-up.
 
+## Transparent-arg commands
+
+Some commands take a shell-code payload that runs in a *different* environment — `ssh HOST 'cmd'` runs `cmd` on the remote host, where tokf is not installed and shouldn't be referenced. For these commands tokf must be especially conservative: it can still wrap the local invocation with `tokf run` (which preserves the argv byte-for-byte), but **user `[[rewrite]]` regex rules are not applied** because a sufficiently broad pattern can splice text into the opaque payload and break the remote call.
+
+The built-in list — always active, can't be disabled — is `ssh`, `mosh`, `slogin`. Basename matching applies, so `/usr/bin/ssh` is treated identically to `ssh`.
+
+You can extend the list via `[transparent]` for tools like `kubectl exec`, `docker exec`, etc.:
+
+```toml
+[transparent]
+commands = ["kubectl", "doctl"]
+```
+
+Names are matched against the basename of the command's first word. `commands` extends — not replaces — the built-in list, so `kubectl` is added on top of `ssh`/`mosh`/`slogin`.
+
+What still happens for transparent commands:
+- The standard `tokf run <cmd>` wrap from a matching filter (argv-preserving prefix only).
+- Pipe stripping with `--baseline-pipe '<suffix>'` (flags inserted between `tokf run` and `<cmd>`; the inner argv is untouched).
+- The built-in `^tokf ` skip and the heredoc / output-redirect skips above.
+
+What is gated:
+- User `[[rewrite]]` regex rules in `rewrites.toml`. They run on the full command string and could splice text into the inner argv, so they're skipped when the first command word's basename is in the transparent list.
+
+If you genuinely need a regex rewrite for an ssh-class command, invoke it explicitly: `tokf run ssh …` is preserved by the `^tokf ` skip rule, so it won't be re-rewritten.
+
+This was added to address [#338](https://github.com/mpecan/tokf/issues/338), where a long-output `ssh HOST 'cmd'` would land `tokf` on the remote bash and exit 127.
+
 ## Debug settings
 
 The `[debug]` section enables diagnostic logging for the rewrite system. All settings are off by default.

--- a/crates/tokf-cli/src/config/mod.rs
+++ b/crates/tokf-cli/src/config/mod.rs
@@ -80,7 +80,7 @@ pub fn pattern_specificity(pattern: &str) -> usize {
 
 /// Extract the basename from a word that might be a path.
 /// Examples: `/usr/bin/ls` -> `ls`, `./mvnw` -> `mvnw`, `git` -> `git`
-pub fn extract_basename(word: &str) -> &str {
+pub(crate) fn extract_basename(word: &str) -> &str {
     // Find the last path separator (/ or \)
     word.rfind(['/', '\\']).map_or(word, |pos| &word[pos + 1..])
 }

--- a/crates/tokf-cli/src/config/mod.rs
+++ b/crates/tokf-cli/src/config/mod.rs
@@ -80,7 +80,7 @@ pub fn pattern_specificity(pattern: &str) -> usize {
 
 /// Extract the basename from a word that might be a path.
 /// Examples: `/usr/bin/ls` -> `ls`, `./mvnw` -> `mvnw`, `git` -> `git`
-fn extract_basename(word: &str) -> &str {
+pub fn extract_basename(word: &str) -> &str {
     // Find the last path separator (/ or \)
     word.rfind(['/', '\\']).map_or(word, |pos| &word[pos + 1..])
 }

--- a/crates/tokf-cli/src/rewrite/bash_ast.rs
+++ b/crates/tokf-cli/src/rewrite/bash_ast.rs
@@ -64,6 +64,32 @@ pub fn has_toplevel_output_redirect(command: &str) -> bool {
     ParsedCommand::parse(command).is_some_and(|p| p.has_toplevel_output_redirect())
 }
 
+/// Return the basename of the first command word, with shell quotes
+/// stripped. Used to identify commands whose argv is opaque to tokf —
+/// e.g. `ssh HOST 'cmd'`, where the quoted payload runs in a different
+/// shell.
+///
+/// Returns `None` for empty input, parse failures, env-only inputs
+/// (`FOO=bar` with no command), and command-substitution-only inputs
+/// (`$(echo ssh)`) where there is no literal first word.
+///
+/// Examples: `ssh HOST cmd` → `Some("ssh")`, `/usr/bin/ssh …` →
+/// `Some("ssh")`, `'ssh' …` → `Some("ssh")`,
+/// `FOO=bar ssh …` → `Some("ssh")`.
+pub fn first_command_basename(command: &str) -> Option<String> {
+    let parsed = ParsedCommand::parse(command)?;
+    let cmd = find_first_command(&parsed.nodes)?;
+    let NodeKind::Command { words, .. } = &cmd.kind else {
+        return None;
+    };
+    let first = words.first()?;
+    let NodeKind::Word { value, .. } = &first.kind else {
+        return None;
+    };
+    let unquoted = unquote(value);
+    Some(crate::config::extract_basename(&unquoted).to_string())
+}
+
 /// A parsed bash command backed by a rable AST.
 pub struct ParsedCommand {
     nodes: Vec<Node>,
@@ -549,7 +575,9 @@ fn is_strippable_grep(args: &[&str]) -> bool {
     has_pattern
 }
 
-#[cfg(test)]
+/// Strip a single layer of matching outer quotes (single or double).
+/// Inner quotes and escapes are not interpreted — this is a shallow
+/// helper used for command-name extraction only.
 fn unquote(s: &str) -> String {
     if (s.starts_with('\'') && s.ends_with('\'')) || (s.starts_with('"') && s.ends_with('"')) {
         s[1..s.len() - 1].to_string()

--- a/crates/tokf-cli/src/rewrite/bash_ast_tests.rs
+++ b/crates/tokf-cli/src/rewrite/bash_ast_tests.rs
@@ -551,3 +551,23 @@ fn first_command_basename_preserves_other_names() {
         Some("ssh-add")
     );
 }
+
+#[test]
+fn first_command_basename_command_substitution_first_token() {
+    // rable parses `$(echo ssh)` as a Word whose `value` is the literal
+    // source text including the `$(…)`. We don't try to resolve it — we
+    // just extract whatever literal we got. The important property is
+    // that this never produces `Some("ssh")` and so cannot accidentally
+    // mark the whole command as transparent.
+    let result = first_command_basename("$(echo ssh) HOST cmd");
+    assert_ne!(result.as_deref(), Some("ssh"));
+}
+
+#[test]
+fn first_command_basename_mismatched_quotes() {
+    // `unquote` only strips matching outer quotes. Mismatched outer quotes
+    // must not yield a false-positive ssh match — the important property
+    // is no panic and that the result, whatever it is, isn't `Some("ssh")`.
+    let result = first_command_basename("'ssh\" HOST cmd");
+    assert_ne!(result.as_deref(), Some("ssh"));
+}

--- a/crates/tokf-cli/src/rewrite/bash_ast_tests.rs
+++ b/crates/tokf-cli/src/rewrite/bash_ast_tests.rs
@@ -495,3 +495,59 @@ fn parse_malformed_syntax_returns_none() {
         "expected parse failure for malformed syntax"
     );
 }
+
+// --- first_command_basename ---
+
+#[test]
+fn first_command_basename_simple() {
+    assert_eq!(
+        first_command_basename("ssh HOST cmd").as_deref(),
+        Some("ssh")
+    );
+}
+
+#[test]
+fn first_command_basename_strips_path() {
+    assert_eq!(
+        first_command_basename("/usr/bin/ssh HOST cmd").as_deref(),
+        Some("ssh")
+    );
+}
+
+#[test]
+fn first_command_basename_unquotes() {
+    // A quoted command name shouldn't fool the check — `'ssh'` runs `ssh`.
+    assert_eq!(
+        first_command_basename("'ssh' HOST cmd").as_deref(),
+        Some("ssh")
+    );
+}
+
+#[test]
+fn first_command_basename_skips_env_prefix() {
+    // The first *command* word, after env assignments, is what runs.
+    assert_eq!(
+        first_command_basename("FOO=bar ssh HOST cmd").as_deref(),
+        Some("ssh")
+    );
+}
+
+#[test]
+fn first_command_basename_empty_input() {
+    assert_eq!(first_command_basename(""), None);
+}
+
+#[test]
+fn first_command_basename_only_env_prefix() {
+    // Just env assignments, no command — nothing to identify.
+    assert_eq!(first_command_basename("FOO=bar"), None);
+}
+
+#[test]
+fn first_command_basename_preserves_other_names() {
+    // Sibling commands (e.g. ssh-add) must not be conflated with ssh.
+    assert_eq!(
+        first_command_basename("ssh-add").as_deref(),
+        Some("ssh-add")
+    );
+}

--- a/crates/tokf-cli/src/rewrite/mod.rs
+++ b/crates/tokf-cli/src/rewrite/mod.rs
@@ -2,6 +2,7 @@ pub mod types;
 
 pub(crate) mod bash_ast;
 pub(crate) mod rules;
+pub(crate) mod transparent;
 pub(crate) mod user_config;
 
 use std::path::PathBuf;
@@ -292,10 +293,20 @@ pub(crate) fn rewrite_with_config_and_options(
         return command.to_string();
     }
 
+    let transparent_extras: &[String] = user_config
+        .transparent
+        .as_ref()
+        .map_or(&[] as &[String], |t| &t.commands);
+
     // User rules run before everything — they can override built-in wrappers.
-    let user_result = apply_rules(&user_config.rewrite, command);
-    if user_result != command {
-        return user_result;
+    // Skipped for transparent-arg commands (#338): regex rewrites can splice
+    // text into an opaque payload that runs in a different shell, breaking
+    // ssh and similar invocations. Argv-preserving wraps below still apply.
+    if !transparent::is_transparent_command(command, transparent_extras) {
+        let user_result = apply_rules(&user_config.rewrite, command);
+        if user_result != command {
+            return user_result;
+        }
     }
 
     let wrapper_rules = build_wrapper_rules();
@@ -349,3 +360,5 @@ mod tests_compound;
 mod tests_env;
 #[cfg(test)]
 mod tests_pipe;
+#[cfg(test)]
+mod tests_transparent;

--- a/crates/tokf-cli/src/rewrite/mod.rs
+++ b/crates/tokf-cli/src/rewrite/mod.rs
@@ -299,10 +299,11 @@ pub(crate) fn rewrite_with_config_and_options(
         .map_or(&[] as &[String], |t| &t.commands);
 
     // User rules run before everything — they can override built-in wrappers.
-    // Skipped for transparent-arg commands (#338): regex rewrites can splice
-    // text into an opaque payload that runs in a different shell, breaking
-    // ssh and similar invocations. Argv-preserving wraps below still apply.
-    if !transparent::is_transparent_command(command, transparent_extras) {
+    // Skipped when *any* compound segment is a transparent-arg invocation
+    // (#338): regex rewrites operate on the full command string, so even an
+    // ssh segment buried behind a `cd … &&` could have text spliced into its
+    // opaque payload. Argv-preserving wraps below still apply per-segment.
+    if !transparent::any_segment_is_transparent(command, transparent_extras) {
         let user_result = apply_rules(&user_config.rewrite, command);
         if user_result != command {
             return user_result;

--- a/crates/tokf-cli/src/rewrite/tests.rs
+++ b/crates/tokf-cli/src/rewrite/tests.rs
@@ -204,6 +204,7 @@ fn rewrite_user_rule_takes_priority() {
         }],
         permissions: None,
         debug: None,
+        transparent: None,
     };
     let result = rewrite_with_config("git status", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(result, "custom-wrapper git status");
@@ -226,6 +227,7 @@ fn rewrite_user_skip_prevents_rewrite() {
         rewrite: vec![],
         permissions: None,
         debug: None,
+        transparent: None,
     };
     let result = rewrite_with_config("git status", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(result, "git status");
@@ -397,6 +399,7 @@ fn wrapper_user_rule_overrides_builtin_wrapper() {
         }],
         permissions: None,
         debug: None,
+        transparent: None,
     };
     let r = rewrite_with_config("make check", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(r, "custom-make check");
@@ -413,6 +416,7 @@ fn wrapper_skip_pattern_prevents_wrapper() {
         rewrite: vec![],
         permissions: None,
         debug: None,
+        transparent: None,
     };
     let r = rewrite_with_config("make check", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(r, "make check");

--- a/crates/tokf-cli/src/rewrite/tests_compound.rs
+++ b/crates/tokf-cli/src/rewrite/tests_compound.rs
@@ -201,6 +201,7 @@ fn rewrite_user_rule_wraps_piped_command() {
         }],
         permissions: None,
         debug: None,
+        transparent: None,
     };
     let r = rewrite_with_config(
         "cargo test | grep FAILED",
@@ -224,6 +225,7 @@ fn rewrite_skip_pattern_wins_over_pipe_guard() {
         rewrite: vec![],
         permissions: None,
         debug: None,
+        transparent: None,
     };
     let r = rewrite_with_config(
         "git status | grep M",

--- a/crates/tokf-cli/src/rewrite/tests_env.rs
+++ b/crates/tokf-cli/src/rewrite/tests_env.rs
@@ -230,6 +230,7 @@ fn rewrite_user_skip_pattern_matches_env_stripped_command() {
         rewrite: vec![],
         permissions: None,
         debug: None,
+        transparent: None,
     };
     // "FOO=bar git status" does NOT start with "git", so skip does not fire
     // and the command IS rewritten.

--- a/crates/tokf-cli/src/rewrite/tests_pipe.rs
+++ b/crates/tokf-cli/src/rewrite/tests_pipe.rs
@@ -28,6 +28,7 @@ fn rewrite_pipe_strip_disabled_preserves_pipe() {
         rewrite: vec![],
         permissions: None,
         debug: None,
+        transparent: None,
     };
     let r = rewrite_with_config(
         "cargo test | tail -5",
@@ -57,6 +58,7 @@ fn rewrite_pipe_strip_disabled_non_piped_still_rewritten() {
         rewrite: vec![],
         permissions: None,
         debug: None,
+        transparent: None,
     };
     let r = rewrite_with_config(
         "cargo test --lib",
@@ -88,6 +90,7 @@ fn rewrite_prefer_less_injects_flag() {
         rewrite: vec![],
         permissions: None,
         debug: None,
+        transparent: None,
     };
     let r = rewrite_with_config(
         "cargo test | tail -5",
@@ -119,6 +122,7 @@ fn rewrite_prefer_less_without_pipe_no_effect() {
         rewrite: vec![],
         permissions: None,
         debug: None,
+        transparent: None,
     };
     let r = rewrite_with_config(
         "cargo test --lib",
@@ -148,6 +152,7 @@ fn rewrite_strip_false_overrides_prefer_less() {
         rewrite: vec![],
         permissions: None,
         debug: None,
+        transparent: None,
     };
     let r = rewrite_with_config(
         "cargo test | tail -5",
@@ -174,6 +179,7 @@ fn rewrite_compound_prefer_less_per_segment() {
         rewrite: vec![],
         permissions: None,
         debug: None,
+        transparent: None,
     };
     let r = rewrite_with_config(
         "git add . && git diff | head -5",

--- a/crates/tokf-cli/src/rewrite/tests_transparent.rs
+++ b/crates/tokf-cli/src/rewrite/tests_transparent.rs
@@ -13,7 +13,9 @@ use std::fs;
 use tempfile::TempDir;
 
 use super::*;
-use crate::rewrite::transparent::{BUILTIN_TRANSPARENT_COMMANDS, is_transparent_command};
+use crate::rewrite::transparent::{
+    BUILTIN_TRANSPARENT_COMMANDS, any_segment_is_transparent, is_transparent_command,
+};
 
 /// Build a config with one wildcard `[[rewrite]]` rule whose replacement
 /// would mangle any inner argv. Used to assert that the rule is *not*
@@ -199,6 +201,86 @@ fn ssh_pipe_strip_preserves_inner_argv() {
     );
 }
 
+#[test]
+fn ssh_with_pipe_inside_quotes_unchanged() {
+    // The `|` is inside the quoted ssh argument and runs on the remote.
+    // rable's AST treats this as a single Command (no top-level pipe), so
+    // pipe-strip logic must not fire. The inner argv must be byte-for-byte
+    // preserved regardless of the user's `[pipe]` settings.
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("ssh.toml"), "command = \"ssh\"").unwrap();
+
+    let config = RewriteConfig::default();
+    let result = rewrite_with_config(
+        "ssh HOST 'cmd | head -5'",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    // ssh has a filter, so the outer wrap fires — but the inner pipe is
+    // sealed inside the quoted argument and must not be stripped or
+    // injected as `--baseline-pipe`.
+    assert_eq!(result, "tokf run ssh HOST 'cmd | head -5'");
+}
+
+#[test]
+fn compound_with_ssh_segment_blocks_user_rule() {
+    // The wildcard rule's regex matches the *whole* compound, so even when
+    // ssh is in a later segment, applying the rule could splice text into
+    // the ssh argv. Gate must trip via any_segment_is_transparent.
+    let dir = TempDir::new().unwrap();
+    let config = config_with_mangling_rule();
+    let result = rewrite_with_config(
+        "cd /tmp && ssh HOST 'cmd'",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    // Whole compound is left untouched by the user rule; per-segment
+    // wraps below still try to fire (cd has no filter, ssh has no filter
+    // in this test, so the result is byte-for-byte identical to input).
+    assert_eq!(result, "cd /tmp && ssh HOST 'cmd'");
+}
+
+#[test]
+fn user_skip_pattern_takes_precedence_over_transparent_gate() {
+    // `[skip]` runs first and is the documented escape hatch. A user who
+    // has explicitly suppressed `ssh ` should still see no rewrite at all,
+    // not even the argv-preserving filter wrap.
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("ssh.toml"), "command = \"ssh\"").unwrap();
+
+    let config = RewriteConfig {
+        skip: Some(types::SkipConfig {
+            patterns: vec!["^ssh ".to_string()],
+        }),
+        pipe: None,
+        rewrite: vec![],
+        permissions: None,
+        debug: None,
+        transparent: None,
+    };
+    let result = rewrite_with_config(
+        "ssh HOST 'cmd'",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "ssh HOST 'cmd'");
+}
+
+#[test]
+fn ssh_basename_match_case_sensitive() {
+    // Shell PATH lookup is case-sensitive on Linux, and even on macOS
+    // (case-insensitive FS notwithstanding) we follow that convention.
+    // `SSH HOST cmd` is a different command name and must NOT be
+    // transparent — the user rule should mangle it.
+    let dir = TempDir::new().unwrap();
+    let config = config_with_mangling_rule();
+    let result = rewrite_with_config("SSH HOST cmd", &config, &[dir.path().to_path_buf()], false);
+    assert_eq!(result, "mangled SSH HOST cmd");
+}
+
 // --- is_transparent_command unit tests ---
 
 #[test]
@@ -244,4 +326,51 @@ fn builtin_list_contains_expected() {
     assert!(BUILTIN_TRANSPARENT_COMMANDS.contains(&"ssh"));
     assert!(BUILTIN_TRANSPARENT_COMMANDS.contains(&"mosh"));
     assert!(BUILTIN_TRANSPARENT_COMMANDS.contains(&"slogin"));
+}
+
+// --- any_segment_is_transparent unit tests ---
+
+#[test]
+fn any_segment_is_transparent_single_segment() {
+    assert!(any_segment_is_transparent("ssh HOST cmd", &[]));
+    assert!(!any_segment_is_transparent("git status", &[]));
+}
+
+#[test]
+fn any_segment_is_transparent_compound_first() {
+    assert!(any_segment_is_transparent("ssh HOST cmd && echo done", &[]));
+}
+
+#[test]
+fn any_segment_is_transparent_compound_middle() {
+    assert!(any_segment_is_transparent(
+        "cd /tmp && ssh HOST cmd && echo done",
+        &[]
+    ));
+}
+
+#[test]
+fn any_segment_is_transparent_compound_last() {
+    assert!(any_segment_is_transparent("cd /tmp && ssh HOST cmd", &[]));
+}
+
+#[test]
+fn any_segment_is_transparent_no_match_anywhere() {
+    assert!(!any_segment_is_transparent(
+        "cd /tmp && ls -la && echo done",
+        &[]
+    ));
+}
+
+#[test]
+fn any_segment_is_transparent_extras_apply_per_segment() {
+    let extras = vec!["kubectl".to_string()];
+    assert!(any_segment_is_transparent(
+        "cd /tmp && kubectl get pods",
+        &extras
+    ));
+    assert!(!any_segment_is_transparent(
+        "cd /tmp && kubectl get pods",
+        &[]
+    ));
 }

--- a/crates/tokf-cli/src/rewrite/tests_transparent.rs
+++ b/crates/tokf-cli/src/rewrite/tests_transparent.rs
@@ -1,0 +1,247 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Tests for the "transparent-arg" command class — see issue #338.
+//!
+//! When a command's last argument is opaque shell code that runs in a
+//! different environment (canonical example: `ssh HOST 'cmd'`), tokf must
+//! not splice text into that argv via regex `[[rewrite]]` rules. The
+//! built-in list (`ssh`, `mosh`, `slogin`) is always active; users can
+//! extend via `[transparent] commands = […]`.
+
+use std::fs;
+
+use tempfile::TempDir;
+
+use super::*;
+use crate::rewrite::transparent::{BUILTIN_TRANSPARENT_COMMANDS, is_transparent_command};
+
+/// Build a config with one wildcard `[[rewrite]]` rule whose replacement
+/// would mangle any inner argv. Used to assert that the rule is *not*
+/// applied to transparent commands.
+fn config_with_mangling_rule() -> RewriteConfig {
+    RewriteConfig {
+        skip: None,
+        pipe: None,
+        rewrite: vec![RewriteRule {
+            match_pattern: "^(.*)$".to_string(),
+            replace: "mangled {0}".to_string(),
+        }],
+        permissions: None,
+        debug: None,
+        transparent: None,
+    }
+}
+
+#[test]
+fn ssh_with_quoted_arg_passthrough_when_no_filter() {
+    // No filter for ssh — the standard `tokf run` wrap path doesn't fire,
+    // and the user's wildcard rewrite rule must not apply either.
+    let dir = TempDir::new().unwrap();
+    let config = config_with_mangling_rule();
+    let result = rewrite_with_config(
+        "ssh HOST 'ls -la /var/log'",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "ssh HOST 'ls -la /var/log'");
+}
+
+#[test]
+fn non_transparent_command_still_subject_to_user_rule() {
+    // Sanity check: the wildcard rule *does* fire on non-transparent
+    // commands. This pins the gating behaviour to the transparent class.
+    let dir = TempDir::new().unwrap();
+    let config = config_with_mangling_rule();
+    let result = rewrite_with_config("git status", &config, &[dir.path().to_path_buf()], false);
+    assert_eq!(result, "mangled git status");
+}
+
+#[test]
+fn ssh_basename_match_with_full_path() {
+    // /usr/bin/ssh must be treated identically to bare `ssh`.
+    let dir = TempDir::new().unwrap();
+    let config = config_with_mangling_rule();
+    let result = rewrite_with_config(
+        "/usr/bin/ssh HOST cmd",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "/usr/bin/ssh HOST cmd");
+}
+
+#[test]
+fn ssh_add_is_not_transparent() {
+    // `ssh-add` is a sibling tool, not a remote-shell launcher — the
+    // wildcard rule should still apply.
+    let dir = TempDir::new().unwrap();
+    let config = config_with_mangling_rule();
+    let result = rewrite_with_config(
+        "ssh-add ~/.ssh/id_rsa",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "mangled ssh-add ~/.ssh/id_rsa");
+}
+
+#[test]
+fn mosh_is_built_in_transparent() {
+    let dir = TempDir::new().unwrap();
+    let config = config_with_mangling_rule();
+    let result = rewrite_with_config(
+        "mosh HOST 'remote-cmd'",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "mosh HOST 'remote-cmd'");
+}
+
+#[test]
+fn slogin_is_built_in_transparent() {
+    let dir = TempDir::new().unwrap();
+    let config = config_with_mangling_rule();
+    let result = rewrite_with_config(
+        "slogin HOST cmd",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "slogin HOST cmd");
+}
+
+#[test]
+fn user_can_extend_transparent_list() {
+    // A user with `kubectl exec` workflows can add `kubectl` to the list.
+    let dir = TempDir::new().unwrap();
+    let config = RewriteConfig {
+        skip: None,
+        pipe: None,
+        rewrite: vec![RewriteRule {
+            match_pattern: "^(.*)$".to_string(),
+            replace: "mangled {0}".to_string(),
+        }],
+        permissions: None,
+        debug: None,
+        transparent: Some(types::TransparentConfig {
+            commands: vec!["kubectl".to_string()],
+        }),
+    };
+    let result = rewrite_with_config(
+        "kubectl exec POD -- cmd",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "kubectl exec POD -- cmd");
+}
+
+#[test]
+fn user_extra_does_not_disable_built_ins() {
+    // Adding kubectl to the user list must not silently turn off ssh.
+    let dir = TempDir::new().unwrap();
+    let config = RewriteConfig {
+        skip: None,
+        pipe: None,
+        rewrite: vec![RewriteRule {
+            match_pattern: "^(.*)$".to_string(),
+            replace: "mangled {0}".to_string(),
+        }],
+        permissions: None,
+        debug: None,
+        transparent: Some(types::TransparentConfig {
+            commands: vec!["kubectl".to_string()],
+        }),
+    };
+    let result = rewrite_with_config("ssh HOST cmd", &config, &[dir.path().to_path_buf()], false);
+    assert_eq!(result, "ssh HOST cmd");
+}
+
+#[test]
+fn ssh_filter_match_still_wraps_with_tokf_run() {
+    // The argv-preserving `tokf run` wrap is still allowed for transparent
+    // commands — it only prefixes, never splices into the argv. So if a
+    // user has a filter for ssh, the outer wrap kicks in and the inner
+    // quoted argument is left untouched.
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("ssh.toml"), "command = \"ssh\"").unwrap();
+
+    let config = RewriteConfig::default();
+    let result = rewrite_with_config(
+        "ssh HOST 'docker ps'",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "tokf run ssh HOST 'docker ps'");
+}
+
+#[test]
+fn ssh_pipe_strip_preserves_inner_argv() {
+    // Pipe stripping with `--baseline-pipe` is also argv-preserving — it
+    // adds flags between `tokf run` and the command. Verify the inner
+    // quoted argument is byte-for-byte preserved.
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("ssh.toml"), "command = \"ssh\"").unwrap();
+
+    let config = RewriteConfig::default();
+    let result = rewrite_with_config(
+        "ssh HOST 'docker ps' | head -5",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(
+        result,
+        "tokf run --baseline-pipe 'head -5' ssh HOST 'docker ps'"
+    );
+}
+
+// --- is_transparent_command unit tests ---
+
+#[test]
+fn is_transparent_command_built_ins() {
+    assert!(is_transparent_command("ssh HOST cmd", &[]));
+    assert!(is_transparent_command("mosh HOST cmd", &[]));
+    assert!(is_transparent_command("slogin HOST cmd", &[]));
+}
+
+#[test]
+fn is_transparent_command_basename() {
+    assert!(is_transparent_command("/usr/bin/ssh HOST cmd", &[]));
+    assert!(is_transparent_command("~/bin/ssh HOST cmd", &[]));
+}
+
+#[test]
+fn is_transparent_command_env_prefix() {
+    assert!(is_transparent_command(
+        "SSH_AUTH_SOCK=/tmp/x ssh HOST cmd",
+        &[]
+    ));
+}
+
+#[test]
+fn is_transparent_command_user_extras() {
+    let extras = vec!["kubectl".to_string(), "doctl".to_string()];
+    assert!(is_transparent_command("kubectl get pods", &extras));
+    assert!(is_transparent_command("doctl k8s cluster list", &extras));
+}
+
+#[test]
+fn is_transparent_command_negative() {
+    assert!(!is_transparent_command("git status", &[]));
+    assert!(!is_transparent_command("ssh-add", &[]));
+    assert!(!is_transparent_command("scp file HOST:dst", &[]));
+    assert!(!is_transparent_command("", &[]));
+}
+
+#[test]
+fn builtin_list_contains_expected() {
+    // Documents the built-in list at the test layer so an accidental
+    // narrowing is caught in CI.
+    assert!(BUILTIN_TRANSPARENT_COMMANDS.contains(&"ssh"));
+    assert!(BUILTIN_TRANSPARENT_COMMANDS.contains(&"mosh"));
+    assert!(BUILTIN_TRANSPARENT_COMMANDS.contains(&"slogin"));
+}

--- a/crates/tokf-cli/src/rewrite/transparent.rs
+++ b/crates/tokf-cli/src/rewrite/transparent.rs
@@ -1,0 +1,33 @@
+//! Detection of "transparent-arg" commands — commands whose last argument
+//! is opaque shell code that runs in a different environment (typically a
+//! remote host or container shell). For these, tokf is allowed to prefix
+//! the command (e.g. `tokf run ssh …`) but **must not** modify the argv
+//! via regex `[[rewrite]]` rules — those can splice text into the opaque
+//! payload and break the remote invocation. See issue #338.
+
+/// Commands always treated as transparent. Extended (not replaced) by the
+/// user's `[transparent] commands = […]` config.
+///
+/// Picked because each takes a remote shell-command as its last argument:
+/// - `ssh`, `slogin` — OpenSSH and the legacy alias.
+/// - `mosh` — wraps ssh, same model from a rewrite-safety POV.
+///
+/// `scp` / `rsync` are intentionally excluded: their last positional
+/// argument is a file path, not shell code, so the regex-mangling failure
+/// mode doesn't apply. `telnet` is excluded for the same reason (port
+/// number, not a shell command).
+pub const BUILTIN_TRANSPARENT_COMMANDS: &[&str] = &["ssh", "mosh", "slogin"];
+
+/// Return true if the first command word's basename matches the built-in
+/// transparent list or one of `user_extras`.
+///
+/// `user_extras` should be the `commands` field from
+/// [`tokf_hook_types::TransparentConfig`] — basename matches, e.g.
+/// `"kubectl"` matches both `kubectl` and `/usr/local/bin/kubectl`.
+pub fn is_transparent_command(command: &str, user_extras: &[String]) -> bool {
+    let Some(name) = super::bash_ast::first_command_basename(command) else {
+        return false;
+    };
+    BUILTIN_TRANSPARENT_COMMANDS.iter().any(|b| *b == name)
+        || user_extras.iter().any(|u| u == &name)
+}

--- a/crates/tokf-cli/src/rewrite/transparent.rs
+++ b/crates/tokf-cli/src/rewrite/transparent.rs
@@ -31,3 +31,15 @@ pub fn is_transparent_command(command: &str, user_extras: &[String]) -> bool {
     BUILTIN_TRANSPARENT_COMMANDS.iter().any(|b| *b == name)
         || user_extras.iter().any(|u| u == &name)
 }
+
+/// Return true if **any** segment of a compound command is a transparent-arg
+/// invocation. Used to gate user `[[rewrite]]` regex rules at the top level
+/// of `rewrite_with_config_and_options`: those rules run on the *whole*
+/// command string, so even one ssh segment hidden behind a `cd … &&` is
+/// enough to make it unsafe to splice text anywhere in the command.
+pub fn any_segment_is_transparent(command: &str, user_extras: &[String]) -> bool {
+    super::bash_ast::split_compound(command)
+        .iter()
+        .map(|(seg, _sep)| seg.trim())
+        .any(|seg| is_transparent_command(seg, user_extras))
+}

--- a/crates/tokf-cli/src/rewrite/types.rs
+++ b/crates/tokf-cli/src/rewrite/types.rs
@@ -1,5 +1,6 @@
 pub use tokf_hook_types::{
     PermissionEngineType, PermissionsConfig, PipeConfig, RewriteConfig, RewriteRule, SkipConfig,
+    TransparentConfig,
 };
 
 /// Options that control how the rewrite system generates `tokf run` commands.
@@ -243,5 +244,32 @@ log_parse_failures = true
     fn deserialize_no_debug_section() {
         let config: RewriteConfig = toml::from_str("").unwrap();
         assert!(config.debug.is_none());
+    }
+
+    #[test]
+    fn deserialize_transparent_section() {
+        let toml_str = r#"
+[transparent]
+commands = ["kubectl", "doctl"]
+"#;
+        let config: RewriteConfig = toml::from_str(toml_str).unwrap();
+        let t = config.transparent.unwrap();
+        assert_eq!(t.commands, vec!["kubectl".to_string(), "doctl".to_string()]);
+    }
+
+    #[test]
+    fn deserialize_transparent_empty_commands() {
+        let toml_str = r"
+[transparent]
+";
+        let config: RewriteConfig = toml::from_str(toml_str).unwrap();
+        let t = config.transparent.unwrap();
+        assert!(t.commands.is_empty());
+    }
+
+    #[test]
+    fn deserialize_no_transparent_section() {
+        let config: RewriteConfig = toml::from_str("").unwrap();
+        assert!(config.transparent.is_none());
     }
 }

--- a/crates/tokf-hook-types/src/config.rs
+++ b/crates/tokf-hook-types/src/config.rs
@@ -24,6 +24,27 @@ pub struct RewriteConfig {
 
     /// Debug/diagnostic settings (all off by default).
     pub debug: Option<DebugConfig>,
+
+    /// Commands whose argv is opaque to tokf because it executes in a
+    /// different shell environment (typically a remote host or container).
+    /// User regex `[[rewrite]]` rules are not applied to these commands —
+    /// only argv-preserving wraps (`tokf run <cmd>`) and pipe-flag injection
+    /// remain.
+    pub transparent: Option<TransparentConfig>,
+}
+
+/// "Transparent-arg" commands: their last argument is opaque shell code.
+///
+/// Built-in list (always active): `ssh`, `mosh`, `slogin`. The `commands`
+/// field extends — does not replace — the built-in list. tokf must not
+/// splice text into the argv of these commands via regex rewrites.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct TransparentConfig {
+    /// Additional command basenames to treat as transparent. Matched against
+    /// the basename of the command's first word, so `kubectl` matches both
+    /// `kubectl` and `/usr/local/bin/kubectl`.
+    #[serde(default)]
+    pub commands: Vec<String>,
 }
 
 /// Debug and diagnostic settings for the rewrite system.

--- a/crates/tokf-hook-types/src/lib.rs
+++ b/crates/tokf-hook-types/src/lib.rs
@@ -5,6 +5,7 @@ pub mod verdict;
 
 pub use config::{
     PermissionEngineType, PermissionsConfig, PipeConfig, RewriteConfig, RewriteRule, SkipConfig,
+    TransparentConfig,
 };
 pub use engine::{ErrorFallback, ExternalEngineConfig};
 pub use format::HookFormat;

--- a/docs/rewrites-config.md
+++ b/docs/rewrites-config.md
@@ -405,6 +405,33 @@ git status && git diff > foo.txt  # → "tokf run git status && git diff > foo.t
 
 `tee` in a pipeline (`git diff | tee log.txt`) is **not** currently treated as an output redirect because `tee` is a command argument, not a redirect operator. The current pipe-handling behaviour is preserved. This is a known follow-up.
 
+## Transparent-arg commands
+
+Some commands take a shell-code payload that runs in a *different* environment — `ssh HOST 'cmd'` runs `cmd` on the remote host, where tokf is not installed and shouldn't be referenced. For these commands tokf must be especially conservative: it can still wrap the local invocation with `tokf run` (which preserves the argv byte-for-byte), but **user `[[rewrite]]` regex rules are not applied** because a sufficiently broad pattern can splice text into the opaque payload and break the remote call.
+
+The built-in list — always active, can't be disabled — is `ssh`, `mosh`, `slogin`. Basename matching applies, so `/usr/bin/ssh` is treated identically to `ssh`.
+
+You can extend the list via `[transparent]` for tools like `kubectl exec`, `docker exec`, etc.:
+
+```toml
+[transparent]
+commands = ["kubectl", "doctl"]
+```
+
+Names are matched against the basename of the command's first word. `commands` extends — not replaces — the built-in list, so `kubectl` is added on top of `ssh`/`mosh`/`slogin`.
+
+What still happens for transparent commands:
+- The standard `tokf run <cmd>` wrap from a matching filter (argv-preserving prefix only).
+- Pipe stripping with `--baseline-pipe '<suffix>'` (flags inserted between `tokf run` and `<cmd>`; the inner argv is untouched).
+- The built-in `^tokf ` skip and the heredoc / output-redirect skips above.
+
+What is gated:
+- User `[[rewrite]]` regex rules in `rewrites.toml`. They run on the full command string and could splice text into the inner argv, so they're skipped when the first command word's basename is in the transparent list.
+
+If you genuinely need a regex rewrite for an ssh-class command, invoke it explicitly: `tokf run ssh …` is preserved by the `^tokf ` skip rule, so it won't be re-rewritten.
+
+This was added to address [#338](https://github.com/mpecan/tokf/issues/338), where a long-output `ssh HOST 'cmd'` would land `tokf` on the remote bash and exit 127.
+
 ## Debug settings
 
 The `[debug]` section enables diagnostic logging for the rewrite system. All settings are off by default.


### PR DESCRIPTION
## Summary

Adds a "transparent-arg" command class for tools whose last argument is opaque shell code that runs in a different environment (canonical case: `ssh HOST 'cmd'`). For these, user `[[rewrite]]` regex rules — which run against the full command string and can splice text anywhere — are gated. The argv-preserving paths (`tokf run` wrap from a matching filter, `--baseline-pipe` injection from pipe-stripping) still apply, so local output filtering for ssh continues to work.

Built-in list: `ssh`, `mosh`, `slogin`. Users extend via `rewrites.toml`:

```toml
[transparent]
commands = ["kubectl", "doctl"]
```

The gate is per-segment for compound commands, so `cd /tmp && ssh HOST 'cmd'` is also protected (any segment containing a transparent invocation suppresses user regex rules across the whole compound).

In response to: #338

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 2195 passed
- [x] New `tests_transparent.rs` (15 cases): wrap still works, pipe-strip preserves argv, user regex gated, basename match, sibling commands not swept up, user-extended list, compound command coverage, pipe-inside-quotes, user-skip precedence, case sensitivity
- [x] New `bash_ast_tests` for `first_command_basename` (8 cases): basename, env prefix, quoted name, command substitution, mismatched quotes
- [x] New serde round-trip tests for `[transparent] commands = […]`
- [x] Docs updated in `docs/rewrites-config.md`; README regenerated by pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)