### PR TITLE
ci: use npm trusted publishing (OIDC) for catalog-types

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,9 @@ jobs:
     needs: [publish]
     if: startsWith(inputs.tag || github.event.release.tag_name, 'tokf-v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # mint the OIDC token for npm trusted publishing
     steps:
       - uses: actions/checkout@v6
         with:
@@ -92,11 +95,12 @@ jobs:
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
+      # Trusted publishing requires npm >= 11.5.1; Node 24 ships an older npm.
+      - name: Update npm
+        run: npm install -g npm@latest
       - name: Publish catalog types
         working-directory: crates/tokf-server/generated
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   build-binaries:
     name: Build ${{ matrix.target }}


### PR DESCRIPTION
## Summary

npm now authorizes this repo's release workflow as a **trusted publisher**, so the `@tokf/catalog-types` publish step no longer needs an npm token. This switches the `publish-npm` job to OIDC.

## Changes
- Add `id-token: write` to the `publish-npm` job so it can mint the OIDC token. A job-level `permissions` block *replaces* the top-level `contents: write`, so `contents: read` is re-granted for the checkout.
- Remove the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env from the publish step.
- Upgrade npm before publishing — trusted publishing requires **npm ≥ 11.5.1**, but Node 24 ships an older npm.

## Notes
- **No GitHub Actions environment required.** The npm trusted-publisher config has no environment set, and the workflow references none — the OIDC claim matches on repo + workflow filename.
- Trusted publishing attaches **build provenance** automatically.
- The `NPM_TOKEN` repo secret is now unused and can be deleted once a release publishes successfully via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
