### PR TITLE
fix(cli): clarify missing command errors

### DIFF
--- a/crates/tokf-cli/src/runner.rs
+++ b/crates/tokf-cli/src/runner.rs
@@ -1,4 +1,4 @@
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, ErrorKind};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
@@ -129,6 +129,20 @@ fn build_shell_command(command: &str) -> Command {
     }
 }
 
+fn spawn_with_context(
+    mut cmd: Command,
+    program: &str,
+    actual_program: &str,
+) -> anyhow::Result<std::process::Child> {
+    cmd.spawn().map_err(|err| {
+        if err.kind() == ErrorKind::NotFound {
+            anyhow::anyhow!("command not found: {program}")
+        } else {
+            anyhow::anyhow!("failed to spawn command `{actual_program}`: {err}")
+        }
+    })
+}
+
 /// Escape a string for safe inclusion in a shell command.
 pub(crate) fn shell_escape(arg: &str) -> String {
     #[cfg(windows)]
@@ -193,7 +207,7 @@ pub fn execute_with_env(
         cmd.env(k, v);
     }
 
-    run_interleaved(cmd.spawn()?)
+    run_interleaved(spawn_with_context(cmd, program, actual_program)?)
 }
 
 /// Execute a shell command with `{args}` interpolation.

--- a/crates/tokf-cli/tests/cli_run.rs
+++ b/crates/tokf-cli/tests/cli_run.rs
@@ -81,7 +81,7 @@ fn run_nonexistent_command_exits_with_error() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("[tokf] error"),
+        stderr.contains("[tokf] error: command not found: nonexistent_cmd_xyz_99"),
         "expected error on stderr, got: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary

- report `command not found: <program>` when `tokf run` cannot spawn the target executable
- keep contextual spawn errors for non-NotFound failures
- tighten the nonexistent-command regression test to assert the command name

Fixes #369.

## Test plan

- `cargo fmt --all`
- `cargo test -p tokf --test cli_run run_nonexistent_command_exits_with_error`
- `cargo test -p tokf test_execute_with_env`
- `cargo test -p tokf --test cli_run`
- `cargo clippy -p tokf --all-targets -- -D warnings`
- `git diff --check`
