### PR TITLE
fix(rewrite): correct multibyte UTF-8 compound rewrites (#383)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,9 +2554,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rable"
-version = "0.1.15"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010fe03c7c468f7eea6ba5a41e4907b2b56bc90f560dffb79d4527b58d6520f3"
+checksum = "3f601efcd059ce48cd6350771ca52e5a079274b88058a5fcec8c383bfaebe69c"
 dependencies = [
  "thiserror 2.0.18",
 ]

--- a/crates/tokf-cli/Cargo.toml
+++ b/crates/tokf-cli/Cargo.toml
@@ -41,7 +41,7 @@ clap_complete = "4.5"
 clap_complete_nushell = "4.5"
 dialoguer = { version = "0.12", default-features = false }
 which = "8"
-rable = "0.1.15"
+rable = "0.2.1"
 tempfile = "3"
 opentelemetry     = { version = "0.31", optional = true, features = ["metrics"] }
 opentelemetry_sdk = { version = "0.31", optional = true, features = ["metrics"] }

--- a/crates/tokf-cli/src/rewrite/bash_ast.rs
+++ b/crates/tokf-cli/src/rewrite/bash_ast.rs
@@ -128,7 +128,9 @@ impl ParsedCommand {
         for (i, node) in self.nodes.iter().enumerate() {
             let parent_sep = if i + 1 < n {
                 let next = &self.nodes[i + 1];
-                self.source[node.span.end..next.span.start].to_string()
+                let start = char_to_byte(&self.source, node.span.end);
+                let end = char_to_byte(&self.source, next.span.start);
+                self.source[start..end].to_string()
             } else {
                 String::new()
             };
@@ -288,8 +290,8 @@ fn flatten_segments(
             let sep = if i == last {
                 parent_sep.clone()
             } else {
-                let gap_start = item.command.span.end;
-                let gap_end = items[i + 1].command.span.start;
+                let gap_start = char_to_byte(source, item.command.span.end);
+                let gap_end = char_to_byte(source, items[i + 1].command.span.start);
                 source[gap_start..gap_end].to_string()
             };
             flatten_segments(&item.command, source, sep, out);
@@ -568,6 +570,25 @@ fn is_strippable_grep(args: &[&str]) -> bool {
         }
     }
     has_pattern
+}
+
+/// Convert a rable span position (a **character** index) into a byte offset
+/// into `source`.
+///
+/// rable's [`rable::ast::Span`] fields are character indices — the lexer scans
+/// the source as a `Vec<char>` — so slicing the byte-indexed `source` string
+/// by a raw span field corrupts any input containing multibyte UTF-8: each
+/// multibyte char before the position makes the char index lag the byte index,
+/// so the slice lands early and splices stray bytes into the result (#383).
+/// This mirrors how rable's own `Node::source_text` resolves spans.
+///
+/// `char_indices().nth()` is O(n) over the position, but command strings are
+/// short, so the cost is negligible.
+fn char_to_byte(source: &str, char_idx: usize) -> usize {
+    source
+        .char_indices()
+        .nth(char_idx)
+        .map_or(source.len(), |(i, _)| i)
 }
 
 /// Strip a single layer of matching outer quotes (single or double).

--- a/crates/tokf-cli/src/rewrite/bash_ast_multibyte_tests.rs
+++ b/crates/tokf-cli/src/rewrite/bash_ast_multibyte_tests.rs
@@ -1,0 +1,62 @@
+//! Regression tests for multibyte-UTF-8 compound splitting (issue #383).
+//!
+//! rable's AST spans are character indices (its lexer scans a `Vec<char>`),
+//! so slicing the byte-indexed source by a raw span field lands early once a
+//! multibyte char precedes it — splicing stray `|`/`;` bytes into the rebuilt
+//! command. These tests lock in that `compound_segments` slices separators by
+//! byte offset (via `char_to_byte`) so the reassembled command is valid shell.
+//!
+//! Kept in a sibling file rather than `bash_ast_tests.rs` to stay under the
+//! 700-line hard file-size limit.
+
+use super::bash_ast::*;
+
+#[test]
+fn round_trip_byte_for_byte_multibyte() {
+    // The reassembled `seg + sep` chain must reproduce the original source
+    // byte-for-byte. Each case mixes a multibyte char in one segment with an
+    // operator boundary in another — the shape that previously corrupted.
+    for input in [
+        "echo \"✓ valid\" || echo \"✗ bad\"; ls | grep tokf",
+        "echo \"✓ done\"; cargo build | tail",
+        "git status | grep modified; echo \"✓\"",
+        "echo café && git log",
+        "echo 中文 || echo x; ls",
+        "echo 🎉\nls",
+        "echo ✓ &&\necho ✗",
+    ] {
+        let Some(p) = ParsedCommand::parse(input) else {
+            continue;
+        };
+        let mut rebuilt = String::new();
+        for (seg, sep) in p.compound_segments() {
+            rebuilt.push_str(&seg);
+            rebuilt.push_str(&sep);
+        }
+        assert_eq!(rebuilt, input, "round-trip failed for {input:?}");
+    }
+}
+
+#[test]
+fn split_compound_multibyte_separators() {
+    // The canonical repro. Lock in exact segment text and separator content
+    // so a regression can't slip through by merely round-tripping. `✓`/`✗`
+    // are 3 bytes each; before the char→byte conversion the `||` and `;`
+    // separators were sliced early — injecting a stray `|` after segment 0
+    // and collapsing the `; ` after segment 1.
+    let p = ParsedCommand::parse("echo \"✓ valid\" || echo \"✗ bad\"; ls | grep tokf").unwrap();
+    let segs = p.compound_segments();
+    assert_eq!(segs.len(), 3, "expected 3 segments, got {segs:?}");
+
+    assert_eq!(segs[0].0, "echo \"✓ valid\"");
+    assert_eq!(segs[0].1, " || ", "sep 0 must be the bare `||` gap");
+
+    assert_eq!(segs[1].0, "echo \"✗ bad\"");
+    assert_eq!(
+        segs[1].1, "; ",
+        "sep 1 must be exactly `; ` (one semicolon)"
+    );
+
+    assert_eq!(segs[2].0, "ls | grep tokf");
+    assert!(segs[2].1.is_empty());
+}

--- a/crates/tokf-cli/src/rewrite/mod.rs
+++ b/crates/tokf-cli/src/rewrite/mod.rs
@@ -352,6 +352,9 @@ pub(crate) fn rewrite_with_config_and_options(
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
+mod bash_ast_multibyte_tests;
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod bash_ast_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/tokf-cli/src/rewrite/tests_compound.rs
+++ b/crates/tokf-cli/src/rewrite/tests_compound.rs
@@ -29,6 +29,49 @@ fn rewrite_compound_both_segments_match() {
 }
 
 #[test]
+fn rewrite_compound_multibyte_segment_not_corrupted() {
+    // Regression (#383): a compound command mixing a multibyte echo with a
+    // filterable piped segment must produce valid shell. Before the rable
+    // char-index span fix + char→byte slicing, the `||`/`;` separators were
+    // spliced at wrong byte offsets, emitting `| |` and a dropped `; ` that
+    // failed to parse.
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("ls.toml"), "command = \"ls\"").unwrap();
+
+    let config = RewriteConfig::default();
+    let r = rewrite_with_config(
+        "echo \"✓ valid\" || echo \"✗ bad\"; ls ~/.claude/skills/ | grep tokf",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(
+        r,
+        "echo \"✓ valid\" || echo \"✗ bad\"; tokf run --baseline-pipe 'grep tokf' ls ~/.claude/skills/"
+    );
+}
+
+#[test]
+fn rewrite_compound_multibyte_echo_then_piped_filter() {
+    // The issue's "Impact" example: emoji echo followed by a stdlib-matched
+    // piped command. The echo segment and `;` separator stay intact.
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("git-diff.toml"), "command = \"git diff\"").unwrap();
+
+    let config = RewriteConfig::default();
+    let r = rewrite_with_config(
+        "echo \"✓ done\"; git diff | tail",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(
+        r,
+        "echo \"✓ done\"; tokf run --baseline-pipe 'tail' git diff"
+    );
+}
+
+#[test]
 fn rewrite_compound_partial_match() {
     let dir = TempDir::new().unwrap();
     fs::write(

--- a/crates/tokf-cli/tests/cli_rewrite.rs
+++ b/crates/tokf-cli/tests/cli_rewrite.rs
@@ -421,6 +421,18 @@ fn rewrite_compound_then_tail_stripped() {
 }
 
 #[test]
+fn rewrite_compound_multibyte_emoji_not_corrupted() {
+    // Regression (#383): end-to-end through the real binary an LLM hook
+    // invokes. A multibyte echo mixed with chain operators and a stripped
+    // pipe previously emitted invalid shell (`| ||`, dropped `; `).
+    let result = rewrite_with_stdlib("echo \"✓ valid\" || echo \"✗ bad\"; git diff | head -5");
+    assert_eq!(
+        result,
+        "echo \"✓ valid\" || echo \"✗ bad\"; tokf run --baseline-pipe 'head -5' git diff"
+    );
+}
+
+#[test]
 fn rewrite_logical_or_still_rewritten_integration() {
     let result = rewrite_with_stdlib("cargo test || echo failed");
     assert_eq!(result, "tokf run cargo test || echo failed");


### PR DESCRIPTION
Closes #383

## Summary

Compound shell commands that mixed a multibyte UTF-8 character (`✓`, `✗`, emoji, CJK) in one segment with a chain operator (`&&`/`||`/`;`/newline) were rewritten into **invalid shell** — spurious `|`/`;` tokens were spliced at the wrong byte offsets, so the command failed to parse. This broke every `tokf hook`-driven rewrite that mixed an emoji/checkmark `echo` with a filterable pipe.

### Before / after

```
in:   echo "✓ valid" || echo "✗ bad"; ls ~/.claude/skills/ | grep tokf
was:  echo "✓ valid" | |echo "✗ bad";tokf run --baseline-pipe 'grep tokf' ls ~/.claude/skills/   ← invalid
now:  echo "✓ valid" || echo "✗ bad"; tokf run --baseline-pipe 'grep tokf' ls ~/.claude/skills/   ← valid
```

## Root cause

Two layers:

1. **Upstream (rable):** AST spans are character indices (the lexer scans a `Vec<char>`), but span *ends* were computed as `pos + value.len()` — a char position plus a **byte** length. For multibyte input the end overshot, so even `Node::source_text` returned the wrong slice for non-final tokens. Fixed in **mpecan/rable#72**, released as **rable 0.2.1**.
2. **tokf:** `compound_segments`/`flatten_segments` sliced the byte-indexed source string by raw (character) span values. Now routed through a `char_to_byte` helper that mirrors rable's own conversion.

The issue's suspected culprit (`rules.rs:75`, the `{rest}` slice) was a red herring — regex offsets are byte offsets by design.

## Changes

- `char_to_byte` helper + the two separator-slice sites in `rewrite/bash_ast.rs`.
- Bump `rable` 0.1.15 → 0.2.1 (absorbs the 0.2.0 API surface changes; tokf only uses `rable::parse` + `rable::ast`).

## Tests

Three layers of regression coverage — all previously failing, now green:
- **AST round-trip + exact separators** — new `bash_ast_multibyte_tests.rs` (split out to stay under the 700-line file limit).
- **In-process rewrite** — `tests_compound.rs`.
- **Real binary an LLM hook invokes** — `cli_rewrite.rs`.

`cargo test -p tokf` (989 lib + 59 CLI), clippy, and fmt all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)