### PR TITLE
feat: unwrap local environment wrappers (nix develop -c)

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,8 @@ The skipped flags are preserved in the command that actually runs — they are o
 
 > **Note on `run` override and transparent flags:** If a filter sets a `run` field, transparent global flags are *not* included in `{args}`.  Only the arguments that appear after the matched pattern words are available as `{args}`.
 
+**Local environment wrappers** — you don't need to do anything special for your filter to match through a local wrapper like `nix develop -c cargo test`. tokf strips the wrapper prefix and matches the inner command (`cargo test`) against your existing patterns. See [Local environment wrappers](rewrites-config.md#local-environment-wrappers) for the configurable list.
+
 ## Common fields
 
 ```toml
@@ -1955,6 +1957,67 @@ What is gated:
 If you genuinely need a regex rewrite for an ssh-class command, invoke it explicitly: `tokf run ssh …` is preserved by the `^tokf ` skip rule, so it won't be re-rewritten.
 
 This was added to address [#338](https://github.com/mpecan/tokf/issues/338), where a long-output `ssh HOST 'cmd'` would land `tokf` on the remote bash and exit 127.
+
+## Local environment wrappers
+
+Some commands wrap an inner command that runs in a *local* environment — the canonical example is `nix develop -c cargo test`, which runs `cargo test` inside a Nix devshell on the same machine. By default tokf only sees the outer command (`nix`), so a `cargo test` filter never matches.
+
+Local wrappers are the **mirror image** of transparent-arg commands. Transparent commands (`ssh`) run their payload remotely, so tokf stays hands-off. Local wrappers run their inner command locally, so tokf can safely:
+
+1. **Inspect** the inner command to pick a filter (`nix develop -c cargo test` → matches the `cargo test` filter), and
+2. **Wrap the whole command** with `tokf run` and filter its combined output.
+
+tokf uses the *outer* wrap — `tokf run nix develop -c cargo test`, not `nix develop -c tokf run cargo test`. Because tokf is the parent process and captures the wrapper's output, nothing requires `tokf` to be on `PATH` *inside* the devshell (which would reintroduce the remote-shell failure mode from #338 locally).
+
+```sh
+# What you type:
+nix develop -c cargo test
+
+# What tokf rewrites it to (outer wrap):
+tokf run nix develop -c cargo test        # → cargo test filter applied to the output
+
+# With a pipe, the pipe is stripped and re-expressed as a baseline:
+nix develop -c cargo test | tail -5
+  →  tokf run --baseline-pipe 'tail -5' nix develop -c cargo test
+```
+
+### Built-in wrappers
+
+The built-in list, active by default, is:
+
+| Command | Prefix matched | Marker (inner command follows) |
+|---|---|---|
+| `nix` | `nix develop …` | `-c`, `--command` |
+
+Any flags or attributes between `nix develop` and the marker are tolerated, so `nix develop .#agent --impure -c cargo test` unwraps correctly. Basename matching applies (`/nix/store/…/bin/nix` is treated as `nix`). A marker with nothing after it (a bare `nix develop -c`) is not a match.
+
+### Configuring wrappers (`[local_wrapper]`)
+
+Add your own wrappers, disable built-ins by name, or turn built-ins off entirely:
+
+```toml
+[local_wrapper]
+# Turn off ALL built-in wrappers (user rules below still apply). Default: true.
+builtins = true
+# Disable specific built-ins by command basename.
+disabled = ["nix"]
+
+# Add your own wrappers. These extend the built-ins.
+[[local_wrapper.rules]]
+command = "distrobox"       # matched against the first word's basename
+subcommands = ["enter"]     # must immediately follow `command`; omit if not needed
+markers = ["--"]            # the inner command starts after the first marker
+```
+
+- `command` / `subcommands` decide **which prefixes** are treated as wrappers.
+- `markers` decides **which part of the command is parsed** as the filterable inner command — everything after the first marker.
+- `disabled` removes named built-ins; `builtins = false` removes all of them. User `rules` always apply.
+
+### Limitation: nested task runners
+
+A task runner nested inside a local wrapper — e.g. `nix develop -c make check` — is **not** filtered per recipe line. Task-runner integration works by injecting `SHELL=tokf` so `make` runs each recipe line through tokf, which would require `tokf` inside the devshell (the exact thing outer-wrapping avoids). Such commands pass through unchanged.
+
+This was added to address [#403](https://github.com/mpecan/tokf/issues/403).
 
 ## Debug settings
 

--- a/crates/tokf-cli/src/commands.rs
+++ b/crates/tokf-cli/src/commands.rs
@@ -521,66 +521,6 @@ pub fn cmd_ls(verbose: bool) -> i32 {
     0
 }
 
-pub fn cmd_which(command: &str, verbose: bool) -> i32 {
-    let Ok(filters) = resolve::discover_filters(false) else {
-        eprintln!("[tokf] error: failed to discover filters");
-        return 1;
-    };
-
-    let words: Vec<&str> = command.split_whitespace().collect();
-    let cwd = std::env::current_dir().unwrap_or_default();
-
-    for filter in &filters {
-        if filter.matches(&words).is_some() {
-            let display_name = filter
-                .relative_path
-                .with_extension("")
-                .display()
-                .to_string();
-
-            let variant_info = if filter.config.variant.is_empty() {
-                String::new()
-            } else {
-                let res =
-                    config::variant::resolve_variants(&filter.config, &filters, &cwd, verbose);
-                let resolved = res.config.command.first().to_string();
-                if resolved != filter.config.command.first() {
-                    format!(" -> variant: \"{resolved}\"")
-                } else if res.output_variants.is_empty() {
-                    format!(
-                        " ({} variant(s), none matched by file)",
-                        filter.config.variant.len()
-                    )
-                } else {
-                    let names: Vec<&str> = res
-                        .output_variants
-                        .iter()
-                        .map(|v| v.name.as_str())
-                        .collect();
-                    format!(
-                        " ({} variant(s), {} deferred to output-pattern: {})",
-                        filter.config.variant.len(),
-                        res.output_variants.len(),
-                        names.join(", ")
-                    )
-                }
-            };
-            println!(
-                "{display_name}  [{}]  command: \"{}\"{variant_info}",
-                filter.priority_label(),
-                filter.config.command.first()
-            );
-            if verbose {
-                eprintln!("[tokf] source: {}", filter.source_path.display());
-            }
-            return 0;
-        }
-    }
-
-    eprintln!("[tokf] no filter found for \"{command}\"");
-    1
-}
-
 pub fn cmd_rewrite(command: &str, verbose: bool) -> i32 {
     let result = rewrite::rewrite(command, verbose);
     println!("{result}");

--- a/crates/tokf-cli/src/config/local_wrapper.rs
+++ b/crates/tokf-cli/src/config/local_wrapper.rs
@@ -1,0 +1,157 @@
+//! Detection of "local environment wrapper" commands — commands like
+//! `nix develop -c <cmd>` that run an inner command in a *local* environment.
+//!
+//! Unlike transparent-arg commands (`ssh`/`mosh`/`slogin`, see
+//! [`super::super::rewrite::transparent`]), whose trailing argv runs on a
+//! remote/opaque shell and must never be inspected, a local wrapper's inner
+//! command runs on the same machine. tokf strips the wrapper prefix to discover
+//! which filter applies, then wraps and executes the *whole* command and
+//! filters its output. See issue #403.
+
+use tokf_hook_types::{LocalWrapperConfig, LocalWrapperRule};
+
+use super::{ResolvedFilter, extract_basename};
+
+/// A built-in local wrapper specification.
+struct BuiltinLocalWrapper {
+    /// Wrapper command basename (e.g. `nix`).
+    command: &'static str,
+    /// Subcommands that must immediately follow `command` (e.g. `develop`).
+    /// Empty means no subcommand is required.
+    subcommands: &'static [&'static str],
+    /// Marker tokens whose *next* word begins the inner command.
+    markers: &'static [&'static str],
+}
+
+/// Built-in local wrappers, always active unless disabled via config.
+const BUILTIN_LOCAL_WRAPPERS: &[BuiltinLocalWrapper] = &[BuiltinLocalWrapper {
+    command: "nix",
+    subcommands: &["develop"],
+    markers: &["-c", "--command"],
+}];
+
+/// Words consumed by a leading local-wrapper prefix, or `None` if `words` does
+/// not start with a known local wrapper.
+///
+/// The consumed count spans the command, any required subcommand, and every
+/// token up to and including the marker. At least one word must follow the
+/// marker (a bare trailing `-c` is not a match). Built-in wrappers are honoured
+/// unless `config.builtins` is `false` or their `command` appears in
+/// `config.disabled`; user `config.rules` are always tried, after the built-ins.
+pub fn strip_local_wrapper(words: &[&str], config: &LocalWrapperConfig) -> Option<usize> {
+    if config.builtins {
+        for b in BUILTIN_LOCAL_WRAPPERS {
+            if config.disabled.iter().any(|d| d == b.command) {
+                continue;
+            }
+            if let Some(n) = match_spec(words, b.command, b.subcommands, b.markers) {
+                return Some(n);
+            }
+        }
+    }
+    for r in &config.rules {
+        if let Some(n) = match_rule(words, r) {
+            return Some(n);
+        }
+    }
+    None
+}
+
+/// Match a user-defined rule (owned `String` fields) against `words`.
+fn match_rule(words: &[&str], rule: &LocalWrapperRule) -> Option<usize> {
+    let subs: Vec<&str> = rule.subcommands.iter().map(String::as_str).collect();
+    let marks: Vec<&str> = rule.markers.iter().map(String::as_str).collect();
+    match_spec(words, &rule.command, &subs, &marks)
+}
+
+/// Core matcher shared by built-in and user specs.
+///
+/// 1. `words[0]`'s basename must equal `command`.
+/// 2. If `subcommands` is non-empty, `words[1]` must be one of them.
+/// 3. Scan forward — tolerating any intervening tokens (flags, `.#attr`,
+///    `--impure`, …) — for the first `markers` token.
+/// 4. A match requires at least one word after the marker; returns
+///    `marker_idx + 1` (the number of words the wrapper prefix consumes).
+fn match_spec(
+    words: &[&str],
+    command: &str,
+    subcommands: &[&str],
+    markers: &[&str],
+) -> Option<usize> {
+    let first = words.first()?;
+    if extract_basename(first) != command {
+        return None;
+    }
+
+    // Position of the first word that could be a marker: after the command and
+    // (if required) the subcommand.
+    let scan_start = if subcommands.is_empty() {
+        1
+    } else {
+        let sub = words.get(1)?;
+        if !subcommands.contains(sub) {
+            return None;
+        }
+        2
+    };
+
+    for (offset, word) in words[scan_start..].iter().enumerate() {
+        if markers.contains(word) {
+            let marker_idx = scan_start + offset;
+            // Require at least one word after the marker (the inner command).
+            if marker_idx + 1 < words.len() {
+                return Some(marker_idx + 1);
+            }
+            return None;
+        }
+    }
+    None
+}
+
+/// Try to match `words` against `filters` directly; on failure, strip one
+/// local-wrapper layer and retry the inner command.
+///
+/// Returns `(filter, matched inner pattern, total words consumed)` where the
+/// consumed count spans the wrapper prefix **and** the matched inner pattern,
+/// so `command_args[..consumed]` still forms the full command prefix.
+///
+/// Recursion terminates: [`strip_local_wrapper`] always consumes at least two
+/// words (command + marker), so `words.len()` strictly decreases each call.
+pub fn match_filters_with_wrapper<'a>(
+    filters: &'a [ResolvedFilter],
+    words: &[&str],
+    config: &LocalWrapperConfig,
+) -> Option<(&'a ResolvedFilter, &'a str, usize)> {
+    for filter in filters {
+        if let Some((pattern, consumed)) = filter.matching_pattern(words) {
+            return Some((filter, pattern, consumed));
+        }
+    }
+    let wrapper_len = strip_local_wrapper(words, config)?;
+    let (filter, pattern, inner_consumed) =
+        match_filters_with_wrapper(filters, &words[wrapper_len..], config)?;
+    Some((filter, pattern, wrapper_len + inner_consumed))
+}
+
+/// Returns `true` if `words` matches any of `patterns` directly, or after
+/// stripping one or more local-wrapper layers.
+///
+/// Used by the rewrite path, which works with raw pattern strings rather than
+/// [`ResolvedFilter`]s. Termination is guaranteed for the same reason as
+/// [`match_filters_with_wrapper`].
+pub fn patterns_match_with_wrapper(
+    patterns: &[String],
+    words: &[&str],
+    config: &LocalWrapperConfig,
+) -> bool {
+    if patterns
+        .iter()
+        .any(|p| super::pattern_matches_prefix(p, words).is_some())
+    {
+        return true;
+    }
+    let Some(wrapper_len) = strip_local_wrapper(words, config) else {
+        return false;
+    };
+    patterns_match_with_wrapper(patterns, &words[wrapper_len..], config)
+}

