### PR TITLE
fix(cli): include missing program in not found errors

### DIFF
--- a/crates/tokf-cli/src/runner.rs
+++ b/crates/tokf-cli/src/runner.rs
@@ -1,3 +1,4 @@
+use std::io::ErrorKind;
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
@@ -129,6 +130,16 @@ fn build_shell_command(command: &str) -> Command {
     }
 }
 
+fn spawn_command(mut cmd: Command, program: &str) -> anyhow::Result<std::process::Child> {
+    match cmd.spawn() {
+        Ok(child) => Ok(child),
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            Err(anyhow::anyhow!("program not found: {program}"))
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
 /// Escape a string for safe inclusion in a shell command.
 pub(crate) fn shell_escape(arg: &str) -> String {
     #[cfg(windows)]
@@ -193,7 +204,7 @@ pub fn execute_with_env(
         cmd.env(k, v);
     }
 
-    run_interleaved(cmd.spawn()?)
+    run_interleaved(spawn_command(cmd, actual_program)?)
 }
 
 /// Execute a shell command with `{args}` interpolation.
@@ -226,13 +237,18 @@ pub fn execute_shell_with_env(
     #[allow(clippy::literal_string_with_formatting_args)]
     let shell_cmd = run.replace("{args}", &joined_args);
 
+    let shell_program = if cfg!(windows) {
+        "powershell.exe"
+    } else {
+        "sh"
+    };
     let mut cmd = build_shell_command(&shell_cmd);
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     for (k, v) in extra_env {
         cmd.env(k, v);
     }
 
-    run_interleaved(cmd.spawn()?)
+    run_interleaved(spawn_command(cmd, shell_program)?)
 }
 
 #[cfg(test)]
@@ -295,7 +311,8 @@ mod tests {
     #[test]
     fn test_execute_nonexistent_command() {
         let result = execute("nonexistent_cmd_xyz", &[]);
-        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert_eq!(err, "program not found: nonexistent_cmd_xyz");
     }
 
     #[test]

--- a/crates/tokf-cli/tests/cli_run.rs
+++ b/crates/tokf-cli/tests/cli_run.rs
@@ -84,6 +84,10 @@ fn run_nonexistent_command_exits_with_error() {
         stderr.contains("[tokf] error"),
         "expected error on stderr, got: {stderr}"
     );
+    assert!(
+        stderr.contains("program not found: nonexistent_cmd_xyz_99"),
+        "expected missing program name on stderr, got: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- include the missing executable name when direct command spawning fails with `ErrorKind::NotFound`
- share the spawn error handling path with shell command spawning so shell executable lookup failures are also explicit
- tighten the CLI regression test to assert the missing command name appears in stderr

Fixes #363.

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p tokf --lib test_execute_nonexistent_command`
- `cargo test -p tokf --test cli_run run_nonexistent_command_exits_with_error`

Note: `cargo test -p tokf run_nonexistent_command_exits_with_error` and `cargo test -p tokf test_execute_nonexistent_command` compile all integration test targets on Windows and currently fail in `crates/tokf-cli/tests/cli_hook_handle.rs` because it imports `std::os::unix::fs::PermissionsExt` and calls `Permissions::from_mode`.