### PR TITLE
fix(rewrite): preserve newline after operator in nested-list segments

### DIFF
--- a/crates/tokf-cli/src/rewrite/bash_ast.rs
+++ b/crates/tokf-cli/src/rewrite/bash_ast.rs
@@ -3,7 +3,7 @@
 //! Provides grammar-aware splitting, pipe detection, heredoc detection,
 //! env-prefix stripping, and command word extraction.
 
-use rable::ast::{ListOperator, Node, NodeKind};
+use rable::ast::{Node, NodeKind};
 
 /// Result of stripping a simple pipe from a command.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -252,16 +252,30 @@ impl ParsedCommand {
 
 /// Recursively flatten a node into `(segment_text, separator)` pairs.
 ///
-/// When descending into a nested `List`, the **last** item inherits the
-/// `parent_sep` because in source order that's what visually follows it.
-/// For example, `A && B || C` parses as `((A && B) || C)`:
+/// The separator after a non-last list item is sliced **byte-for-byte** from
+/// the source as the gap between this item's command end-span and the next
+/// item's command start-span — exactly like [`ParsedCommand::compound_segments`]
+/// does for top-level nodes. That gap captures the operator (`&&`/`||`/`;`/`&`)
+/// **plus** any surrounding whitespace, newlines, or comments, so a downstream
+/// rebuild via `seg + sep` reproduces the original source.
+///
+/// Reconstructing the separator from the operator *kind* instead (the previous
+/// approach) silently dropped a newline that immediately followed an operator:
+/// `git status &&\ngit log` collapsed to `git status &&git log`, gluing the
+/// segments onto one line and swallowing any intervening comment. That was an
+/// instance of the issue #355 token-fusion class on the nested-list path that
+/// the original #355 fix (top-level only) didn't cover.
+///
+/// The **last** item inherits the `parent_sep` because in source order that's
+/// what visually follows it. For example, `A && B || C` parses as
+/// `((A && B) || C)`:
 /// - outer items: `[(InnerList, "||"), (C, None)]`
-/// - inner items: `[(A, "&&"), (B, None)]` — descended with `parent_sep` `"||"`
-///   - i=0 (A) not last → emit `(A, "&&")`
-///   - i=1 (B) last → inherit `"||"` → emit `(B, "||")`
+/// - inner items: `[(A, "&&"), (B, None)]` — descended with `parent_sep` `" || "`
+///   - i=0 (A) not last → sep = gap `A`→`B` = `" && "`
+///   - i=1 (B) last → inherit `" || "`
 /// - back to outer, i=1 (C) last → emit `(C, "")`
 ///