--- a/crates/tokf-cli/src/config/mod.rs
+++ b/crates/tokf-cli/src/config/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod local_wrapper;
 pub mod types;
 pub mod variant;
 
@@ -467,5 +468,7 @@ mod tests;
 mod tests_basename;
 #[cfg(test)]
 mod tests_discovery;
+#[cfg(test)]
+mod tests_local_wrapper;
 #[cfg(test)]
 mod tests_matching;

--- a/crates/tokf-cli/src/config/tests_local_wrapper.rs
+++ b/crates/tokf-cli/src/config/tests_local_wrapper.rs
@@ -1,0 +1,317 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::PathBuf;
+
+use tokf_hook_types::{LocalWrapperConfig, LocalWrapperRule};
+
+use super::ResolvedFilter;
+use super::local_wrapper::{
+    match_filters_with_wrapper, patterns_match_with_wrapper, strip_local_wrapper,
+};
+use super::types::FilterConfig;
+
+fn words(s: &str) -> Vec<&str> {
+    s.split_whitespace().collect()
+}
+
+/// Default config: built-ins on, no disables, no user rules.
+fn default_cfg() -> LocalWrapperConfig {
+    LocalWrapperConfig::default()
+}
+
+fn distrobox_rule() -> LocalWrapperRule {
+    LocalWrapperRule {
+        command: "distrobox".to_string(),
+        subcommands: vec!["enter".to_string()],
+        markers: vec!["--".to_string()],
+    }
+}
+
+// --- strip_local_wrapper: the three issue examples ---
+
+#[test]
+fn strips_nix_develop_c_cargo_test() {
+    // nix develop -c cargo test  → consume "nix develop -c" (3 words)
+    assert_eq!(
+        strip_local_wrapper(&words("nix develop -c cargo test"), &default_cfg()),
+        Some(3)
+    );
+}
+
+#[test]
+fn strips_nix_develop_attr_c_pytest() {
+    // nix develop .#agent -c pytest → consume "nix develop .#agent -c" (4 words)
+    assert_eq!(
+        strip_local_wrapper(&words("nix develop .#agent -c pytest"), &default_cfg()),
+        Some(4)
+    );
+}
+
+#[test]
+fn strips_nix_develop_impure_c_npm_test() {
+    assert_eq!(
+        strip_local_wrapper(&words("nix develop --impure -c npm test"), &default_cfg()),
+        Some(4)
+    );
+}
+
+#[test]
+fn strips_long_form_command_marker() {
+    assert_eq!(
+        strip_local_wrapper(&words("nix develop --command cargo test"), &default_cfg()),
+        Some(3)
+    );
+}
+
+#[test]
+fn strips_path_prefixed_nix() {
+    assert_eq!(
+        strip_local_wrapper(
+            &words("/nix/store/abc/bin/nix develop -c cargo test"),
+            &default_cfg()
+        ),
+        Some(3)
+    );
+}
+
+// --- strip_local_wrapper: no-match cases ---
+
+#[test]
+fn no_match_nix_build() {
+    // Not a develop subcommand.
+    assert_eq!(
+        strip_local_wrapper(&words("nix build .#foo"), &default_cfg()),
+        None
+    );
+}
+
+#[test]
+fn no_match_nix_develop_without_marker() {
+    // Enters an interactive shell, no inner command.
+    assert_eq!(
+        strip_local_wrapper(&words("nix develop"), &default_cfg()),
+        None
+    );
+    assert_eq!(
+        strip_local_wrapper(&words("nix develop .#agent"), &default_cfg()),
+        None
+    );
+}
+
+#[test]
+fn no_match_bare_trailing_marker() {
+    // Marker present but nothing after it.
+    assert_eq!(
+        strip_local_wrapper(&words("nix develop -c"), &default_cfg()),
+        None
+    );
+}
+
+#[test]
+fn no_match_unrelated_command() {
+    assert_eq!(
+        strip_local_wrapper(&words("cargo test"), &default_cfg()),
+        None
+    );
+    assert_eq!(strip_local_wrapper(&words(""), &default_cfg()), None);
+}
+
+// --- disable behaviour ---
+
+#[test]
+fn disabled_list_turns_off_nix_builtin() {
+    let cfg = LocalWrapperConfig {
+        builtins: true,
+        disabled: vec!["nix".to_string()],
+        rules: vec![],
+    };
+    assert_eq!(
+        strip_local_wrapper(&words("nix develop -c cargo test"), &cfg),
+        None
+    );
+}
+
+#[test]
+fn builtins_false_turns_off_all_builtins() {
+    let cfg = LocalWrapperConfig {
+        builtins: false,
+        disabled: vec![],
+        rules: vec![],
+    };
+    assert_eq!(
+        strip_local_wrapper(&words("nix develop -c cargo test"), &cfg),
+        None
+    );
+}
+
+#[test]
+fn user_rule_still_matches_when_nix_disabled() {
+    let cfg = LocalWrapperConfig {
+        builtins: true,
+        disabled: vec!["nix".to_string()],
+        rules: vec![distrobox_rule()],
+    };
+    // nix is disabled…
+    assert_eq!(
+        strip_local_wrapper(&words("nix develop -c cargo test"), &cfg),
+        None
+    );
+    // …but the user rule works: distrobox enter my-box -- cargo test
+    assert_eq!(
+        strip_local_wrapper(&words("distrobox enter my-box -- cargo test"), &cfg),
+        Some(4)
+    );
+}
+
+#[test]
+fn user_rule_works_with_builtins_off() {
+    let cfg = LocalWrapperConfig {
+        builtins: false,
+        disabled: vec![],
+        rules: vec![distrobox_rule()],
+    };
+    assert_eq!(
+        strip_local_wrapper(&words("distrobox enter box -- pytest"), &cfg),
+        Some(4)
+    );
+    assert_eq!(
+        strip_local_wrapper(&words("nix develop -c cargo test"), &cfg),
+        None
+    );
+}
+
+#[test]
+fn user_rule_without_subcommands() {
+    let cfg = LocalWrapperConfig {
+        builtins: true,
+        disabled: vec![],
+        rules: vec![LocalWrapperRule {
+            command: "toolbox".to_string(),
+            subcommands: vec![],
+            markers: vec!["run".to_string()],
+        }],
+    };
+    // toolbox run cargo test → consume "toolbox run" (2 words)
+    assert_eq!(
+        strip_local_wrapper(&words("toolbox run cargo test"), &cfg),
+        Some(2)
+    );
+}
+
+// --- patterns_match_with_wrapper ---
+
+#[test]
+fn patterns_match_direct() {
+    let patterns = vec!["cargo test".to_string()];
+    assert!(patterns_match_with_wrapper(
+        &patterns,
+        &words("cargo test"),
+        &default_cfg()
+    ));
+}
+
+#[test]
+fn patterns_match_through_wrapper() {
+    let patterns = vec!["cargo test".to_string()];
+    assert!(patterns_match_with_wrapper(
+        &patterns,
+        &words("nix develop -c cargo test"),
+        &default_cfg()
+    ));
+}
+
+#[test]
+fn patterns_no_match_through_wrapper_when_inner_unknown() {
+    let patterns = vec!["cargo test".to_string()];
+    assert!(!patterns_match_with_wrapper(
+        &patterns,
+        &words("nix develop -c echo hi"),
+        &default_cfg()
+    ));
+}
+
+#[test]
+fn patterns_no_match_when_disabled() {
+    let patterns = vec!["cargo test".to_string()];
+    let cfg = LocalWrapperConfig {
+        builtins: false,
+        disabled: vec![],
+        rules: vec![],
+    };
+    assert!(!patterns_match_with_wrapper(
+        &patterns,
+        &words("nix develop -c cargo test"),
+        &cfg
+    ));
+}
+
+#[test]
+fn patterns_degenerate_nesting_terminates() {
+    // Double-wrapped: nix develop -c nix develop -c cargo test.
+    let patterns = vec!["cargo test".to_string()];
+    assert!(patterns_match_with_wrapper(
+        &patterns,
+        &words("nix develop -c nix develop -c cargo test"),
+        &default_cfg()
+    ));
+}
+
+// --- match_filters_with_wrapper ---
+
+fn resolved(command: &str) -> ResolvedFilter {
+    let cfg: FilterConfig = toml::from_str(&format!("command = \"{command}\"")).unwrap();
+    ResolvedFilter {
+        config: cfg,
+        hash: "hash".to_string(),
+        source_path: PathBuf::from("<built-in>/test.toml"),
+        relative_path: PathBuf::from("test.toml"),
+        priority: 0,
+    }
+}
+
+#[test]
+fn match_filters_direct() {
+    let filters = vec![resolved("cargo test")];
+    let (_f, pattern, consumed) =
+        match_filters_with_wrapper(&filters, &words("cargo test"), &default_cfg()).unwrap();
+    assert_eq!(pattern, "cargo test");
+    assert_eq!(consumed, 2);
+}
+
+#[test]
+fn match_filters_through_wrapper_extends_consumed() {
+    let filters = vec![resolved("cargo test")];
+    let (_f, pattern, consumed) = match_filters_with_wrapper(
+        &filters,
+        &words("nix develop -c cargo test"),
+        &default_cfg(),
+    )
+    .unwrap();
+    // matched_command is the inner pattern only…
+    assert_eq!(pattern, "cargo test");
+    // …but consumed spans the full "nix develop -c cargo test" prefix.
+    assert_eq!(consumed, 5);
+}
+
+#[test]
+fn match_filters_no_match_returns_none() {
+    let filters = vec![resolved("cargo test")];
+    assert!(
+        match_filters_with_wrapper(&filters, &words("nix develop -c echo hi"), &default_cfg())
+            .is_none()
+    );
+}
+
+#[test]
+fn match_filters_nested_wrapper_terminates() {
+    let filters = vec![resolved("cargo test")];
+    let (_f, pattern, consumed) = match_filters_with_wrapper(
+        &filters,
+        &words("nix develop -c nix develop -c cargo test"),
+        &default_cfg(),
+    )
+    .unwrap();
+    assert_eq!(pattern, "cargo test");
+    // 3 (outer wrapper) + 3 (inner wrapper) + 2 (cargo test) = 8
+    assert_eq!(consumed, 8);
+}

