### PR TITLE
feat(cli): add tokf issue subcommand for diagnostic reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -2078,6 +2078,48 @@ The doctor excludes events whose command path looks like a temp-dir or test-fixt
 
 `tokf doctor` is the **post-hoc** half of the diagnostics story. Phase 2 will add **runtime surfacing** — an in-process LRU that detects bursts as they happen and prints a `[tokf] notice:` line on stderr in the same tool result the agent sees. Phase 3 will add an `--apply-suggestions` interactive mode that proposes config patches. Both are explicitly out of scope for the current release.
 
+## tokf issue
+
+`tokf issue` builds a GitHub bug report with a non-PII diagnostic snapshot of your installation, **shows you the full body before anything is sent**, and submits it via `gh` if available — falling back to a printable markdown document otherwise. Transparency is the contract: every byte that would be uploaded is rendered to your terminal first.
+
+```sh
+tokf issue                                       # interactive: title prompt + $EDITOR for body
+tokf issue --title "panic in cargo/test" \
+           --body "Filter crashes on empty input"
+tokf issue --title "..." --body "..." --print    # print markdown only, never call gh
+tokf issue --title "..." --body-from bug.md      # body from file (or `-` for stdin)
+tokf issue --title "..." --body "..." -y         # skip the confirmation prompt
+tokf issue --title "..." --body "..." \
+           --include-filters                     # opt in to attaching filter names
+tokf issue --title "..." --body "..." \
+           --repo my-fork/tokf                   # file against a different repo
+```
+
+### What gets included
+
+The diagnostic snapshot is the same data shape as `tokf info`, with the user's home directory replaced by `~`:
+
+- `tokf` version, OS, architecture, shell name (e.g. `zsh`, never the full `$SHELL` path).
+- Whether `gh` and `git` are on `PATH`.
+- `TOKF_HOME` value, filter search directories with existence + writable status, tracking DB and cache paths and writability, filter counts by scope (built-in / user / local), and which config files exist.
+
+### What is intentionally excluded
+
+A footer comment in every report enumerates what was withheld:
+
+- Hostname, username, machine UUID
+- Auth tokens (server credentials live in the OS keyring; `tokf issue` never reads them)
+- Environment variables, command history, filter contents
+- Filter **names** by default — user/local filter names can encode internal command names. Add `--include-filters` to attach them; the preview always shows what would be sent. In interactive mode (title or body coming from a prompt), tokf asks once whether to include your custom filter names — useful for debugging filter-resolution bugs.
+
+### Submission flow
+
+1. The full markdown body is printed to **stderr** between `--- ISSUE PREVIEW ---` markers, every time.
+2. With `--print`, that's the end — the body is also written to stdout for piping.
+3. Without `--print`:
+   - If `gh` is missing, tokf prints the markdown and a pre-filled `https://github.com/<repo>/issues/new?title=...&body=...` URL (when the body fits in URL limits — otherwise a copy/paste hint).
+   - If `gh` is present, tokf asks `Submit to mpecan/tokf? [y/N]` (skip with `-y`), runs `gh issue create --body-file <tmpfile>`, and prints the resulting issue URL on success. On `gh` failure, the same fallback markdown is emitted so you don't lose the body.
+
 ## Cache management
 
 tokf caches the filter discovery index for faster startup. The cache rebuilds automatically when filters change, but you can manage it manually:

--- a/crates/tokf-cli/Cargo.toml
+++ b/crates/tokf-cli/Cargo.toml
@@ -42,6 +42,7 @@ clap_complete_nushell = "4.5"
 dialoguer = { version = "0.12", default-features = false }
 which = "8"
 rable = "0.1.15"
+tempfile = "3"
 opentelemetry     = { version = "0.31", optional = true, features = ["metrics"] }
 opentelemetry_sdk = { version = "0.31", optional = true, features = ["metrics"] }
 opentelemetry-otlp = { version = "0.31", optional = true }