-/// Result: `[(A, "&&"), (B, "||"), (C, "")]`.
+/// Result: `[(A, " && "), (B, " || "), (C, "")]`.
 fn flatten_segments(
     node: &Node,
     source: &str,
@@ -271,53 +285,18 @@ fn flatten_segments(
     if let NodeKind::List { items } = &node.kind {
         let last = items.len().saturating_sub(1);
         for (i, item) in items.iter().enumerate() {
-            let local_sep = item
-                .operator
-                .map(|op| format_operator(source, op, &item.command))
-                .unwrap_or_default();
             let sep = if i == last {
                 parent_sep.clone()
             } else {
-                local_sep
+                let gap_start = item.command.span.end;
+                let gap_end = items[i + 1].command.span.start;
+                source[gap_start..gap_end].to_string()
             };
             flatten_segments(&item.command, source, sep, out);
         }
     } else {
         out.push((node.source_text(source).to_string(), parent_sep));
     }
-}
-
-/// Format the operator after a list item, preserving surrounding whitespace.
-fn format_operator(source: &str, op: ListOperator, cmd: &Node) -> String {
-    let op_str = match op {
-        ListOperator::And => "&&",
-        ListOperator::Or => "||",
-        ListOperator::Semi => ";",
-        ListOperator::Background => "&",
-    };
-
-    // Find the operator in the source after the command's text.
-    let cmd_text = cmd.source_text(source);
-    let search_from = source.find(cmd_text).unwrap_or(0) + cmd_text.len();
-    source[search_from..].find(op_str).map_or_else(
-        || format!(" {op_str} "),
-        |pos| {
-            let abs = search_from + pos;
-            let abs_end = abs + op_str.len();
-            let bytes = source.as_bytes();
-            let before = if abs > 0 && bytes[abs - 1] == b' ' {
-                " "
-            } else {
-                ""
-            };
-            let after = if abs_end < bytes.len() && bytes[abs_end] == b' ' {
-                " "
-            } else {
-                ""
-            };
-            format!("{before}{op_str}{after}")
-        },
-    )
 }
 
 /// Collect pipe byte positions from Pipeline nodes.

--- a/crates/tokf-cli/src/rewrite/bash_ast_tests.rs
+++ b/crates/tokf-cli/src/rewrite/bash_ast_tests.rs
@@ -123,6 +123,16 @@ fn compound_segments_round_trip_byte_for_byte() {
         "cat <<EOF\nbody\nEOF\necho done",
         "cmd1 \\\necho continued",
         "cmd1   \n   cmd2",
+        // Operator immediately followed by a newline — the nested-list
+        // counterpart of the #355 fusion bug. The separator must carry the
+        // newline, not just the operator, or `cmd1 &&\ncmd2` collapses to
+        // `cmd1 &&cmd2`.
+        "cmd1 &&\ncmd2",
+        "cmd1 ||\ncmd2",
+        "cmd1 ;\ncmd2",
+        "cmd1 &&\ncmd2 ||\ncmd3",
+        "cmd1 &&\n  cmd2",
+        "cmd1 && # note\ncmd2",
     ] {
         let Some(p) = ParsedCommand::parse(input) else {
             continue;
@@ -154,6 +164,25 @@ fn compound_segments_mixed_newline_and_and() {
     );
     assert_eq!(segs[2].0, "cmd3");
     assert!(segs[2].1.is_empty());
+}
+
+#[test]
+fn compound_segments_operator_then_newline_keeps_newline() {
+    // `cmd1 &&\ncmd2` parses as a single List(cmd1, cmd2); the gap between
+    // the two items in source is " &&\n". The separator must preserve that
+    // newline byte-for-byte. Previously it was reconstructed from the
+    // operator kind alone (" &&"), dropping the newline and gluing the
+    // segments — the nested-list instance of the issue #355 fusion bug.
+    let p = ParsedCommand::parse("cmd1 &&\ncmd2").unwrap();
+    let segs = p.compound_segments();
+    assert_eq!(segs.len(), 2);
+    assert_eq!(segs[0].0, "cmd1");
+    assert_eq!(
+        segs[0].1, " &&\n",
+        "operator separator must keep the newline"
+    );
+    assert_eq!(segs[1].0, "cmd2");
+    assert!(segs[1].1.is_empty());
 }
 
 // --- pipe detection ---


### PR DESCRIPTION
## Summary

Fixes an **additional class of the issue #355 token-fusion bug** — this time on the nested-`List` reconstruction path that the original #355 fix didn't cover. **It's purely a tokf reconstruction defect; rable parses multiline commands correctly (its AST spans are byte-accurate).**

When a compound command has a chain operator (`&&`, `||`, `;`, `&`) immediately followed by a newline, that newline was dropped during segment reconstruction:

```
git status &&        →   tokf run git status &&tokf run git log   (newline lost)
git log
```

Consequences:
- A trailing token fuses into the next command — `tail -1\necho` → `tail -1echo` — which can become a redirect target and create **stray files** (`1echo`, `1tokf`) in the agent's cwd.
- An intervening comment line gets **swallowed**, silently dropping the command after it.

This only fired when at least one segment matched a filter (which is what triggers reconstruction).

## Root cause

Issue #355 fixed the **top-level** newline path (`compound_segments`) by slicing the separator byte-for-byte from source. The **nested-`List`** path (`flatten_segments` → `format_operator`) still rebuilt the separator from the operator *kind* and re-added only a single space, discarding any following newline/comment/whitespace.

## Fix

Reconstruct the nested separator the same way as the top level: the separator after a non-last list item is the source gap between its command end-span and the next item's start-span (`source[item.command.span.end .. next.command.span.start]`), which captures the operator plus all surrounding whitespace and comments. This deletes `format_operator` entirely, including its latent first-match `source.find` bug.

## Tests
- New `compound_segments_operator_then_newline_keeps_newline` regression test.
- Six operator-then-newline round-trip cases added to `compound_segments_round_trip_byte_for_byte` (`cmd1 &&\ncmd2`, `||`, `;`, chained, indented, comment-after-operator).
- `bash_ast` suite: 78 pass. Full `rewrite` suite: 310 pass. `clippy -D warnings` clean, `fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)