--- a/crates/tokf-cli/src/main.rs
+++ b/crates/tokf-cli/src/main.rs
@@ -29,6 +29,7 @@ mod sync_cmd;
 mod telemetry_cmd;
 // pub(crate): accessed by install_cmd::run_verify
 pub(crate) mod verify_cmd;
+mod which_cmd;
 
 use std::path::Path;
 
@@ -426,8 +427,9 @@ enum RemoteAction {
 fn main() {
     use commands::{
         cmd_apply, cmd_check, cmd_hook_handle, cmd_hook_install, cmd_ls, cmd_rewrite, cmd_run,
-        cmd_skill_install, cmd_which, or_exit,
+        cmd_skill_install, or_exit,
     };
+    use which_cmd::cmd_which;
 
     tokf::paths::init_from_env();
 

--- a/crates/tokf-cli/src/resolve.rs
+++ b/crates/tokf-cli/src/resolve.rs
@@ -35,46 +35,58 @@ pub fn find_filter(
     let resolved = discover_filters(no_cache)?;
     let words: Vec<&str> = command_args.iter().map(String::as_str).collect();
     let cwd = std::env::current_dir().unwrap_or_default();
+    let wrapper_cfg = tokf::rewrite::load_user_config()
+        .unwrap_or_default()
+        .local_wrapper
+        .unwrap_or_default();
 
-    for filter in &resolved {
-        if let Some((matched_command, consumed)) = filter.matching_pattern(&words) {
-            if verbose {
-                eprintln!(
-                    "[tokf] matched {} (command: \"{}\") in {}",
-                    filter.relative_path.display(),
-                    filter.config.command.first(),
-                    filter
-                        .source_path
-                        .parent()
-                        .map_or("?", |p| p.to_str().unwrap_or("?")),
-                );
-            }
+    // Match directly, or after stripping a local environment wrapper prefix
+    // (e.g. `nix develop -c cargo test` matches the `cargo test` filter). The
+    // returned `consumed` spans the full prefix — wrapper words plus the matched
+    // pattern — so the whole command is executed and its output filtered.
+    if let Some((filter, matched_command, consumed)) =
+        config::local_wrapper::match_filters_with_wrapper(&resolved, &words, &wrapper_cfg)
+    {
+        if verbose {
+            eprintln!(
+                "[tokf] matched {} (command: \"{}\") in {}",
+                filter.relative_path.display(),
+                filter.config.command.first(),
+                filter
+                    .source_path
+                    .parent()
+                    .map_or("?", |p| p.to_str().unwrap_or("?")),
+            );
+        }
 
-            // Phase A: resolve file-based variants
-            if filter.config.variant.is_empty() {
-                return Ok(Some(FilterMatch {
-                    config: filter.config.clone(),
-                    hash: filter.hash.clone(),
-                    words_consumed: consumed,
-                    matched_command: matched_command.to_string(),
-                    output_variants: vec![],
-                    resolved_filters: resolved,
-                }));
-            }
-
-            let resolution =
-                config::variant::resolve_variants(&filter.config, &resolved, &cwd, verbose);
-            let hash = tokf_common::hash::canonical_hash(&resolution.config)
-                .unwrap_or_else(|_| filter.hash.clone());
+        // Phase A: resolve file-based variants
+        if filter.config.variant.is_empty() {
+            let config = filter.config.clone();
+            let hash = filter.hash.clone();
+            let matched_command = matched_command.to_string();
             return Ok(Some(FilterMatch {
-                config: resolution.config,
+                config,
                 hash,
                 words_consumed: consumed,
-                matched_command: matched_command.to_string(),
-                output_variants: resolution.output_variants,
+                matched_command,
+                output_variants: vec![],
                 resolved_filters: resolved,
             }));
         }
+
+        let resolution =
+            config::variant::resolve_variants(&filter.config, &resolved, &cwd, verbose);
+        let hash = tokf_common::hash::canonical_hash(&resolution.config)
+            .unwrap_or_else(|_| filter.hash.clone());
+        let matched_command = matched_command.to_string();
+        return Ok(Some(FilterMatch {
+            config: resolution.config,
+            hash,
+            words_consumed: consumed,
+            matched_command,
+            output_variants: resolution.output_variants,
+            resolved_filters: resolved,
+        }));
     }
 
     if verbose {

--- a/crates/tokf-cli/src/resolve.rs
+++ b/crates/tokf-cli/src/resolve.rs
@@ -35,10 +35,7 @@ pub fn find_filter(
     let resolved = discover_filters(no_cache)?;
     let words: Vec<&str> = command_args.iter().map(String::as_str).collect();
     let cwd = std::env::current_dir().unwrap_or_default();
-    let wrapper_cfg = tokf::rewrite::load_user_config()
-        .unwrap_or_default()
-        .local_wrapper
-        .unwrap_or_default();
+    let wrapper_cfg = tokf::rewrite::load_local_wrapper_config();
 
     // Match directly, or after stripping a local environment wrapper prefix
     // (e.g. `nix develop -c cargo test` matches the `cargo test` filter). The
@@ -61,14 +58,11 @@ pub fn find_filter(
 
         // Phase A: resolve file-based variants
         if filter.config.variant.is_empty() {
-            let config = filter.config.clone();
-            let hash = filter.hash.clone();
-            let matched_command = matched_command.to_string();
             return Ok(Some(FilterMatch {
-                config,
-                hash,
+                config: filter.config.clone(),
+                hash: filter.hash.clone(),
                 words_consumed: consumed,
-                matched_command,
+                matched_command: matched_command.to_string(),
                 output_variants: vec![],
                 resolved_filters: resolved,
             }));
@@ -78,12 +72,11 @@ pub fn find_filter(
             config::variant::resolve_variants(&filter.config, &resolved, &cwd, verbose);
         let hash = tokf_common::hash::canonical_hash(&resolution.config)
             .unwrap_or_else(|_| filter.hash.clone());
-        let matched_command = matched_command.to_string();
         return Ok(Some(FilterMatch {
             config: resolution.config,
             hash,
             words_consumed: consumed,
-            matched_command,
+            matched_command: matched_command.to_string(),
             output_variants: resolution.output_variants,
             resolved_filters: resolved,
         }));

--- a/crates/tokf-cli/src/rewrite/mod.rs
+++ b/crates/tokf-cli/src/rewrite/mod.rs
@@ -73,9 +73,24 @@ fn collect_filter_patterns(search_dirs: &[PathBuf]) -> Vec<String> {
 /// Try to match a command against filter patterns using the authoritative
 /// [`config::pattern_matches_prefix`] logic.  Returns a `tokf run` invocation
 /// if matched.
-fn try_filter_match(cmd: &str, patterns: &[String], options: &RewriteOptions) -> Option<String> {
+///
+/// A command wrapped in a local environment wrapper (e.g.
+/// `nix develop -c cargo test`) matches when its inner command does. The wrap
+/// is applied to the **whole** command (`tokf run nix develop -c cargo test`),
+/// not the inner part — tokf is the parent process and filters the wrapper's
+/// combined output, so nothing needs `tokf` on `PATH` inside the wrapped
+/// environment. See issue #403.
+fn try_filter_match(
+    cmd: &str,
+    patterns: &[String],
+    options: &RewriteOptions,
+    local_wrapper: &types::LocalWrapperConfig,
+) -> Option<String> {
     let words: Vec<&str> = cmd.split_whitespace().collect();
     if words.is_empty() {
+        return None;
+    }
+    if !config::local_wrapper::patterns_match_with_wrapper(patterns, &words, local_wrapper) {
         return None;
     }
     let prefix = if options.no_mask_exit_code {
@@ -83,12 +98,18 @@ fn try_filter_match(cmd: &str, patterns: &[String], options: &RewriteOptions) ->
     } else {
         "tokf run"
     };
-    for pattern in patterns {
-        if config::pattern_matches_prefix(pattern, &words).is_some() {
-            return Some(format!("{prefix} {cmd}"));
-        }
-    }
-    None
+    Some(format!("{prefix} {cmd}"))
+}
+
+/// Match a segment against filter patterns using the fields collected in
+/// [`SegmentRules`]. Thin wrapper over [`try_filter_match`].
+fn segment_filter_match(cmd: &str, rules: &SegmentRules<'_>) -> Option<String> {
+    try_filter_match(
+        cmd,
+        rules.filter_patterns,
+        rules.options,
+        rules.local_wrapper,
+    )
 }
 
 /// Top-level rewrite function. Orchestrates skip check, user rules, and filter rules.
@@ -114,6 +135,9 @@ struct SegmentRules<'a> {
     wrapper: &'a [RewriteRule],
     /// Raw filter pattern strings matched via `pattern_matches_prefix`.
     filter_patterns: &'a [String],
+    /// Local environment wrappers (e.g. `nix develop -c`) to unwrap when
+    /// matching filter patterns.
+    local_wrapper: &'a types::LocalWrapperConfig,
     /// Options controlling `tokf run` generation (e.g. `--no-mask-exit-code`).
     options: &'a RewriteOptions,
     /// When true, log to stderr when the bash parser fails to parse a command.
@@ -186,7 +210,7 @@ fn rewrite_segment(
             && let Some(StrippedPipe { base, suffix }) = cmd_parsed
                 .as_ref()
                 .and_then(bash_ast::ParsedCommand::strip_simple_pipe)
-            && let Some(rewritten) = try_filter_match(&base, rules.filter_patterns, rules.options)
+            && let Some(rewritten) = segment_filter_match(&base, rules)
         {
             if verbose {
                 eprintln!("[tokf] stripped pipe — tokf filter provides structured output");
@@ -201,7 +225,7 @@ fn rewrite_segment(
         return segment.to_string();
     }
 
-    try_filter_match(cmd, rules.filter_patterns, rules.options).map_or_else(
+    segment_filter_match(cmd, rules).map_or_else(
         || segment.to_string(),
         |result| format!("{env_prefix}{result}"),
     )
@@ -312,6 +336,7 @@ pub(crate) fn rewrite_with_config_and_options(
 
     let wrapper_rules = build_wrapper_rules();
     let filter_patterns = collect_filter_patterns(search_dirs);
+    let local_wrapper = user_config.local_wrapper.clone().unwrap_or_default();
     let log_parse_failures = user_config
         .debug
         .as_ref()
@@ -319,6 +344,7 @@ pub(crate) fn rewrite_with_config_and_options(
     let rules = SegmentRules {
         wrapper: &wrapper_rules,
         filter_patterns: &filter_patterns,
+        local_wrapper: &local_wrapper,
         options,
         log_parse_failures,
     };
@@ -362,6 +388,8 @@ mod tests;
 mod tests_compound;
 #[cfg(test)]
 mod tests_env;
+#[cfg(test)]
+mod tests_local_wrapper;
 #[cfg(test)]
 mod tests_pipe;
 #[cfg(test)]

--- a/crates/tokf-cli/src/rewrite/mod.rs
+++ b/crates/tokf-cli/src/rewrite/mod.rs
@@ -12,7 +12,7 @@ use bash_ast::{StrippedPipe, split_compound, strip_env_prefix};
 use rules::{apply_rules, should_skip};
 use types::{RewriteConfig, RewriteOptions, RewriteRule};
 
-pub use user_config::load_user_config;
+pub use user_config::{load_local_wrapper_config, load_user_config};
 
 /// Built-in wrapper rules for task runners that support shell overrides.
 ///

--- a/crates/tokf-cli/src/rewrite/tests.rs
+++ b/crates/tokf-cli/src/rewrite/tests.rs
@@ -205,6 +205,7 @@ fn rewrite_user_rule_takes_priority() {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     };
     let result = rewrite_with_config("git status", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(result, "custom-wrapper git status");
@@ -228,6 +229,7 @@ fn rewrite_user_skip_prevents_rewrite() {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     };
     let result = rewrite_with_config("git status", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(result, "git status");
@@ -400,6 +402,7 @@ fn wrapper_user_rule_overrides_builtin_wrapper() {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     };
     let r = rewrite_with_config("make check", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(r, "custom-make check");
@@ -417,6 +420,7 @@ fn wrapper_skip_pattern_prevents_wrapper() {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     };
     let r = rewrite_with_config("make check", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(r, "make check");

--- a/crates/tokf-cli/src/rewrite/tests_compound.rs
+++ b/crates/tokf-cli/src/rewrite/tests_compound.rs
@@ -245,6 +245,7 @@ fn rewrite_user_rule_wraps_piped_command() {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     };
     let r = rewrite_with_config(
         "cargo test | grep FAILED",
@@ -269,6 +270,7 @@ fn rewrite_skip_pattern_wins_over_pipe_guard() {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     };
     let r = rewrite_with_config(
         "git status | grep M",

--- a/crates/tokf-cli/src/rewrite/tests_env.rs
+++ b/crates/tokf-cli/src/rewrite/tests_env.rs
@@ -231,6 +231,7 @@ fn rewrite_user_skip_pattern_matches_env_stripped_command() {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     };
     // "FOO=bar git status" does NOT start with "git", so skip does not fire
     // and the command IS rewritten.

--- a/crates/tokf-cli/src/rewrite/tests_local_wrapper.rs
+++ b/crates/tokf-cli/src/rewrite/tests_local_wrapper.rs
@@ -1,0 +1,219 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Tests for local environment wrapper unwrapping in the rewrite path — see
+//! issue #403.
+//!
+//! `nix develop -c cargo test` runs `cargo test` locally, so tokf unwraps the
+//! prefix to match the `cargo test` filter and wraps the *whole* command with
+//! `tokf run` (outer wrap — tokf is the parent and filters the combined
+//! output). Contrast with transparent-arg commands (ssh), which are remote.
+
+use std::fs;
+
+use tempfile::TempDir;
+
+use super::*;
+use types::{LocalWrapperConfig, LocalWrapperRule};
+
+/// A tempdir search dir holding a `cargo test` filter.
+fn cargo_test_filters() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("cargo-test.toml"),
+        "command = \"cargo test\"",
+    )
+    .unwrap();
+    dir
+}
+
+#[test]
+fn wraps_whole_command_outer() {
+    let dir = cargo_test_filters();
+    let config = RewriteConfig::default();
+    let result = rewrite_with_config(
+        "nix develop -c cargo test",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "tokf run nix develop -c cargo test");
+}
+
+#[test]
+fn wraps_with_attr_and_flags() {
+    let dir = cargo_test_filters();
+    let config = RewriteConfig::default();
+    let result = rewrite_with_config(
+        "nix develop .#agent --impure -c cargo test",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(
+        result,
+        "tokf run nix develop .#agent --impure -c cargo test"
+    );
+}
+
+#[test]
+fn wraps_long_form_command_marker() {
+    let dir = cargo_test_filters();
+    let config = RewriteConfig::default();
+    let result = rewrite_with_config(
+        "nix develop --command cargo test",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "tokf run nix develop --command cargo test");
+}
+
+#[test]
+fn pipe_composition_wraps_and_strips() {
+    let dir = cargo_test_filters();
+    let config = RewriteConfig::default();
+    let result = rewrite_with_config(
+        "nix develop -c cargo test | tail -5",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(
+        result,
+        "tokf run --baseline-pipe 'tail -5' nix develop -c cargo test"
+    );
+}
+
+#[test]
+fn env_prefix_composition() {
+    let dir = cargo_test_filters();
+    let config = RewriteConfig::default();
+    let result = rewrite_with_config(
+        "FOO=bar nix develop -c cargo test",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "FOO=bar tokf run nix develop -c cargo test");
+}
+
+#[test]
+fn compound_composition_wraps_each_segment() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("cargo-test.toml"),
+        "command = \"cargo test\"",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("cargo-build.toml"),
+        "command = \"cargo build\"",
+    )
+    .unwrap();
+
+    let config = RewriteConfig::default();
+    let result = rewrite_with_config(
+        "nix develop -c cargo test && nix develop -c cargo build",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(
+        result,
+        "tokf run nix develop -c cargo test && tokf run nix develop -c cargo build"
+    );
+}
+
+#[test]
+fn unmatched_inner_passes_through() {
+    let dir = cargo_test_filters();
+    let config = RewriteConfig::default();
+    let result = rewrite_with_config(
+        "nix develop -c echo hi",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "nix develop -c echo hi");
+}
+
+#[test]
+fn make_nesting_passes_through_documented_limitation() {
+    // `make` is handled by SHELL=tokf injection, which would need tokf inside
+    // the devshell — so a make command nested in a local wrapper is NOT
+    // rewritten. It passes through unchanged (only the outer level could be
+    // filtered, and make has no filter of its own).
+    let dir = cargo_test_filters();
+    let config = RewriteConfig::default();
+    let result = rewrite_with_config(
+        "nix develop -c make check",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "nix develop -c make check");
+}
+
+#[test]
+fn disabled_builtin_leaves_command_unrewritten() {
+    let dir = cargo_test_filters();
+    let config = RewriteConfig {
+        local_wrapper: Some(LocalWrapperConfig {
+            builtins: true,
+            disabled: vec!["nix".to_string()],
+            rules: vec![],
+        }),
+        ..RewriteConfig::default()
+    };
+    let result = rewrite_with_config(
+        "nix develop -c cargo test",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "nix develop -c cargo test");
+}
+
+#[test]
+fn builtins_off_leaves_command_unrewritten() {
+    let dir = cargo_test_filters();
+    let config = RewriteConfig {
+        local_wrapper: Some(LocalWrapperConfig {
+            builtins: false,
+            disabled: vec![],
+            rules: vec![],
+        }),
+        ..RewriteConfig::default()
+    };
+    let result = rewrite_with_config(
+        "nix develop -c cargo test",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "nix develop -c cargo test");
+}
+
+#[test]
+fn user_rule_wraps_custom_wrapper() {
+    let dir = cargo_test_filters();
+    let config = RewriteConfig {
+        local_wrapper: Some(LocalWrapperConfig {
+            builtins: true,
+            disabled: vec![],
+            rules: vec![LocalWrapperRule {
+                command: "distrobox".to_string(),
+                subcommands: vec!["enter".to_string()],
+                markers: vec!["--".to_string()],
+            }],
+        }),
+        ..RewriteConfig::default()
+    };
+    let result = rewrite_with_config(
+        "distrobox enter my-box -- cargo test",
+        &config,
+        &[dir.path().to_path_buf()],
+        false,
+    );
+    assert_eq!(result, "tokf run distrobox enter my-box -- cargo test");
+}

--- a/crates/tokf-cli/src/rewrite/tests_pipe.rs
+++ b/crates/tokf-cli/src/rewrite/tests_pipe.rs
@@ -29,6 +29,7 @@ fn rewrite_pipe_strip_disabled_preserves_pipe() {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     };
     let r = rewrite_with_config(
         "cargo test | tail -5",
@@ -59,6 +60,7 @@ fn rewrite_pipe_strip_disabled_non_piped_still_rewritten() {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     };
     let r = rewrite_with_config(
         "cargo test --lib",
@@ -91,6 +93,7 @@ fn rewrite_prefer_less_injects_flag() {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     };
     let r = rewrite_with_config(
         "cargo test | tail -5",
@@ -123,6 +126,7 @@ fn rewrite_prefer_less_without_pipe_no_effect() {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     };
     let r = rewrite_with_config(
         "cargo test --lib",
@@ -153,6 +157,7 @@ fn rewrite_strip_false_overrides_prefer_less() {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     };
     let r = rewrite_with_config(
         "cargo test | tail -5",
@@ -180,6 +185,7 @@ fn rewrite_compound_prefer_less_per_segment() {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     };
     let r = rewrite_with_config(
         "git add . && git diff | head -5",

--- a/crates/tokf-cli/src/rewrite/tests_transparent.rs
+++ b/crates/tokf-cli/src/rewrite/tests_transparent.rs
@@ -31,6 +31,7 @@ fn config_with_mangling_rule() -> RewriteConfig {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     }
 }
 
@@ -130,6 +131,7 @@ fn user_can_extend_transparent_list() {
         transparent: Some(types::TransparentConfig {
             commands: vec!["kubectl".to_string()],
         }),
+        local_wrapper: None,
     };
     let result = rewrite_with_config(
         "kubectl exec POD -- cmd",
@@ -156,6 +158,7 @@ fn user_extra_does_not_disable_built_ins() {
         transparent: Some(types::TransparentConfig {
             commands: vec!["kubectl".to_string()],
         }),
+        local_wrapper: None,
     };
     let result = rewrite_with_config("ssh HOST cmd", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(result, "ssh HOST cmd");
@@ -259,6 +262,7 @@ fn user_skip_pattern_takes_precedence_over_transparent_gate() {
         permissions: None,
         debug: None,
         transparent: None,
+        local_wrapper: None,
     };
     let result = rewrite_with_config(
         "ssh HOST 'cmd'",

--- a/crates/tokf-cli/src/rewrite/types.rs
+++ b/crates/tokf-cli/src/rewrite/types.rs
@@ -1,6 +1,6 @@
 pub use tokf_hook_types::{
-    PermissionEngineType, PermissionsConfig, PipeConfig, RewriteConfig, RewriteRule, SkipConfig,
-    TransparentConfig,
+    LocalWrapperConfig, LocalWrapperRule, PermissionEngineType, PermissionsConfig, PipeConfig,
+    RewriteConfig, RewriteRule, SkipConfig, TransparentConfig,
 };
 
 /// Options that control how the rewrite system generates `tokf run` commands.
@@ -160,6 +160,78 @@ replace = "tokf run {0}"
     fn deserialize_no_permissions_section() {
         let config: RewriteConfig = toml::from_str("").unwrap();
         assert!(config.permissions.is_none());
+    }
+
+    #[test]
+    fn deserialize_no_local_wrapper_section() {
+        let config: RewriteConfig = toml::from_str("").unwrap();
+        assert!(config.local_wrapper.is_none());
+    }
+
+    #[test]
+    fn deserialize_local_wrapper_defaults_when_present() {
+        let toml_str = r"
+[local_wrapper]
+";
+        let config: RewriteConfig = toml::from_str(toml_str).unwrap();
+        let lw = config.local_wrapper.unwrap();
+        assert!(lw.builtins, "builtins should default to true");
+        assert!(lw.disabled.is_empty());
+        assert!(lw.rules.is_empty());
+    }
+
+    #[test]
+    fn deserialize_local_wrapper_disabled_and_rules() {
+        let toml_str = r#"
+[local_wrapper]
+disabled = ["nix"]
+
+[[local_wrapper.rules]]
+command = "distrobox"
+subcommands = ["enter"]
+markers = ["--"]
+"#;
+        let config: RewriteConfig = toml::from_str(toml_str).unwrap();
+        let lw = config.local_wrapper.unwrap();
+        assert!(lw.builtins, "builtins should still default to true");
+        assert_eq!(lw.disabled, vec!["nix".to_string()]);
+        assert_eq!(lw.rules.len(), 1);
+        assert_eq!(lw.rules[0].command, "distrobox");
+        assert_eq!(lw.rules[0].subcommands, vec!["enter".to_string()]);
+        assert_eq!(lw.rules[0].markers, vec!["--".to_string()]);
+    }
+
+    #[test]
+    fn deserialize_local_wrapper_builtins_off() {
+        let toml_str = r"
+[local_wrapper]
+builtins = false
+";
+        let config: RewriteConfig = toml::from_str(toml_str).unwrap();
+        let lw = config.local_wrapper.unwrap();
+        assert!(!lw.builtins);
+    }
+
+    #[test]
+    fn deserialize_local_wrapper_rule_without_subcommands() {
+        let toml_str = r#"
+[[local_wrapper.rules]]
+command = "toolbox"
+markers = ["run"]
+"#;
+        let config: RewriteConfig = toml::from_str(toml_str).unwrap();
+        let lw = config.local_wrapper.unwrap();
+        assert_eq!(lw.rules.len(), 1);
+        assert!(lw.rules[0].subcommands.is_empty());
+        assert_eq!(lw.rules[0].markers, vec!["run".to_string()]);
+    }
+
+    #[test]
+    fn local_wrapper_config_default_enables_builtins() {
+        let lw = LocalWrapperConfig::default();
+        assert!(lw.builtins, "Default impl must enable builtins");
+        assert!(lw.disabled.is_empty());
+        assert!(lw.rules.is_empty());
     }
 
     #[test]

--- a/crates/tokf-cli/src/rewrite/user_config.rs
+++ b/crates/tokf-cli/src/rewrite/user_config.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::types::RewriteConfig;
+use super::types::{LocalWrapperConfig, RewriteConfig};
 
 /// Search config dirs for `rewrites.toml` (first found wins).
 ///
@@ -9,6 +9,15 @@ use super::types::RewriteConfig;
 /// 2. `~/.config/tokf/rewrites.toml` (user-level)
 pub fn load_user_config() -> Option<RewriteConfig> {
     load_user_config_from(&config_search_paths())
+}
+
+/// Load the `[local_wrapper]` config, falling back to defaults when no
+/// `rewrites.toml` exists or it omits the section.
+pub fn load_local_wrapper_config() -> LocalWrapperConfig {
+    load_user_config()
+        .unwrap_or_default()
+        .local_wrapper
+        .unwrap_or_default()
 }
 
 fn config_search_paths() -> Vec<PathBuf> {

--- a/crates/tokf-cli/src/which_cmd.rs
+++ b/crates/tokf-cli/src/which_cmd.rs
@@ -13,10 +13,7 @@ pub fn cmd_which(command: &str, verbose: bool) -> i32 {
 
     let words: Vec<&str> = command.split_whitespace().collect();
     let cwd = std::env::current_dir().unwrap_or_default();
-    let wrapper_cfg = rewrite::load_user_config()
-        .unwrap_or_default()
-        .local_wrapper
-        .unwrap_or_default();
+    let wrapper_cfg = rewrite::load_local_wrapper_config();
 
     // Match directly, or after stripping a local environment wrapper prefix
     // (e.g. `nix develop -c cargo test` reports the `cargo test` filter).

--- a/crates/tokf-cli/src/which_cmd.rs
+++ b/crates/tokf-cli/src/which_cmd.rs
@@ -1,0 +1,71 @@
+use tokf::config;
+use tokf::rewrite;
+
+use crate::resolve;
+
+/// `tokf which <command>` — report which filter (if any) matches a command,
+/// including through a local environment wrapper such as `nix develop -c`.
+pub fn cmd_which(command: &str, verbose: bool) -> i32 {
+    let Ok(filters) = resolve::discover_filters(false) else {
+        eprintln!("[tokf] error: failed to discover filters");
+        return 1;
+    };
+
+    let words: Vec<&str> = command.split_whitespace().collect();
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let wrapper_cfg = rewrite::load_user_config()
+        .unwrap_or_default()
+        .local_wrapper
+        .unwrap_or_default();
+
+    // Match directly, or after stripping a local environment wrapper prefix
+    // (e.g. `nix develop -c cargo test` reports the `cargo test` filter).
+    let Some((filter, _pattern, _consumed)) =
+        config::local_wrapper::match_filters_with_wrapper(&filters, &words, &wrapper_cfg)
+    else {
+        eprintln!("[tokf] no filter found for \"{command}\"");
+        return 1;
+    };
+
+    let display_name = filter
+        .relative_path
+        .with_extension("")
+        .display()
+        .to_string();
+
+    let variant_info = if filter.config.variant.is_empty() {
+        String::new()
+    } else {
+        let res = config::variant::resolve_variants(&filter.config, &filters, &cwd, verbose);
+        let resolved = res.config.command.first().to_string();
+        if resolved != filter.config.command.first() {
+            format!(" -> variant: \"{resolved}\"")
+        } else if res.output_variants.is_empty() {
+            format!(
+                " ({} variant(s), none matched by file)",
+                filter.config.variant.len()
+            )
+        } else {
+            let names: Vec<&str> = res
+                .output_variants
+                .iter()
+                .map(|v| v.name.as_str())
+                .collect();
+            format!(
+                " ({} variant(s), {} deferred to output-pattern: {})",
+                filter.config.variant.len(),
+                res.output_variants.len(),
+                names.join(", ")
+            )
+        }
+    };
+    println!(
+        "{display_name}  [{}]  command: \"{}\"{variant_info}",
+        filter.priority_label(),
+        filter.config.command.first()
+    );
+    if verbose {
+        eprintln!("[tokf] source: {}", filter.source_path.display());
+    }
+    0
+}

--- a/crates/tokf-cli/tests/cli_rewrite.rs
+++ b/crates/tokf-cli/tests/cli_rewrite.rs
@@ -539,6 +539,28 @@ fn which_shows_variant_info() {
 }
 
 #[test]
+fn which_reports_filter_through_nix_wrapper() {
+    let dir = tempfile::TempDir::new().unwrap();
+
+    let output = tokf()
+        .args(["which", "nix develop -c cargo test"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "which should report a filter through the nix wrapper, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("cargo/test"),
+        "expected the cargo test filter to be reported, got: {stdout}"
+    );
+}
+
+#[test]
 fn which_variant_file_match() {
     let dir = tempfile::TempDir::new().unwrap();
     // Create a vitest config file so the variant resolves

--- a/crates/tokf-cli/tests/cli_run.rs
+++ b/crates/tokf-cli/tests/cli_run.rs
@@ -571,3 +571,185 @@ output = "FILTERED_TEMPLATE"
         "filter template must not appear when --jq is passed, got: {stdout}"
     );
 }
+
+// --- local environment wrappers (nix develop -c) ---
+
+/// Write a fake `nix` executable into `dir` that skips its own args until it
+/// sees `-c`/`--command`, then execs everything after. This lets us exercise
+/// the local-wrapper unwrapping end-to-end without a real Nix install.
+#[cfg(unix)]
+fn write_fake_nix(dir: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let script = "#!/bin/sh\n\
+        while [ $# -gt 0 ]; do\n\
+        \x20 case \"$1\" in\n\
+        \x20   -c|--command) shift; exec \"$@\" ;;\n\
+        \x20   *) shift ;;\n\
+        \x20 esac\n\
+        done\n\
+        exit 0\n";
+    let nix_path = dir.join("nix");
+    std::fs::write(&nix_path, script).unwrap();
+    std::fs::set_permissions(&nix_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+/// PATH with `bindir` prepended so the fake `nix` shadows any real one while
+/// `git` etc. remain resolvable.
+#[cfg(unix)]
+fn path_with(bindir: &std::path::Path) -> String {
+    let existing = std::env::var("PATH").unwrap_or_default();
+    format!("{}:{}", bindir.display(), existing)
+}
+
+#[cfg(unix)]
+#[test]
+fn run_nix_develop_unwraps_git_status() {
+    let bindir = tempfile::TempDir::new().unwrap();
+    write_fake_nix(bindir.path());
+
+    let repo = tempfile::TempDir::new().unwrap();
+    let init = Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(repo.path())
+        .output()
+        .unwrap();
+    assert!(init.status.success());
+    std::fs::write(repo.path().join("a-new-file.txt"), "hi").unwrap();
+
+    let output = tokf()
+        .args(["run", "--verbose", "nix", "develop", "-c", "git", "status"])
+        .env("PATH", path_with(bindir.path()))
+        .current_dir(repo.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("matched git/status.toml"),
+        "expected the git status filter to match through the nix wrapper, got: {stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("a-new-file.txt"),
+        "expected filtered git status to list the new file, got: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn run_nix_develop_attr_and_flags_unwrap() {
+    // `nix develop .#agent --impure -c git status` — attrs/flags before -c.
+    let bindir = tempfile::TempDir::new().unwrap();
+    write_fake_nix(bindir.path());
+
+    let repo = tempfile::TempDir::new().unwrap();
+    let init = Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(repo.path())
+        .output()
+        .unwrap();
+    assert!(init.status.success());
+
+    let output = tokf()
+        .args([
+            "run",
+            "--verbose",
+            "nix",
+            "develop",
+            ".#agent",
+            "--impure",
+            "-c",
+            "git",
+            "status",
+        ])
+        .env("PATH", path_with(bindir.path()))
+        .current_dir(repo.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("matched git/status.toml"),
+        "expected match through nix develop with attr + flags, got: {stderr}"
+    );
+}
+
+/// Real-nix smoke test — opt-in, ignored by default. Runs only when a real
+/// `nix` is on PATH. Creates a minimal flake with an empty devShell and checks
+/// that `tokf run nix develop -c git status` filters correctly.
+///
+/// This can download nixpkgs on first run, so it is `#[ignore]`d and only runs
+/// via `cargo test -- --ignored`.
+#[cfg(unix)]
+#[test]
+#[ignore = "requires a real nix install; may download nixpkgs"]
+fn run_nix_develop_real_nix() {
+    let has_nix = Command::new("nix")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success());
+    if !has_nix {
+        eprintln!("skipping: no real `nix` on PATH");
+        return;
+    }
+
+    let repo = tempfile::TempDir::new().unwrap();
+    let init = Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(repo.path())
+        .output()
+        .unwrap();
+    assert!(init.status.success());
+    std::fs::write(repo.path().join("real-nix-file.txt"), "hi").unwrap();
+
+    let flake = r#"{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  outputs = { self, nixpkgs }:
+    let pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    in { devShells.x86_64-linux.default = pkgs.mkShellNoCC { }; };
+}
+"#;
+    std::fs::write(repo.path().join("flake.nix"), flake).unwrap();
+    // Stage the flake so `nix develop` (which requires a git tree) sees it.
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(repo.path())
+        .output()
+        .unwrap();
+
+    let output = tokf()
+        .args([
+            "run",
+            "--verbose",
+            "nix",
+            "develop",
+            "--extra-experimental-features",
+            "nix-command flakes",
+            "-c",
+            "git",
+            "status",
+        ])
+        .current_dir(repo.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("matched git/status.toml"),
+        "expected the git status filter to match through real nix, got: {stderr}"
+    );
+}

--- a/crates/tokf-cli/tests/cli_run.rs
+++ b/crates/tokf-cli/tests/cli_run.rs
@@ -710,11 +710,17 @@ fn run_nix_develop_real_nix() {
     assert!(init.status.success());
     std::fs::write(repo.path().join("real-nix-file.txt"), "hi").unwrap();
 
+    // Arch-agnostic: define an empty devShell for every common system so
+    // `nix develop` resolves on x86_64/aarch64 Linux or macOS alike.
     let flake = r#"{
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   outputs = { self, nixpkgs }:
-    let pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    in { devShells.x86_64-linux.default = pkgs.mkShellNoCC { }; };
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAll = f: nixpkgs.lib.genAttrs systems (s: f nixpkgs.legacyPackages.${s});
+    in {
+      devShells = forAll (pkgs: { default = pkgs.mkShellNoCC { }; });
+    };
 }
 "#;
     std::fs::write(repo.path().join("flake.nix"), flake).unwrap();

--- a/crates/tokf-hook-types/src/config.rs
+++ b/crates/tokf-hook-types/src/config.rs
@@ -31,6 +31,13 @@ pub struct RewriteConfig {
     /// only argv-preserving wraps (`tokf run <cmd>`) and pipe-flag injection
     /// remain.
     pub transparent: Option<TransparentConfig>,
+
+    /// Local environment wrappers (e.g. `nix develop -c <cmd>`) whose inner
+    /// command runs locally and should be unwrapped so tokf can match a filter
+    /// against it. Unlike [`transparent`](Self::transparent) commands, these
+    /// are local, so the whole command is wrapped with `tokf run` and its
+    /// output filtered. See issue #403.
+    pub local_wrapper: Option<LocalWrapperConfig>,
 }
 
 /// "Transparent-arg" commands: their last argument is opaque shell code.
@@ -45,6 +52,62 @@ pub struct TransparentConfig {
     /// `kubectl` and `/usr/local/bin/kubectl`.
     #[serde(default)]
     pub commands: Vec<String>,
+}
+
+/// Local environment wrappers, e.g. `nix develop -c <cmd>`.
+///
+/// The inner command runs locally, so tokf unwraps the prefix to match a filter
+/// against it, then wraps the *whole* command with `tokf run` and filters the
+/// output.
+///
+/// Built-in list (active by default): `nix develop -c` / `nix develop --command`.
+/// User `rules` extend the built-ins; `disabled` removes named built-ins;
+/// `builtins = false` disables all built-ins (user `rules` still apply).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LocalWrapperConfig {
+    /// When false, disable ALL built-in local wrappers. User `rules` still
+    /// apply. Default: true.
+    #[serde(default = "default_true")]
+    pub builtins: bool,
+
+    /// Built-in wrappers to disable, matched by `command` basename. Ignored
+    /// when `builtins = false` (everything is already off).
+    #[serde(default)]
+    pub disabled: Vec<String>,
+
+    /// Additional user-defined wrappers. These extend — do not replace — the
+    /// built-in list.
+    #[serde(default)]
+    pub rules: Vec<LocalWrapperRule>,
+}
+
+impl Default for LocalWrapperConfig {
+    fn default() -> Self {
+        Self {
+            builtins: true,
+            disabled: Vec::new(),
+            rules: Vec::new(),
+        }
+    }
+}
+
+/// A single local-wrapper rule: how to recognise a wrapper prefix and where the
+/// inner command begins.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LocalWrapperRule {
+    /// Wrapper command, matched against the basename of the first word
+    /// (e.g. `nix` matches both `nix` and `/nix/store/…/bin/nix`).
+    pub command: String,
+
+    /// Subcommands that must immediately follow `command` (e.g. `["develop"]`
+    /// for `nix develop`). Empty means no subcommand is required.
+    #[serde(default)]
+    pub subcommands: Vec<String>,
+
+    /// Marker tokens (flags) whose *next* word begins the inner command
+    /// (e.g. `["-c", "--command"]`). Everything after the first marker is the
+    /// filterable inner command.
+    pub markers: Vec<String>,
 }
 
 /// Debug and diagnostic settings for the rewrite system.

--- a/crates/tokf-hook-types/src/lib.rs
+++ b/crates/tokf-hook-types/src/lib.rs
@@ -4,8 +4,8 @@ pub mod format;
 pub mod verdict;
 
 pub use config::{
-    PermissionEngineType, PermissionsConfig, PipeConfig, RewriteConfig, RewriteRule, SkipConfig,
-    TransparentConfig,
+    LocalWrapperConfig, LocalWrapperRule, PermissionEngineType, PermissionsConfig, PipeConfig,
+    RewriteConfig, RewriteRule, SkipConfig, TransparentConfig,
 };
 pub use engine::{ErrorFallback, ExternalEngineConfig};
 pub use format::HookFormat;

--- a/docs/rewrites-config.md
+++ b/docs/rewrites-config.md
@@ -432,6 +432,67 @@ If you genuinely need a regex rewrite for an ssh-class command, invoke it explic
 
 This was added to address [#338](https://github.com/mpecan/tokf/issues/338), where a long-output `ssh HOST 'cmd'` would land `tokf` on the remote bash and exit 127.
 
+## Local environment wrappers
+
+Some commands wrap an inner command that runs in a *local* environment — the canonical example is `nix develop -c cargo test`, which runs `cargo test` inside a Nix devshell on the same machine. By default tokf only sees the outer command (`nix`), so a `cargo test` filter never matches.
+
+Local wrappers are the **mirror image** of transparent-arg commands. Transparent commands (`ssh`) run their payload remotely, so tokf stays hands-off. Local wrappers run their inner command locally, so tokf can safely:
+
+1. **Inspect** the inner command to pick a filter (`nix develop -c cargo test` → matches the `cargo test` filter), and
+2. **Wrap the whole command** with `tokf run` and filter its combined output.
+
+tokf uses the *outer* wrap — `tokf run nix develop -c cargo test`, not `nix develop -c tokf run cargo test`. Because tokf is the parent process and captures the wrapper's output, nothing requires `tokf` to be on `PATH` *inside* the devshell (which would reintroduce the remote-shell failure mode from #338 locally).
+
+```sh
+# What you type:
+nix develop -c cargo test
+
+# What tokf rewrites it to (outer wrap):
+tokf run nix develop -c cargo test        # → cargo test filter applied to the output
+
+# With a pipe, the pipe is stripped and re-expressed as a baseline:
+nix develop -c cargo test | tail -5
+  →  tokf run --baseline-pipe 'tail -5' nix develop -c cargo test
+```
+
+### Built-in wrappers
+
+The built-in list, active by default, is:
+
+| Command | Prefix matched | Marker (inner command follows) |
+|---|---|---|
+| `nix` | `nix develop …` | `-c`, `--command` |
+
+Any flags or attributes between `nix develop` and the marker are tolerated, so `nix develop .#agent --impure -c cargo test` unwraps correctly. Basename matching applies (`/nix/store/…/bin/nix` is treated as `nix`). A marker with nothing after it (a bare `nix develop -c`) is not a match.
+
+### Configuring wrappers (`[local_wrapper]`)
+
+Add your own wrappers, disable built-ins by name, or turn built-ins off entirely:
+
+```toml
+[local_wrapper]
+# Turn off ALL built-in wrappers (user rules below still apply). Default: true.
+builtins = true
+# Disable specific built-ins by command basename.
+disabled = ["nix"]
+
+# Add your own wrappers. These extend the built-ins.
+[[local_wrapper.rules]]
+command = "distrobox"       # matched against the first word's basename
+subcommands = ["enter"]     # must immediately follow `command`; omit if not needed
+markers = ["--"]            # the inner command starts after the first marker
+```
+
+- `command` / `subcommands` decide **which prefixes** are treated as wrappers.
+- `markers` decides **which part of the command is parsed** as the filterable inner command — everything after the first marker.
+- `disabled` removes named built-ins; `builtins = false` removes all of them. User `rules` always apply.
+
+### Limitation: nested task runners
+
+A task runner nested inside a local wrapper — e.g. `nix develop -c make check` — is **not** filtered per recipe line. Task-runner integration works by injecting `SHELL=tokf` so `make` runs each recipe line through tokf, which would require `tokf` inside the devshell (the exact thing outer-wrapping avoids). Such commands pass through unchanged.
+
+This was added to address [#403](https://github.com/mpecan/tokf/issues/403).
+
 ## Debug settings
 
 The `[debug]` section enables diagnostic logging for the rewrite system. All settings are off by default.

--- a/docs/writing-filters.md
+++ b/docs/writing-filters.md
@@ -37,6 +37,8 @@ The skipped flags are preserved in the command that actually runs — they are o
 
 > **Note on `run` override and transparent flags:** If a filter sets a `run` field, transparent global flags are *not* included in `{args}`.  Only the arguments that appear after the matched pattern words are available as `{args}`.
 
+**Local environment wrappers** — you don't need to do anything special for your filter to match through a local wrapper like `nix develop -c cargo test`. tokf strips the wrapper prefix and matches the inner command (`cargo test`) against your existing patterns. See [Local environment wrappers](rewrites-config.md#local-environment-wrappers) for the configurable list.
+
 ## Common fields
 
 ```toml


### PR DESCRIPTION
## Summary

Closes #403.

`nix develop -c cargo test` (and `nix develop .#agent -c pytest`, `nix develop --impure -c npm test`) previously matched no filter, because tokf inspects only the literal first word of a command (`nix`). This PR teaches tokf to **unwrap local environment wrapper prefixes** so the inner command (`cargo test`) is matched against filters.

This is the mirror image of #338's transparent-arg commands (`ssh`/`mosh`/`slogin`): those run their payload on a *remote* shell, so tokf must never inspect or splice into it. `nix develop -c <cmd>` runs **locally**, so it's safe to inspect the inner command for matching.

### Outer wrap, not inner injection

tokf uses the wrapper prefix only to *pick* the filter, then wraps and executes the **whole** command:

```
nix develop -c cargo test   →   tokf run nix develop -c cargo test
```

Because tokf is the parent process and captures the wrapper's combined output, nothing requires the `tokf` binary on `PATH` *inside* the devshell (which would reintroduce #338's `tokf: command not found` failure mode locally when a devshell resets `PATH`).

## Configurability

New `[local_wrapper]` section in `rewrites.toml`:

```toml
[local_wrapper]
builtins = true          # master switch for built-ins (default true)
disabled = ["nix"]       # disable specific built-ins by command basename

[[local_wrapper.rules]]  # add your own wrappers
command = "distrobox"
subcommands = ["enter"]
markers = ["--"]
```

- `command` / `subcommands` decide **which prefixes** are treated as wrappers.
- `markers` decide **which part of the command is parsed** for filtering (everything after the first marker).
- Built-in list: `nix develop` with `-c` / `--command`. User `rules` extend it; `disabled` / `builtins = false` remove built-ins.

## Composed commands

Handled and tested:
- **Pipes**: `nix develop -c cargo test | tail -5` → `tokf run --baseline-pipe 'tail -5' nix develop -c cargo test`
- **Compound**: `nix develop -c cargo test && nix develop -c cargo build` — each segment wrapped independently
- **Env prefix**: `FOO=bar nix develop -c cargo test`

**Documented limitation:** a task runner nested inside a wrapper (`nix develop -c make check`) is not filtered per recipe line — the `SHELL=tokf` trick would need tokf inside the devshell. Such commands pass through unchanged.

## Changes

- `feat(config)`: `[local_wrapper]` schema + `config/local_wrapper` matching module (built-in nix, disable, user rules)
- `feat(runner)`: wire into `resolve::find_filter` and `tokf which` (extracted `cmd_which` into `which_cmd.rs` to stay under the 700-line file limit)
- `feat(hook)`: wire into the rewrite path (outer wrap, composes with pipes/compound/env)
- `docs`: new "Local environment wrappers" section + regenerated README

## Testing

- 23 unit tests (matching, disable, path-basename, nesting termination)
- 11 rewrite integration tests (composition + config paths + make-nesting limitation)
- 2 always-on CLI tests using a **fake `nix` shim** (no real Nix needed) + 1 `#[ignore]`d real-nix smoke test + 1 `tokf which` test through the wrapper
- Full suite green (1673 passed, 3 ignored); `cargo clippy --workspace --all-targets -D warnings` and `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)