### PR TITLE
fix(cli): use PowerShell for run filters on Windows

### DIFF
--- a/crates/tokf-cli/src/runner.rs
+++ b/crates/tokf-cli/src/runner.rs
@@ -227,7 +227,7 @@ pub fn execute_shell_with_env(
     let shell_cmd = run.replace("{args}", &joined_args);
 
     let mut cmd = build_shell_command(&shell_cmd);
-cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     for (k, v) in extra_env {
         cmd.env(k, v);
     }

--- a/crates/tokf-cli/src/runner.rs
+++ b/crates/tokf-cli/src/runner.rs
@@ -111,9 +111,35 @@ pub fn resolve_program(program: &str) -> Option<std::path::PathBuf> {
     None
 }
 
-/// Escape a string for safe inclusion in a shell command (single-quote wrapping).
+/// Build the system shell command for a shell snippet.
+fn build_shell_command(command: &str) -> Command {
+    #[cfg(windows)]
+    {
+        let mut cmd = Command::new("powershell.exe");
+        cmd.args(["-NoLogo", "-NoProfile", "-NonInteractive", "-Command"])
+            .arg(command);
+        cmd
+    }
+
+    #[cfg(not(windows))]
+    {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg(command);
+        cmd
+    }
+}
+
+/// Escape a string for safe inclusion in a shell command.
 pub(crate) fn shell_escape(arg: &str) -> String {
-    format!("'{}'", arg.replace('\'', "'\\''"))
+    #[cfg(windows)]
+    {
+        format!("'{}'", arg.replace('\'', "''"))
+    }
+
+    #[cfg(not(windows))]
+    {
+        format!("'{}'", arg.replace('\'', "'\\''"))
+    }
 }
 
 /// Execute a command with the given arguments.
@@ -200,10 +226,8 @@ pub fn execute_shell_with_env(
     #[allow(clippy::literal_string_with_formatting_args)]
     let shell_cmd = run.replace("{args}", &joined_args);
 
-    let mut cmd = Command::new("sh");
-    cmd.arg("-c")
-        .arg(&shell_cmd)
-        .stdout(Stdio::piped())
+    let mut cmd = build_shell_command(&shell_cmd);
+    cmd.stdout(Stdio::piped())
         .stderr(Stdio::piped());
     for (k, v) in extra_env {
         cmd.env(k, v);
@@ -322,6 +346,13 @@ mod tests {
         assert!(stdout.contains("; echo injected"));
         // "injected" should not appear as a separate execution
         assert!(!stdout.contains("\ninjected"));
+    }
+
+    #[test]
+    fn test_execute_shell_args_with_single_quote() {
+        let args = vec!["it's quoted".to_string()];
+        let result = execute_shell("echo {args}", &args).unwrap();
+        assert_eq!(result.stdout.trim(), "it's quoted");
     }
 
     // --- build_result / combined field tests ---

--- a/crates/tokf-cli/src/runner.rs
+++ b/crates/tokf-cli/src/runner.rs
@@ -227,8 +227,7 @@ pub fn execute_shell_with_env(
     let shell_cmd = run.replace("{args}", &joined_args);
 
     let mut cmd = build_shell_command(&shell_cmd);
-    cmd.stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     for (k, v) in extra_env {
         cmd.env(k, v);
     }

--- a/crates/tokf-cli/tests/cli_run.rs
+++ b/crates/tokf-cli/tests/cli_run.rs
@@ -87,6 +87,44 @@ fn run_nonexistent_command_exits_with_error() {
 }
 
 #[test]
+fn run_builtin_git_status_filter_succeeds() {
+    let dir = tempfile::TempDir::new().unwrap();
+
+    let init = Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let output = tokf()
+        .args(["run", "--verbose", "git", "status"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("matched git/status.toml"),
+        "expected built-in git status filter to match, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("program not found"),
+        "built-in git status filter should not depend on sh, got: {stderr}"
+    );
+}
+
+#[test]
 fn run_no_filter_preserves_failing_exit_code() {
     let output = tokf()
         .args([


### PR DESCRIPTION
## Summary
- stop hardcoding `sh -c` for filter `run = "..."` execution
- use `powershell.exe` on Windows while keeping `sh -c` on non-Windows platforms
- add regression coverage for built-in `git status` filtering and quoted argument interpolation

## Testing
- cargo test -p tokf --test cli_run run_builtin_git_status_filter_succeeds
- cargo test -p tokf --lib test_execute_shell_args_with_single_quote

Fixes #360