@@ -77,7 +78,6 @@ otel-grpc = [
 
 [dev-dependencies]
 tokf-dev = { path = ".", package = "tokf", features = ["test-keyring"] }
-tempfile = "3"
 serial_test = "3"
 mockito = "1.7.2"
 filetime = "0.2"

--- a/crates/tokf-cli/src/info_cmd.rs
+++ b/crates/tokf-cli/src/info_cmd.rs
@@ -2,13 +2,13 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use tokf::config;
+use tokf::config::{self, ResolvedFilter};
 use tokf::tracking;
 
 /// Write-access status for a path that tokf needs to write to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
-enum WriteAccess {
+pub enum WriteAccess {
     /// Path exists and is writable by the current process.
     Writable,
     /// Path exists but is not writable.
@@ -22,7 +22,7 @@ enum WriteAccess {
 }
 
 impl WriteAccess {
-    const fn label(self) -> &'static str {
+    pub const fn label(self) -> &'static str {
         match self {
             Self::Writable => "writable",
             Self::ReadOnly => "read-only!",
@@ -90,54 +90,54 @@ fn check_write_access(path: &Path) -> WriteAccess {
 }
 
 #[derive(Serialize)]
-struct SearchDir {
-    scope: &'static str,
-    path: String,
-    exists: bool,
+pub struct SearchDir {
+    pub scope: &'static str,
+    pub path: String,
+    pub exists: bool,
     /// `Some(access)` when the directory exists; `None` when it does not.
-    access: Option<WriteAccess>,
+    pub access: Option<WriteAccess>,
 }
 
 #[derive(Serialize)]
-struct TrackingDb {
-    env_override: Option<String>,
-    path: Option<String>,
-    exists: bool,
-    access: Option<WriteAccess>,
+pub struct TrackingDb {
+    pub env_override: Option<String>,
+    pub path: Option<String>,
+    pub exists: bool,
+    pub access: Option<WriteAccess>,
 }
 
 #[derive(Serialize)]
-struct CacheInfo {
-    path: Option<String>,
-    exists: bool,
-    access: Option<WriteAccess>,
+pub struct CacheInfo {
+    pub path: Option<String>,
+    pub exists: bool,
+    pub access: Option<WriteAccess>,
 }
 
 #[derive(Serialize)]
-struct FilterCounts {
-    local: usize,
-    user: usize,
-    builtin: usize,
-    total: usize,
+pub struct FilterCounts {
+    pub local: usize,
+    pub user: usize,
+    pub builtin: usize,
+    pub total: usize,
 }
 
 #[derive(Serialize)]
-struct ConfigFileEntry {
-    scope: &'static str,
-    path: String,
-    exists: bool,
+pub struct ConfigFileEntry {
+    pub scope: &'static str,
+    pub path: String,
+    pub exists: bool,
 }
 
 #[derive(Serialize)]
-struct InfoOutput {
-    version: String,
+pub struct InfoOutput {
+    pub version: String,
     /// `TOKF_HOME` env var value when set; affects all user-level paths.
-    home_override: Option<String>,
-    search_dirs: Vec<SearchDir>,
-    tracking_db: TrackingDb,
-    cache: CacheInfo,
-    config_files: Vec<ConfigFileEntry>,
-    filters: Option<FilterCounts>,
+    pub home_override: Option<String>,
+    pub search_dirs: Vec<SearchDir>,
+    pub tracking_db: TrackingDb,
+    pub cache: CacheInfo,
+    pub config_files: Vec<ConfigFileEntry>,
+    pub filters: Option<FilterCounts>,
 }
 
 pub fn cmd_info(json: bool) -> i32 {
@@ -178,30 +178,39 @@ fn collect_search_dirs(search_dirs: &[PathBuf]) -> Vec<SearchDir> {
     dirs
 }
 
-fn collect_filter_counts(search_dirs: &[PathBuf]) -> Option<FilterCounts> {
-    match config::discover_all_filters(search_dirs) {
-        Ok(f) => {
-            let local = f.iter().filter(|fi| fi.priority == 0).count();
-            let user = f
-                .iter()
-                .filter(|fi| fi.priority > 0 && fi.priority < u8::MAX)
-                .count();
-            let builtin = f.iter().filter(|fi| fi.priority == u8::MAX).count();
-            Some(FilterCounts {
-                local,
-                user,
-                builtin,
-                total: f.len(),
-            })
-        }
+/// Bucket a discovered filter list into the counts shown in `tokf info`.
+pub fn count_filters_by_priority(filters: &[ResolvedFilter]) -> FilterCounts {
+    let local = filters.iter().filter(|fi| fi.priority == 0).count();
+    let user = filters
+        .iter()
+        .filter(|fi| fi.priority > 0 && fi.priority < u8::MAX)
+        .count();
+    let builtin = filters.iter().filter(|fi| fi.priority == u8::MAX).count();
+    FilterCounts {
+        local,
+        user,
+        builtin,
+        total: filters.len(),
+    }
+}
+
+pub fn collect_info(search_dirs: &[PathBuf]) -> InfoOutput {
+    let filters = match config::discover_all_filters(search_dirs) {
+        Ok(f) => Some(f),
         Err(e) => {
             eprintln!("[tokf] error discovering filters: {e:#}");
             None
         }
-    }
+    };
+    collect_info_with_filters(search_dirs, filters.as_deref())
 }
 
-fn collect_info(search_dirs: &[PathBuf]) -> InfoOutput {
+/// Build an `InfoOutput` from a pre-discovered filter list. Pass `None` when
+/// discovery failed; the caller is expected to have already logged the error.
+pub fn collect_info_with_filters(
+    search_dirs: &[PathBuf],
+    filters: Option<&[ResolvedFilter]>,
+) -> InfoOutput {
     let dirs = collect_search_dirs(search_dirs);
 
     // Normalise to None when empty/whitespace-only, matching paths::resolve_user_path() behaviour.
@@ -238,7 +247,7 @@ fn collect_info(search_dirs: &[PathBuf]) -> InfoOutput {
         tracking_db,
         cache,
         config_files,
-        filters: collect_filter_counts(search_dirs),
+        filters: filters.map(count_filters_by_priority),
     }
 }
 

--- a/crates/tokf-cli/src/issue_cmd/mod.rs
+++ b/crates/tokf-cli/src/issue_cmd/mod.rs
@@ -1,0 +1,560 @@
+//! `tokf issue` — gather a non-PII diagnostic snapshot, show it to the user,
+//! and submit it via `gh` (or fall back to a printable markdown document).
+//!
+//! The body is **always** previewed on stderr before any submission. PII is
+//! filtered at the rendering layer (home prefix → `~`); the file additionally
+//! avoids collecting hostname, username, machine UUID, or auth tokens.
+
+use std::fmt::Write as _;
+use std::io::{Read, Write as _};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::info_cmd::{self, InfoOutput, WriteAccess};
+
+const DEFAULT_REPO: &str = "mpecan/tokf";
+
+/// GitHub's `issues/new?...` URL has practical length limits; stay well under
+/// browser/server caps. Above this, fall back to copy/paste guidance.
+const ISSUES_NEW_URL_BUDGET: usize = 8000;
+
+/// Args for `tokf issue`. Defined here (not inline in `main.rs`) so the
+/// per-flag doc comments don't push `main.rs` over the 700-line hard limit;
+/// `#[command(flatten)]` in `Commands::Issue` inlines them into the
+/// subcommand. Mirrors the pattern used by `commands::DoctorArgs`.
+#[derive(clap::Args, Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)] // CLI flags are naturally booleans.
+pub struct IssueArgs {
+    /// Issue title (skip the interactive prompt)
+    #[arg(long)]
+    pub title: Option<String>,
+    /// Issue description body (mutually exclusive with --body-from)
+    #[arg(long, conflicts_with = "body_from")]
+    pub body: Option<String>,
+    /// Read body from file path, or `-` for stdin
+    #[arg(long, value_name = "FILE")]
+    pub body_from: Option<String>,
+    /// Print the markdown to stdout instead of submitting via gh
+    #[arg(long)]
+    pub print: bool,
+    /// Skip the confirmation prompt before submitting
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+    /// Override the destination repository
+    #[arg(long, value_name = "OWNER/REPO", default_value = DEFAULT_REPO)]
+    pub repo: String,
+    /// Include the names of every loaded filter in the report (off by default)
+    #[arg(long)]
+    pub include_filters: bool,
+}
+
+#[derive(Debug, Clone)]
+struct EnvSnapshot {
+    os: &'static str,
+    arch: &'static str,
+    shell: Option<String>,
+    has_gh: bool,
+    has_git: bool,
+}
+
+struct FilterNames {
+    local: Vec<String>,
+    user: Vec<String>,
+    builtin: Vec<String>,
+}
+
+pub fn cmd_issue(opts: &IssueArgs) -> i32 {
+    if opts.body.is_some() && opts.body_from.is_some() {
+        eprintln!("[tokf] --body and --body-from are mutually exclusive");
+        return 2;
+    }
+
+    let prepared = match prepare_issue(opts) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("[tokf] {e:#}");
+            return 1;
+        }
+    };
+
+    print_preview(&prepared);
+    dispatch(opts, &prepared)
+}
+
+struct PreparedIssue {
+    title: String,
+    markdown: String,
+}
+
+fn prepare_issue(opts: &IssueArgs) -> Result<PreparedIssue> {
+    let title = resolve_title(opts)?;
+    let user_body = resolve_body(opts)?;
+
+    let search_dirs = tokf::config::default_search_dirs();
+    let discovered_filters = match tokf::config::discover_all_filters(&search_dirs) {
+        Ok(f) => Some(f),
+        Err(e) => {
+            eprintln!("[tokf] error discovering filters: {e:#}");
+            None
+        }
+    };
+    let info = info_cmd::collect_info_with_filters(&search_dirs, discovered_filters.as_deref());
+    let env = collect_env();
+
+    let include_filters = opts.include_filters || should_prompt_for_filters(opts, &info);
+    let filter_names = include_filters
+        .then(|| discovered_filters.as_deref().map(collect_filter_names))
+        .flatten();
+
+    let home = dirs::home_dir();
+    let inputs = MarkdownInputs {
+        user_body: &user_body,
+        info: &info,
+        env: &env,
+        filters: filter_names.as_ref(),
+        home: home.as_deref(),
+    };
+    let markdown = render_markdown(&inputs);
+    Ok(PreparedIssue { title, markdown })
+}
+
+fn print_preview(p: &PreparedIssue) {
+    eprintln!("\n--- ISSUE PREVIEW ---");
+    eprintln!("title: {}", p.title);
+    eprintln!();
+    eprintln!("{}", p.markdown);
+    eprintln!("--- END PREVIEW ---\n");
+}
+
+fn dispatch(opts: &IssueArgs, p: &PreparedIssue) -> i32 {
+    if opts.print {
+        println!("{}", p.markdown);
+        return 0;
+    }
+    if which::which("gh").is_err() {
+        eprintln!("[tokf] gh not found on PATH — falling back to printable output.");
+        fallback_print(&opts.repo, &p.title, &p.markdown);
+        return 0;
+    }
+    if !opts.yes && !confirm_submit(&opts.repo) {
+        eprintln!("[tokf] not submitting — printing markdown for copy/paste.");
+        fallback_print(&opts.repo, &p.title, &p.markdown);
+        return 0;
+    }
+    match submit_via_gh(&opts.repo, &p.title, &p.markdown) {
+        Ok(url) => {
+            if !url.is_empty() {
+                println!("{url}");
+            }
+            0
+        }
+        Err(e) => {
+            eprintln!("[tokf] gh submission failed: {e:#}");
+            eprintln!("[tokf] falling back to printable output:");
+            fallback_print(&opts.repo, &p.title, &p.markdown);
+            1
+        }
+    }
+}
+
+fn resolve_title(opts: &IssueArgs) -> Result<String> {
+    if let Some(t) = &opts.title {
+        let t = t.trim().to_string();
+        if t.is_empty() {
+            anyhow::bail!("--title cannot be empty");
+        }
+        return Ok(t);
+    }
+    let raw: String = dialoguer::Input::new()
+        .with_prompt("Issue title")
+        .interact_text()
+        .context("reading title")?;
+    let t = raw.trim().to_string();
+    if t.is_empty() {
+        anyhow::bail!("title cannot be empty");
+    }
+    Ok(t)
+}
+
+fn resolve_body(opts: &IssueArgs) -> Result<String> {
+    if let Some(b) = &opts.body {
+        return Ok(b.clone());
+    }
+    if let Some(p) = &opts.body_from {
+        if p == "-" {
+            let mut s = String::new();
+            std::io::stdin()
+                .read_to_string(&mut s)
+                .context("reading body from stdin")?;
+            return Ok(s);
+        }
+        return std::fs::read_to_string(p).with_context(|| format!("reading body from {p}"));
+    }
+    if let Some(b) = read_body_via_editor()? {
+        return Ok(b);
+    }
+    let raw: String = dialoguer::Input::new()
+        .with_prompt("Describe the issue (single line; pass --body-from for longer text)")
+        .allow_empty(true)
+        .interact_text()
+        .context("reading body")?;
+    Ok(raw)
+}
+
+/// Open `$EDITOR` (or `$VISUAL`) on a temp file with comment guidance.
+/// Returns `Ok(None)` when no editor is configured. Strips `#`-prefixed
+/// lines from the result.
+fn read_body_via_editor() -> Result<Option<String>> {
+    let editor = std::env::var("EDITOR")
+        .ok()
+        .or_else(|| std::env::var("VISUAL").ok())
+        .filter(|s| !s.trim().is_empty());
+    let Some(editor) = editor else {
+        return Ok(None);
+    };
+    let tmp = tempfile::Builder::new()
+        .prefix("tokf-issue-")
+        .suffix(".md")
+        .tempfile()
+        .context("creating temp file for editor")?;
+    std::fs::write(
+        tmp.path(),
+        "# Describe the issue. Lines starting with '#' are removed.\n\
+         # Save and quit when done.\n\n",
+    )
+    .context("seeding temp file")?;
+    let status = std::process::Command::new(&editor)
+        .arg(tmp.path())
+        .status()
+        .with_context(|| format!("running editor: {editor}"))?;
+    if !status.success() {
+        anyhow::bail!("editor exited with non-zero status: {status}");
+    }
+    let raw = std::fs::read_to_string(tmp.path()).context("reading edited body")?;
+    let cleaned: String = raw
+        .lines()
+        .filter(|l| !l.starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Ok(Some(cleaned.trim().to_string()))
+}
+
+fn confirm_submit(repo: &str) -> bool {
+    dialoguer::Confirm::new()
+        .with_prompt(format!("Submit to {repo}?"))
+        .default(false)
+        .interact()
+        .unwrap_or(false)
+}
+
+/// True when the user is in interactive mode (i.e. we already prompted for
+/// at least one of title/body) and they have custom filters that could be
+/// useful to include. The actual prompt fires here on `true`.
+fn should_prompt_for_filters(opts: &IssueArgs, info: &InfoOutput) -> bool {
+    if opts.include_filters {
+        return false; // already covered by the flag
+    }
+    let interactive = opts.title.is_none() || (opts.body.is_none() && opts.body_from.is_none());
+    if !interactive {
+        return false;
+    }
+    let custom = custom_filter_count(info);
+    if custom == 0 {
+        return false;
+    }
+    prompt_include_custom_filters(custom)
+}
+
+fn custom_filter_count(info: &InfoOutput) -> usize {
+    info.filters.as_ref().map_or(0, |f| f.user + f.local)
+}
+
+fn prompt_include_custom_filters(count: usize) -> bool {
+    dialoguer::Confirm::new()
+        .with_prompt(format!(
+            "Include {count} custom filter name(s) in the report? Helpful for debugging; may reveal project-internal command names."
+        ))
+        .default(false)
+        .interact()
+        .unwrap_or(false)
+}
+
+fn collect_env() -> EnvSnapshot {
+    let shell = std::env::var("SHELL").ok().and_then(|p| {
+        Path::new(&p)
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+    });
+    EnvSnapshot {
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+        shell,
+        has_gh: which::which("gh").is_ok(),
+        has_git: which::which("git").is_ok(),
+    }
+}
+
+fn collect_filter_names(filters: &[tokf::config::ResolvedFilter]) -> FilterNames {
+    let mut names = FilterNames {
+        local: Vec::new(),
+        user: Vec::new(),
+        builtin: Vec::new(),
+    };
+    for f in filters {
+        let name = f.relative_path.with_extension("").display().to_string();
+        if f.priority == 0 {
+            names.local.push(name);
+        } else if f.priority == u8::MAX {
+            names.builtin.push(name);
+        } else {
+            names.user.push(name);
+        }
+    }
+    names.local.sort();
+    names.user.sort();
+    names.builtin.sort();
+    names
+}
+
+/// Replace the user's home directory prefix in `s` with `~`. No-op when
+/// `home` is `None` or empty. Idempotent.
+fn redact_home(s: &str, home: Option<&Path>) -> String {
+    let Some(h) = home else {
+        return s.to_string();
+    };
+    let h_str = h.display().to_string();
+    if h_str.is_empty() {
+        return s.to_string();
+    }
+    s.replace(&h_str, "~")
+}
+
+struct MarkdownInputs<'a> {
+    user_body: &'a str,
+    info: &'a InfoOutput,
+    env: &'a EnvSnapshot,
+    filters: Option<&'a FilterNames>,
+    home: Option<&'a Path>,
+}
+
+fn render_markdown(inputs: &MarkdownInputs<'_>) -> String {
+    let mut out = String::new();
+    render_summary(&mut out, inputs.user_body);
+    render_environment(&mut out, inputs.info, inputs.env);
+    render_installation(&mut out, inputs.info, inputs.home);
+    if let Some(fl) = inputs.filters {
+        render_filter_opt_in(&mut out, fl);
+    }
+    render_footer(&mut out, inputs.filters.is_some());
+    out
+}
+
+fn render_summary(out: &mut String, user_body: &str) {
+    out.push_str("## Summary\n\n");
+    if user_body.trim().is_empty() {
+        out.push_str("_(no description provided)_");
+    } else {
+        out.push_str(user_body);
+    }
+    out.push_str("\n\n");
+}
+
+fn render_environment(out: &mut String, info: &InfoOutput, env: &EnvSnapshot) {
+    out.push_str("## Environment\n\n");
+    let _ = writeln!(out, "- **tokf**: {}", info.version);
+    let _ = writeln!(out, "- **OS / arch**: {} / {}", env.os, env.arch);
+    if let Some(s) = &env.shell {
+        let _ = writeln!(out, "- **Shell**: {s}");
+    }
+    let _ = writeln!(
+        out,
+        "- **Tools**: gh {}, git {}",
+        if env.has_gh { "yes" } else { "no" },
+        if env.has_git { "yes" } else { "no" },
+    );
+    out.push('\n');
+}
+
+fn render_installation(out: &mut String, info: &InfoOutput, home: Option<&Path>) {
+    let r = |s: &str| redact_home(s, home);
+    out.push_str("## tokf installation\n\n");
+    let home_line = info
+        .home_override
+        .as_deref()
+        .map_or_else(|| "(not set)".to_string(), &r);
+    let _ = writeln!(out, "- TOKF_HOME: {home_line}");
+
+    for dir in &info.search_dirs {
+        if dir.scope == "built-in" {
+            let _ = writeln!(out, "- [{}] {} (always available)", dir.scope, dir.path);
+            continue;
+        }
+        let status = search_dir_status(dir.exists, dir.access);
+        let _ = writeln!(out, "- [{}] {} ({status})", dir.scope, r(&dir.path));
+    }
+
+    let _ = writeln!(
+        out,
+        "- Tracking DB: {}",
+        path_with_access(
+            info.tracking_db.path.as_deref(),
+            info.tracking_db.access,
+            &r
+        )
+    );
+    let _ = writeln!(
+        out,
+        "- Filter cache: {}",
+        path_with_access(info.cache.path.as_deref(), info.cache.access, &r)
+    );
+
+    if let Some(f) = &info.filters {
+        let _ = writeln!(
+            out,
+            "- Filters: {} built-in, {} user, {} local ({} total)",
+            f.builtin, f.user, f.local, f.total
+        );
+    } else {
+        out.push_str("- Filters: (discovery error)\n");
+    }
+
+    out.push_str("- Config files:\n");
+    for entry in &info.config_files {
+        let status = if entry.exists { "exists" } else { "not found" };
+        let _ = writeln!(out, "  - [{}] {} — {status}", entry.scope, r(&entry.path));
+    }
+    out.push('\n');
+}
+
+const fn search_dir_status(exists: bool, access: Option<WriteAccess>) -> &'static str {
+    if !exists {
+        return "not found";
+    }
+    match access {
+        Some(WriteAccess::Writable) => "exists, writable",
+        Some(WriteAccess::ReadOnly) => "exists, read-only",
+        _ => "exists",
+    }
+}
+
+fn render_filter_opt_in(out: &mut String, fl: &FilterNames) {
+    out.push_str("## Filters (opt-in)\n\n");
+    render_filter_section(out, "built-in", &fl.builtin);
+    render_filter_section(out, "user", &fl.user);
+    render_filter_section(out, "local", &fl.local);
+}
+
+fn render_footer(out: &mut String, filters_included: bool) {
+    out.push_str("<!--\n");
+    out.push_str(
+        "Excluded for privacy: hostname, username, machine UUID, auth tokens,\n\
+         environment variables, command history, filter contents.\n",
+    );
+    if !filters_included {
+        out.push_str("Filter names omitted (re-run with --include-filters to include them).\n");
+    }
+    out.push_str("-->\n\n");
+    out.push_str("---\n_Generated by `tokf issue`. Review before posting._\n");
+}
+
+fn path_with_access(
+    path: Option<&str>,
+    access: Option<WriteAccess>,
+    redact: &impl Fn(&str) -> String,
+) -> String {
+    path.map_or_else(
+        || "(not available)".to_string(),
+        |p| {
+            let label = access.map_or("unknown", WriteAccess::label);
+            format!("{} ({label})", redact(p))
+        },
+    )
+}
+
+fn render_filter_section(out: &mut String, label: &str, list: &[String]) {
+    let _ = writeln!(out, "**{label}** ({})\n", list.len());
+    if list.is_empty() {
+        out.push_str("_(none)_\n\n");
+        return;
+    }
+    for n in list {
+        let _ = writeln!(out, "- `{n}`");
+    }
+    out.push('\n');
+}
+
+fn submit_via_gh(repo: &str, title: &str, body: &str) -> Result<String> {
+    let mut tmp = tempfile::Builder::new()
+        .prefix("tokf-issue-")
+        .suffix(".md")
+        .tempfile()
+        .context("creating temp file for body")?;
+    tmp.write_all(body.as_bytes())
+        .context("writing body to temp file")?;
+    tmp.flush().ok();
+    let output = std::process::Command::new("gh")
+        .args([
+            "issue",
+            "create",
+            "--repo",
+            repo,
+            "--title",
+            title,
+            "--body-file",
+        ])
+        .arg(tmp.path())
+        .output()
+        .context("invoking gh")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("gh exited with {} — {}", output.status, stderr.trim());
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout.lines().last().unwrap_or("").trim().to_string())
+}
+
+fn fallback_print(repo: &str, title: &str, body: &str) {
+    println!("{body}");
+    match build_issues_new_url(repo, title, body) {
+        Some(url) => {
+            eprintln!("\n[tokf] Pre-filled URL (open in your browser):");
+            eprintln!("{url}");
+        }
+        None => {
+            eprintln!(
+                "\n[tokf] Body too long for URL pre-fill. Open https://github.com/{repo}/issues/new and paste the markdown above."
+            );
+        }
+    }
+}
+
+fn build_issues_new_url(repo: &str, title: &str, body: &str) -> Option<String> {
+    let url = format!(
+        "https://github.com/{}/issues/new?title={}&body={}",
+        repo,
+        url_encode(title),
+        url_encode(body),
+    );
+    if url.len() > ISSUES_NEW_URL_BUDGET {
+        None
+    } else {
+        Some(url)
+    }
+}
+
+/// Percent-encode using the unreserved set from RFC 3986.
+fn url_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~') {
+            out.push(b as char);
+        } else {
+            let _ = write!(out, "%{b:02X}");
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tokf-cli/src/issue_cmd/tests.rs
+++ b/crates/tokf-cli/src/issue_cmd/tests.rs
@@ -1,0 +1,227 @@
+#![allow(clippy::unwrap_used)]
+
+use std::path::{Path, PathBuf};
+
+use super::*;
+use crate::info_cmd::{
+    CacheInfo, ConfigFileEntry, FilterCounts, InfoOutput, SearchDir, TrackingDb, WriteAccess,
+};
+
+fn sample_info() -> InfoOutput {
+    InfoOutput {
+        version: "0.2.41".to_string(),
+        home_override: None,
+        search_dirs: vec![
+            SearchDir {
+                scope: "local",
+                path: "/Users/alice/proj/.tokf/filters".to_string(),
+                exists: false,
+                access: None,
+            },
+            SearchDir {
+                scope: "user",
+                path: "/Users/alice/.config/tokf/filters".to_string(),
+                exists: true,
+                access: Some(WriteAccess::Writable),
+            },
+            SearchDir {
+                scope: "built-in",
+                path: "<embedded>".to_string(),
+                exists: true,
+                access: None,
+            },
+        ],
+        tracking_db: TrackingDb {
+            env_override: None,
+            path: Some("/Users/alice/.local/share/tokf/tracking.db".to_string()),
+            exists: true,
+            access: Some(WriteAccess::Writable),
+        },
+        cache: CacheInfo {
+            path: Some("/Users/alice/.cache/tokf/filter-cache.bin".to_string()),
+            exists: true,
+            access: Some(WriteAccess::Writable),
+        },
+        config_files: vec![ConfigFileEntry {
+            scope: "global",
+            path: "/Users/alice/.config/tokf/config.toml".to_string(),
+            exists: false,
+        }],
+        filters: Some(FilterCounts {
+            local: 0,
+            user: 3,
+            builtin: 92,
+            total: 95,
+        }),
+    }
+}
+
+fn sample_env() -> EnvSnapshot {
+    EnvSnapshot {
+        os: "linux",
+        arch: "x86_64",
+        shell: Some("zsh".to_string()),
+        has_gh: true,
+        has_git: true,
+    }
+}
+
+#[test]
+fn redact_home_strips_user_home() {
+    let home = PathBuf::from("/Users/alice");
+    assert_eq!(
+        redact_home("/Users/alice/.config/tokf", Some(&home)),
+        "~/.config/tokf"
+    );
+    assert_eq!(redact_home("/etc/hosts", Some(&home)), "/etc/hosts");
+}
+
+#[test]
+fn redact_home_idempotent() {
+    let home = PathBuf::from("/Users/alice");
+    let once = redact_home("/Users/alice/x", Some(&home));
+    let twice = redact_home(&once, Some(&home));
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn redact_home_handles_no_home() {
+    assert_eq!(redact_home("/Users/alice/x", None), "/Users/alice/x");
+}
+
+fn render_with(
+    info: &InfoOutput,
+    env: &EnvSnapshot,
+    body: &str,
+    filters: Option<&FilterNames>,
+    home: Option<&Path>,
+) -> String {
+    render_markdown(&MarkdownInputs {
+        user_body: body,
+        info,
+        env,
+        filters,
+        home,
+    })
+}
+
+#[test]
+fn render_markdown_includes_version_and_counts() {
+    let info = sample_info();
+    let env = sample_env();
+    let home = PathBuf::from("/Users/alice");
+    let md = render_with(&info, &env, "something is broken", None, Some(&home));
+    assert!(md.contains("**tokf**: 0.2.41"), "missing version:\n{md}");
+    assert!(
+        md.contains("92 built-in, 3 user, 0 local (95 total)"),
+        "missing counts:\n{md}"
+    );
+    assert!(md.contains("something is broken"), "missing body:\n{md}");
+    assert!(
+        md.contains("Excluded for privacy"),
+        "missing privacy footer:\n{md}"
+    );
+    assert!(
+        md.contains("Filter names omitted"),
+        "missing filter-names note when filters not included:\n{md}"
+    );
+}
+
+#[test]
+fn render_markdown_redacts_home_paths() {
+    let info = sample_info();
+    let env = sample_env();
+    let home = PathBuf::from("/Users/alice");
+    let md = render_with(&info, &env, "b", None, Some(&home));
+    assert!(!md.contains("/Users/alice"), "home prefix leaked:\n{md}");
+    assert!(
+        md.contains("~/.config/tokf"),
+        "expected redacted ~/.config:\n{md}"
+    );
+}
+
+#[test]
+fn render_markdown_handles_missing_optional_paths() {
+    let mut info = sample_info();
+    info.tracking_db.path = None;
+    info.tracking_db.access = None;
+    info.cache.path = None;
+    info.cache.access = None;
+    info.filters = None;
+    let env = sample_env();
+    let md = render_with(&info, &env, "b", None, None);
+    assert!(md.contains("Tracking DB: (not available)"), "{md}");
+    assert!(md.contains("Filter cache: (not available)"), "{md}");
+    assert!(md.contains("Filters: (discovery error)"), "{md}");
+}
+
+#[test]
+fn render_markdown_omits_filter_names_by_default() {
+    let info = sample_info();
+    let env = sample_env();
+    let names = FilterNames {
+        local: vec!["git/internal-secret".to_string()],
+        user: vec![],
+        builtin: vec!["cargo/build".to_string()],
+    };
+    let without = render_with(&info, &env, "b", None, None);
+    assert!(!without.contains("git/internal-secret"));
+    assert!(!without.contains("## Filters (opt-in)"));
+
+    let with = render_with(&info, &env, "b", Some(&names), None);
+    assert!(with.contains("## Filters (opt-in)"));
+    assert!(with.contains("git/internal-secret"));
+    assert!(with.contains("cargo/build"));
+    assert!(
+        !with.contains("Filter names omitted"),
+        "footer note should disappear when names are included"
+    );
+}
+
+#[test]
+fn render_markdown_empty_body_shows_placeholder() {
+    let info = sample_info();
+    let env = sample_env();
+    let md = render_with(&info, &env, "   ", None, None);
+    assert!(md.contains("_(no description provided)_"), "{md}");
+}
+
+#[test]
+fn custom_filter_count_sums_user_and_local() {
+    let mut info = sample_info();
+    info.filters = Some(FilterCounts {
+        local: 2,
+        user: 5,
+        builtin: 99,
+        total: 106,
+    });
+    assert_eq!(custom_filter_count(&info), 7);
+}
+
+#[test]
+fn custom_filter_count_zero_when_no_counts() {
+    let mut info = sample_info();
+    info.filters = None;
+    assert_eq!(custom_filter_count(&info), 0);
+}
+
+#[test]
+fn url_encode_escapes_reserved() {
+    assert_eq!(url_encode("hello world"), "hello%20world");
+    assert_eq!(url_encode("a&b=c"), "a%26b%3Dc");
+    assert_eq!(url_encode("abc-_.~"), "abc-_.~");
+}
+
+#[test]
+fn build_issues_new_url_truncates_when_oversize() {
+    let big = "x".repeat(ISSUES_NEW_URL_BUDGET);
+    assert!(build_issues_new_url("o/r", "t", &big).is_none());
+}
+
+#[test]
+fn build_issues_new_url_succeeds_for_small_body() {
+    let url = build_issues_new_url("mpecan/tokf", "title with space", "body").unwrap();
+    assert!(url.starts_with("https://github.com/mpecan/tokf/issues/new?"));
+    assert!(url.contains("title=title%20with%20space"));
+    assert!(url.contains("body=body"));
+}

--- a/crates/tokf-cli/src/main.rs
+++ b/crates/tokf-cli/src/main.rs
@@ -14,6 +14,7 @@ mod generic;
 mod history_cmd;
 mod info_cmd;
 mod install_cmd;
+mod issue_cmd;
 mod output;
 mod publish_cmd;
 #[cfg(feature = "stdlib-publish")]
@@ -220,6 +221,8 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// File a GitHub issue with a non-PII diagnostic snapshot (uses `gh` if available)
+    Issue(issue_cmd::IssueArgs),
     /// Authenticate with the tokf server (credentials stored in OS keyring)
     Auth {
         #[command(subcommand)]
@@ -538,6 +541,7 @@ fn main() {
             *safety,
         ),
         Commands::Info { json } => info_cmd::cmd_info(*json),
+        Commands::Issue(args) => issue_cmd::cmd_issue(args),
         Commands::Auth { action } => or_exit(match action {
             AuthAction::Login => auth_cmd::cmd_auth_login(),
             AuthAction::Logout => auth_cmd::cmd_auth_logout(),

--- a/crates/tokf-cli/tests/cli_issue.rs
+++ b/crates/tokf-cli/tests/cli_issue.rs
@@ -1,0 +1,124 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn tokf() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_tokf"))
+}
+
+/// `--print` is the deterministic, gh-free path: it always emits the markdown
+/// to stdout, regardless of `gh` availability or the user's home directory.
+#[test]
+fn issue_print_outputs_markdown() {
+    let tmp = TempDir::new().unwrap();
+    let output = tokf()
+        .current_dir(tmp.path())
+        .env("TOKF_HOME", tmp.path())
+        .args([
+            "issue",
+            "--title",
+            "smoke",
+            "--body",
+            "test body",
+            "--print",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "exit={:?} stderr={stderr}",
+        output.status.code()
+    );
+    assert!(stdout.contains("## Summary"), "no summary:\n{stdout}");
+    assert!(stdout.contains("test body"), "body missing:\n{stdout}");
+    assert!(stdout.contains("**tokf**:"), "no version:\n{stdout}");
+    assert!(
+        stdout.contains("Excluded for privacy"),
+        "no privacy footer:\n{stdout}"
+    );
+}
+
+/// PII boundary: home prefix must not appear in the output. We set
+/// `TOKF_HOME` inside a `TempDir` whose path is below the real `$HOME`, so
+/// any leaked path will contain the user's home segment.
+#[test]
+fn issue_print_redacts_home_paths() {
+    let tmp = TempDir::new().unwrap();
+    let real_home = dirs::home_dir().expect("home dir resolvable");
+    let output = tokf()
+        .current_dir(tmp.path())
+        .env("TOKF_HOME", tmp.path())
+        .args(["issue", "--title", "t", "--body", "b", "--print"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let home_str = real_home.display().to_string();
+    assert!(
+        !stdout.contains(&home_str),
+        "home prefix `{home_str}` leaked into output:\n{stdout}"
+    );
+}
+
+/// `--body` and `--body-from` are mutually exclusive (clap-level conflict).
+#[test]
+fn issue_body_flags_conflict() {
+    let tmp = TempDir::new().unwrap();
+    let body_file = tmp.path().join("body.txt");
+    std::fs::write(&body_file, "hello").unwrap();
+    let output = tokf()
+        .current_dir(tmp.path())
+        .env("TOKF_HOME", tmp.path())
+        .args([
+            "issue",
+            "--title",
+            "t",
+            "--body",
+            "x",
+            "--body-from",
+            body_file.to_str().unwrap(),
+            "--print",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for conflicting flags"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be used with") || stderr.contains("conflicts"),
+        "expected clap conflict message in stderr:\n{stderr}"
+    );
+}
+
+/// `--body-from <path>` reads the body from a file.
+#[test]
+fn issue_body_from_file() {
+    let tmp = TempDir::new().unwrap();
+    let body_file = tmp.path().join("body.txt");
+    std::fs::write(&body_file, "from-file-marker-xyz").unwrap();
+    let output = tokf()
+        .current_dir(tmp.path())
+        .env("TOKF_HOME", tmp.path())
+        .args([
+            "issue",
+            "--title",
+            "t",
+            "--body-from",
+            body_file.to_str().unwrap(),
+            "--print",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("from-file-marker-xyz"),
+        "body not pulled from file:\n{stdout}"
+    );
+}

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -144,6 +144,48 @@ The doctor excludes events whose command path looks like a temp-dir or test-fixt
 
 `tokf doctor` is the **post-hoc** half of the diagnostics story. Phase 2 will add **runtime surfacing** — an in-process LRU that detects bursts as they happen and prints a `[tokf] notice:` line on stderr in the same tool result the agent sees. Phase 3 will add an `--apply-suggestions` interactive mode that proposes config patches. Both are explicitly out of scope for the current release.
 
+## tokf issue
+
+`tokf issue` builds a GitHub bug report with a non-PII diagnostic snapshot of your installation, **shows you the full body before anything is sent**, and submits it via `gh` if available — falling back to a printable markdown document otherwise. Transparency is the contract: every byte that would be uploaded is rendered to your terminal first.
+
+```sh
+tokf issue                                       # interactive: title prompt + $EDITOR for body
+tokf issue --title "panic in cargo/test" \
+           --body "Filter crashes on empty input"
+tokf issue --title "..." --body "..." --print    # print markdown only, never call gh
+tokf issue --title "..." --body-from bug.md      # body from file (or `-` for stdin)
+tokf issue --title "..." --body "..." -y         # skip the confirmation prompt
+tokf issue --title "..." --body "..." \
+           --include-filters                     # opt in to attaching filter names
+tokf issue --title "..." --body "..." \
+           --repo my-fork/tokf                   # file against a different repo
+```
+
+### What gets included
+
+The diagnostic snapshot is the same data shape as `tokf info`, with the user's home directory replaced by `~`:
+
+- `tokf` version, OS, architecture, shell name (e.g. `zsh`, never the full `$SHELL` path).
+- Whether `gh` and `git` are on `PATH`.
+- `TOKF_HOME` value, filter search directories with existence + writable status, tracking DB and cache paths and writability, filter counts by scope (built-in / user / local), and which config files exist.
+
+### What is intentionally excluded
+
+A footer comment in every report enumerates what was withheld:
+
+- Hostname, username, machine UUID
+- Auth tokens (server credentials live in the OS keyring; `tokf issue` never reads them)
+- Environment variables, command history, filter contents
+- Filter **names** by default — user/local filter names can encode internal command names. Add `--include-filters` to attach them; the preview always shows what would be sent. In interactive mode (title or body coming from a prompt), tokf asks once whether to include your custom filter names — useful for debugging filter-resolution bugs.
+
+### Submission flow
+
+1. The full markdown body is printed to **stderr** between `--- ISSUE PREVIEW ---` markers, every time.
+2. With `--print`, that's the end — the body is also written to stdout for piping.
+3. Without `--print`:
+   - If `gh` is missing, tokf prints the markdown and a pre-filled `https://github.com/<repo>/issues/new?title=...&body=...` URL (when the body fits in URL limits — otherwise a copy/paste hint).
+   - If `gh` is present, tokf asks `Submit to mpecan/tokf? [y/N]` (skip with `-y`), runs `gh issue create --body-file <tmpfile>`, and prints the resulting issue URL on success. On `gh` failure, the same fallback markdown is emitted so you don't lose the body.
+
 ## Cache management
 
 tokf caches the filter discovery index for faster startup. The cache rebuilds automatically when filters change, but you can manage it manually:


### PR DESCRIPTION
## Summary

- New `tokf issue` subcommand: gathers a non-PII diagnostic snapshot, **previews the full markdown body on stderr before any submission**, and either calls `gh issue create` or falls back to a printable markdown document with a pre-filled `issues/new?title=&body=` URL.
- Home directory prefix is redacted to `~`. Hostname, username, machine UUID, auth tokens, env vars, command history, and filter contents are never collected.
- Filter names off by default (user/local names can carry project-internal command names). `--include-filters` opts in; in interactive mode tokf asks once when custom filters are present.
- `info_cmd::collect_info` refactored to expose `collect_info_with_filters` so the new command can reuse the diagnostic shape without running `discover_all_filters` twice.

## CLI surface

```
tokf issue [--title <T>] [--body <B>] [--body-from <FILE|->] [--print]
           [-y|--yes] [--repo <OWNER/REPO>] [--include-filters]
```

- No flags → interactive: title prompt, `\$EDITOR` for the body (falls back to inline input), preview, then a `Submit to mpecan/tokf?` confirmation.
- ` --print` writes the markdown to stdout, never calls \`gh\`. Same fallback path runs automatically when \`gh\` is missing or fails.

## Test plan

- [x] \`cargo fmt\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p tokf\` — 1544 passed (13 new unit tests in \`issue_cmd::tests\`, 4 new integration tests in \`tests/cli_issue.rs\`)
- [x] Manual smoke: \`--print\` path emits markdown with \`~\`-redacted home, no \`/Users/<name>/\` leakage
- [x] Manual smoke: gh-missing path emits pre-filled \`issues/new\` URL
- [x] Pre-commit hook (file-size limits, README regeneration) passed

## Notable design choices

- Diagnostic shape mirrors \`tokf info\` exactly — same struct, same coverage. Bug reports and \`tokf info\` output stay in sync automatically.
- \`tempfile\` was promoted from dev-deps to deps (used to hand the body to \`gh --body-file\` and to seed the editor temp file).
- \`IssueArgs\` clap struct lives in \`issue_cmd/mod.rs\` (mirrors \`commands::DoctorArgs\`) so per-flag doc comments don't bloat \`main.rs\` past the 700-line hard limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)