### PR TITLE
feat(output): annotate filtered output with its history entry ID

### DIFF
--- a/.claude/TOKF.md
+++ b/.claude/TOKF.md
@@ -1,2 +1,5 @@
 🗜️ means this output was compressed by tokf.
-Run `tokf raw last` to see the full uncompressed output of the last command.
+🗜️#42 means the full, unfiltered output is recoverable as history entry 42 —
+run `tokf raw 42`. Pipe it (`tokf raw 42 | grep ...`, `| head`) rather than
+reading it whole; a recovered entry can be very large.
+Run `tokf raw last` for the last command's full output.

--- a/README.md
+++ b/README.md
@@ -1273,11 +1273,48 @@ output = "{branch} — {counts}"
 🗜️ compressed — run `tokf raw 99` for full output
 ```
 
-The `🗜️` prefix appears on all filtered output (disable with `tokf config set output.show_indicator false` or `TOKF_SHOW_INDICATOR=false`). The hint line is appended to stdout so it is visible to both humans and LLMs in the tool output. The history entry itself always stores the clean filtered output, without the hint line or indicator.
+The `🗜️` prefix appears on all filtered output (disable with `tokf config set output.show_indicator false` or `TOKF_SHOW_INDICATOR=false`). The hint line is appended to stdout so it is visible to both humans and LLMs in the tool output. The history entry itself always stores the clean filtered output, without the hint line, indicator or recovery marker.
+
+## Per-entry recovery markers
+
+When a filtered command is recorded in history, the indicator carries that entry's ID directly:
+
+```
+🗜️#87 ✓ cargo test: 42 passed
+```
+
+`🗜️#87` means the full, unfiltered output is one command away — `tokf raw 87`. Without an ID (`🗜️` alone) the run was not recorded, so there is nothing to recover.
+
+This is **additive**: the filtered body is byte-identical to what tokf printed before, and the ID rides the indicator that was already being printed. It costs roughly three tokens; there is no extra line and no extra newline. Disabling the indicator (`output.show_indicator = false`) removes the marker too — the ID is not smuggled back in on its own line.
+
+### Why the CLI rather than a tool call
+
+Recovery is deliberately a shell command. `tokf raw <id>` composes:
+
+```sh
+tokf raw 87 | grep -n 'error\[' | head -20
+```
+
+A recovered entry can be enormous — a `cargo metadata` capture runs to hundreds of thousands of tokens — so being able to narrow it *before* it reaches the model matters. Output that arrives through a tool call lands in context whole, with no opportunity to filter it first. Piping also means the recovered text can itself be filtered by tokf.
+
+Prefer `tokf raw <id> | ...` over reading an entry whole.
+
+### Why the ID is decimal
+
+Decimal is the cheapest encoding, which is counterintuitive — a shorter string is not a smaller number of tokens. BPE tokenizers pack runs of digits (up to three per token) while mixed-case alphanumerics fragment. Measured against `cl100k`:
+
+| id | decimal | base36 | base62 |
+|---|---|---|---|
+| 142 | **1** | 2 | 2 |
+| 4821 | **2** | 2 | 2 |
+| 51234 | **2** | 3 | **2** |
+| 998877 | **2** | 2 | 3 |
+
+Decimal is never worse and sometimes better, so the ID is printed as-is.
 
 ## Context injection
 
-During `tokf hook install`, tokf creates a `.claude/TOKF.md` file and adds an `@TOKF.md` reference to `.claude/CLAUDE.md`. This gives LLMs a two-line context explaining what `🗜️` means and how to retrieve full output (`tokf raw last`). Use `--no-context` to skip this step.
+During `tokf hook install`, tokf creates a `.claude/TOKF.md` file and adds an `@TOKF.md` reference to `.claude/CLAUDE.md`. This gives LLMs a short context explaining what `🗜️` and `🗜️#<id>` mean and how to retrieve full output (`tokf raw <id>`, or `tokf raw last`). Use `--no-context` to skip this step.
 
 ---
 

--- a/crates/tokf-cli/src/commands.rs
+++ b/crates/tokf-cli/src/commands.rs
@@ -5,7 +5,6 @@ use tokf::baseline;
 use tokf::config;
 use tokf::filter;
 use tokf::history;
-use tokf::history::OutputConfig;
 use tokf::hook;
 use tokf::rewrite;
 use tokf::runner;
@@ -13,6 +12,7 @@ use tokf::skill;
 use tokf::telemetry;
 
 use crate::Cli;
+use crate::marker;
 use crate::resolve;
 
 // R6: Rename Opencode → OpenCode; use #[value(name = "opencode")] to keep CLI arg as "opencode".
@@ -376,22 +376,14 @@ pub fn cmd_run(
         cmd_result.exit_code,
     );
 
-    let output_cfg = {
-        let cwd = std::env::current_dir().unwrap_or_default();
-        let project_root = history::project_root_for(&cwd);
-        OutputConfig::load(Some(&project_root))
-    };
+    let render_cfg = marker::load_render_config();
 
     let mask = !cli.no_mask_exit_code && cmd_result.exit_code != 0;
     if mask {
         println!("Error: Exit code {}", cmd_result.exit_code);
     }
     if !final_output.is_empty() {
-        if output_cfg.show_indicator {
-            println!("🗜️ {final_output}");
-        } else {
-            println!("{final_output}");
-        }
+        marker::print_with_indicator(&final_output, &render_cfg, history_id);
     }
 
     if show_hint && let Some(id) = history_id {

--- a/crates/tokf-cli/src/generic/mod.rs
+++ b/crates/tokf-cli/src/generic/mod.rs
@@ -8,6 +8,7 @@ use tokf::history;
 use tokf::runner;
 
 use crate::Cli;
+use crate::marker;
 use crate::resolve;
 
 /// Shared execution + tracking for generic fallback commands.
@@ -53,19 +54,18 @@ pub fn cmd_generic_run(
 
     let command_str = command_args.join(" ");
 
-    // Load output config for compression indicator
-    let output_cfg = {
-        let cwd = std::env::current_dir().unwrap_or_default();
-        let project_root = history::project_root_for(&cwd);
-        history::OutputConfig::load(Some(&project_root))
-    };
+    // Record history first: the entry ID feeds the recovery marker printed below.
+    let history_id = history::try_record(
+        &command_str,
+        filter_name,
+        &cmd_result.combined,
+        &filtered,
+        cmd_result.exit_code,
+    );
 
+    let render_cfg = marker::load_render_config();
     if !filtered.is_empty() {
-        if output_cfg.show_indicator {
-            println!("🗜️ {filtered}");
-        } else {
-            println!("{filtered}");
-        }
+        marker::print_with_indicator(&filtered, &render_cfg, history_id);
     }
 
     // Record tracking
@@ -81,15 +81,6 @@ pub fn cmd_generic_run(
         false,
     );
     resolve::try_auto_sync();
-
-    // Record history
-    history::try_record(
-        &command_str,
-        filter_name,
-        &cmd_result.combined,
-        &filtered,
-        cmd_result.exit_code,
-    );
 
     if cli.no_mask_exit_code {
         Ok(cmd_result.exit_code)

--- a/crates/tokf-cli/src/history/queries.rs
+++ b/crates/tokf-cli/src/history/queries.rs
@@ -47,17 +47,23 @@ pub fn record_history(
     let id = conn.last_insert_rowid();
 
     // Retention is scoped per project so each project keeps its own N entries.
+    //
+    // The row we just inserted is explicitly excluded from the prune. Without
+    // that guard a retention of 0 would delete the entry in the same call that
+    // returns its ID, and callers would print a `🗜️#<id>` recovery marker
+    // pointing at a row that no longer exists.
     let retention_i64 = i64::from(config.retention_count);
     conn.execute(
         "DELETE FROM history
          WHERE project = ?1
+           AND id <> ?3
            AND id NOT IN (
                SELECT id FROM history
                WHERE project = ?1
                ORDER BY id DESC
                LIMIT ?2
            )",
-        rusqlite::params![record.project, retention_i64],
+        rusqlite::params![record.project, retention_i64, id],
     )
     .context("enforce history retention")?;
 

--- a/crates/tokf-cli/src/history/tests.rs
+++ b/crates/tokf-cli/src/history/tests.rs
@@ -282,6 +282,43 @@ fn record_history_enforces_retention_per_project() {
     assert_eq!(all.len(), 4, "total across projects should be 4");
 }
 
+#[test]
+fn record_history_never_prunes_the_entry_it_just_inserted() {
+    // `history.retention = 0` is an accepted config value. The returned ID is
+    // printed as a `🗜️#<id>` recovery marker, so the row it names must still
+    // exist when `record_history` returns — otherwise the marker is dead on
+    // arrival rather than merely going stale after N more commands.
+    let (_dir, conn) = temp_db();
+    let config = HistoryConfig { retention_count: 0 };
+
+    let first = record_history(
+        &conn,
+        &make_record("proj", "cmd-1", None, "raw-1", "filtered", 0),
+        &config,
+    )
+    .expect("record");
+    let entry = get_history_entry(&conn, first).expect("get");
+    assert!(entry.is_some(), "entry {first} must be resolvable");
+
+    // The next insert is allowed to prune the previous one — only the row being
+    // returned right now is protected.
+    let second = record_history(
+        &conn,
+        &make_record("proj", "cmd-2", None, "raw-2", "filtered", 0),
+        &config,
+    )
+    .expect("record");
+    assert!(
+        get_history_entry(&conn, second).expect("get").is_some(),
+        "entry {second} must be resolvable"
+    );
+    assert_eq!(
+        list_history(&conn, 10, Some("proj")).expect("list").len(),
+        1,
+        "retention=0 still keeps only the newest entry"
+    );
+}
+
 // --- list_history ---
 
 #[test]

--- a/crates/tokf-cli/src/history_cmd.rs
+++ b/crates/tokf-cli/src/history_cmd.rs
@@ -3,6 +3,37 @@ use std::path::Path;
 use tokf::history;
 use tokf::tracking;
 
+use crate::commands::HistoryAction;
+
+/// Dispatch a `tokf history <action>` subcommand.
+///
+/// # Errors
+/// Returns an error if the underlying history command fails.
+pub fn dispatch_history(action: &HistoryAction) -> anyhow::Result<i32> {
+    match action {
+        HistoryAction::List { limit, all } => cmd_history_list(*limit, *all),
+        HistoryAction::Show { id, raw } => cmd_history_show(*id, *raw),
+        HistoryAction::Last { raw, all } => cmd_history_last(*raw, *all),
+        HistoryAction::Search { query, limit, all } => cmd_history_search(query, *limit, *all),
+        HistoryAction::Clear { all } => cmd_history_clear(*all),
+    }
+}
+
+/// Dispatch `tokf raw <target>` where target is `last` or a numeric entry ID.
+///
+/// # Errors
+/// Returns an error if the underlying history command fails.
+pub fn dispatch_raw(target: &str) -> anyhow::Result<i32> {
+    if target == "last" {
+        cmd_history_last(true, false)
+    } else if let Ok(id) = target.parse::<i64>() {
+        cmd_history_show(id, true)
+    } else {
+        eprintln!("[tokf] expected `last` or a numeric ID, got: {target}");
+        Ok(1)
+    }
+}
+
 fn open_history_conn() -> anyhow::Result<rusqlite::Connection> {
     let path =
         tracking::db_path().ok_or_else(|| anyhow::anyhow!("cannot determine history DB path"))?;

--- a/crates/tokf-cli/src/hook/install.rs
+++ b/crates/tokf-cli/src/hook/install.rs
@@ -93,7 +93,10 @@ pub(super) fn write_context_doc(dir: &Path) -> anyhow::Result<bool> {
     }
     let content = "\
 🗜️ means this output was compressed by tokf.
-Run `tokf raw last` to see the full uncompressed output of the last command.
+🗜️#42 means the full, unfiltered output is recoverable as history entry 42 —
+run `tokf raw 42`. Pipe it (`tokf raw 42 | grep ...`, `| head`) rather than
+reading it whole; a recovered entry can be very large.
+Run `tokf raw last` for the last command's full output.
 ";
     std::fs::write(&tokf_md, content)?;
     Ok(true)

--- a/crates/tokf-cli/src/main.rs
+++ b/crates/tokf-cli/src/main.rs
@@ -15,6 +15,7 @@ mod history_cmd;
 mod info_cmd;
 mod install_cmd;
 mod issue_cmd;
+mod marker;
 mod output;
 mod publish_cmd;
 #[cfg(feature = "stdlib-publish")]
@@ -556,23 +557,8 @@ fn main() {
             RemoteAction::Sync => remote_cmd::cmd_remote_sync(),
             RemoteAction::Backfill => remote_cmd::cmd_remote_backfill(cli.no_cache),
         }),
-        Commands::History { action } => or_exit(match action {
-            HistoryAction::List { limit, all } => history_cmd::cmd_history_list(*limit, *all),
-            HistoryAction::Show { id, raw } => history_cmd::cmd_history_show(*id, *raw),
-            HistoryAction::Last { raw, all } => history_cmd::cmd_history_last(*raw, *all),
-            HistoryAction::Search { query, limit, all } => {
-                history_cmd::cmd_history_search(query, *limit, *all)
-            }
-            HistoryAction::Clear { all } => history_cmd::cmd_history_clear(*all),
-        }),
-        Commands::Raw { target } => or_exit(if target == "last" {
-            history_cmd::cmd_history_last(true, false)
-        } else if let Ok(id) = target.parse::<i64>() {
-            history_cmd::cmd_history_show(id, true)
-        } else {
-            eprintln!("[tokf] expected `last` or a numeric ID, got: {target}");
-            Ok(1)
-        }),
+        Commands::History { action } => or_exit(history_cmd::dispatch_history(action)),
+        Commands::Raw { target } => or_exit(history_cmd::dispatch_raw(target)),
         Commands::Sync { status } => or_exit(sync_cmd::cmd_sync(*status)),
         Commands::Publish {
             filter,

--- a/crates/tokf-cli/src/marker.rs
+++ b/crates/tokf-cli/src/marker.rs
@@ -1,0 +1,80 @@
+//! Rendering of the compression indicator and the per-entry recovery marker.
+//!
+//! tokf annotates filtered output; it never replaces it. The filtered body is
+//! printed exactly as before — the marker is a short prefix on the indicator
+//! that is already paid for.
+//!
+//! Forms:
+//! - `""` — indicator disabled (`output.show_indicator = false`).
+//! - `"🗜️ "` — compressed, but this run was not recorded in history.
+//! - `"🗜️#42 "` — compressed and recoverable: `tokf raw 42`.
+//!
+//! `🗜️#<id>` extends the existing `🗜️` vocabulary rather than introducing a
+//! second marker language. Measured against cl100k, the id costs ~3 tokens on
+//! top of an indicator that is already printed — no extra line, no extra
+//! newline. A denser encoding does not help: BPE packs digit runs (up to three
+//! digits per token) while mixed-case alphanumerics fragment, so base36/base62
+//! ids of the same value cost the same or more.
+//!
+//! Recovery is deliberately the CLI (`tokf raw <id>`) rather than a dedicated
+//! tool call: shell output can be post-processed — piped through `grep`, `head`,
+//! or tokf itself — whereas a tool result lands in context whole. Recovering a
+//! large entry must not be able to blow the context window.
+
+use tokf::history::OutputConfig;
+
+/// Render the prefix that precedes filtered output.
+///
+/// The id is attached whenever the run was recorded in history, which is the
+/// only condition under which `tokf raw <id>` can resolve it. When the
+/// indicator is disabled nothing at all is emitted — the id is not smuggled
+/// back in.
+pub fn render_indicator(show_indicator: bool, history_id: Option<i64>) -> String {
+    if !show_indicator {
+        return String::new();
+    }
+    history_id.map_or_else(|| "🗜️ ".to_string(), |id| format!("🗜️#{id} "))
+}
+
+/// Load the print-time config for the current working directory's project.
+pub fn load_render_config() -> OutputConfig {
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let project_root = tokf::history::project_root_for(&cwd);
+    OutputConfig::load(Some(&project_root))
+}
+
+/// Print filtered output with the appropriate indicator/marker prefix.
+///
+/// Additive by construction: `body` is printed verbatim, whatever the prefix.
+pub fn print_with_indicator(body: &str, cfg: &OutputConfig, history_id: Option<i64>) {
+    let prefix = render_indicator(cfg.show_indicator, history_id);
+    println!("{prefix}{body}");
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::render_indicator;
+
+    #[test]
+    fn indicator_disabled_emits_nothing() {
+        assert_eq!(render_indicator(false, Some(42)), "");
+        assert_eq!(render_indicator(false, None), "");
+    }
+
+    #[test]
+    fn no_history_id_falls_back_to_plain_indicator() {
+        assert_eq!(render_indicator(true, None), "🗜️ ");
+    }
+
+    #[test]
+    fn history_id_emits_marker() {
+        assert_eq!(render_indicator(true, Some(42)), "🗜️#42 ");
+    }
+
+    #[test]
+    fn large_ids_format_without_panic() {
+        let out = render_indicator(true, Some(i64::MAX));
+        assert_eq!(out, format!("🗜️#{} ", i64::MAX));
+    }
+}

--- a/docs/token-tracking.md
+++ b/docs/token-tracking.md
@@ -63,8 +63,45 @@ output = "{branch} — {counts}"
 🗜️ compressed — run `tokf raw 99` for full output
 ```
 
-The `🗜️` prefix appears on all filtered output (disable with `tokf config set output.show_indicator false` or `TOKF_SHOW_INDICATOR=false`). The hint line is appended to stdout so it is visible to both humans and LLMs in the tool output. The history entry itself always stores the clean filtered output, without the hint line or indicator.
+The `🗜️` prefix appears on all filtered output (disable with `tokf config set output.show_indicator false` or `TOKF_SHOW_INDICATOR=false`). The hint line is appended to stdout so it is visible to both humans and LLMs in the tool output. The history entry itself always stores the clean filtered output, without the hint line, indicator or recovery marker.
+
+## Per-entry recovery markers
+
+When a filtered command is recorded in history, the indicator carries that entry's ID directly:
+
+```
+🗜️#87 ✓ cargo test: 42 passed
+```
+
+`🗜️#87` means the full, unfiltered output is one command away — `tokf raw 87`. Without an ID (`🗜️` alone) the run was not recorded, so there is nothing to recover.
+
+This is **additive**: the filtered body is byte-identical to what tokf printed before, and the ID rides the indicator that was already being printed. It costs roughly three tokens; there is no extra line and no extra newline. Disabling the indicator (`output.show_indicator = false`) removes the marker too — the ID is not smuggled back in on its own line.
+
+### Why the CLI rather than a tool call
+
+Recovery is deliberately a shell command. `tokf raw <id>` composes:
+
+```sh
+tokf raw 87 | grep -n 'error\[' | head -20
+```
+
+A recovered entry can be enormous — a `cargo metadata` capture runs to hundreds of thousands of tokens — so being able to narrow it *before* it reaches the model matters. Output that arrives through a tool call lands in context whole, with no opportunity to filter it first. Piping also means the recovered text can itself be filtered by tokf.
+
+Prefer `tokf raw <id> | ...` over reading an entry whole.
+
+### Why the ID is decimal
+
+Decimal is the cheapest encoding, which is counterintuitive — a shorter string is not a smaller number of tokens. BPE tokenizers pack runs of digits (up to three per token) while mixed-case alphanumerics fragment. Measured against `cl100k`:
+
+| id | decimal | base36 | base62 |
+|---|---|---|---|
+| 142 | **1** | 2 | 2 |
+| 4821 | **2** | 2 | 2 |
+| 51234 | **2** | 3 | **2** |
+| 998877 | **2** | 2 | 3 |
+
+Decimal is never worse and sometimes better, so the ID is printed as-is.
 
 ## Context injection
 
-During `tokf hook install`, tokf creates a `.claude/TOKF.md` file and adds an `@TOKF.md` reference to `.claude/CLAUDE.md`. This gives LLMs a two-line context explaining what `🗜️` means and how to retrieve full output (`tokf raw last`). Use `--no-context` to skip this step.
+During `tokf hook install`, tokf creates a `.claude/TOKF.md` file and adds an `@TOKF.md` reference to `.claude/CLAUDE.md`. This gives LLMs a short context explaining what `🗜️` and `🗜️#<id>` mean and how to retrieve full output (`tokf raw <id>`, or `tokf raw last`). Use `--no-context` to skip this step.


### PR DESCRIPTION
## Summary

Annotates filtered output with its history entry ID so recovery is **addressable** rather than guessable:

```
🗜️#87 ✓ cargo test: 42 passed
```

`🗜️#87` means the full, unfiltered output is one command away — `tokf raw 87`.

Closes #420.

## Scope change from the first revision

This PR originally also added an MCP server exposing a `resolve` tool. **That half has been dropped** on maintainer review, and the reasoning is worth recording because it inverts the issue's original premise.

**An MCP tool result cannot be post-processed; CLI output can.** `tokf raw <id>` composes with the shell:

```sh
tokf raw 87 | grep -n 'error\[' | head -20
```

A tool result lands in context whole. A recovered entry can be enormous — a `cargo metadata` capture runs to hundreds of thousands of tokens — so recovering one through a tool call could blow the context window with no chance to narrow it first. That makes MCP not merely redundant with the CLI but *strictly worse* for the case recovery exists to serve. It also routes around tokf itself: `tokf raw` output can be filtered by tokf; MCP output cannot.

The issue's original framing — "the model can fetch it itself rather than a human running `tokf raw last`" — was simply wrong. The model already has Bash and already runs tokf. The real gap was never reachability but **addressability**: `last` is ambiguous the moment two commands have run. The ID closes that completely, and the MCP server was paying real costs (a subcommand, a config key, setup-flow changes, a stranded-marker guard) for a problem that did not exist.

Removed relative to the previous revision: `tokf mcp` subcommand and resolve tool, `mcp.registered` config key, `RenderConfig`, setup-flow registration, `mcp status` drift detection, and `docs/mcp-recovery.md`. Net effect: **1277 lines of MCP implementation and ~650 lines of config plumbing are gone**; what remains is 175 insertions across 7 files.

## What's in it

Three independently reviewable commits:

1. **`refactor(cli)`** — extract history/raw dispatch out of `main.rs`. No behaviour change.
2. **`fix(history)`** — `prune_old_entries` no longer deletes the row `try_record` just inserted. With `history.retention = 0` the insert and prune raced in the same call: the ID came back but the row did not survive, so any recovery pointer referenced a deleted entry. Real bug, independent of the marker.
3. **`feat(output)`** — the marker itself.

**Additive by construction.** The filtered body is byte-identical to before; the ID rides an indicator that was already printed. No extra line, no extra newline, ~3 tokens. Disabling `output.show_indicator` removes the marker too — the ID is not smuggled back in on its own line. With no history entry, output falls back to plain `🗜️`, so a marker can never point at nothing.

Both `TOKF.md` templates — this repo's and the one `tokf hook install` ships to users — explain the marker and steer toward piping rather than reading an entry whole.

## Why the ID is decimal

A denser encoding was proposed and measured against `cl100k`. It does not help: BPE packs digit runs (up to three per token) while mixed-case alphanumerics fragment.

| id | decimal | base36 | base62 |
|---|---|---|---|
| 142 | **1** | 2 | 2 |
| 4821 | **2** | 2 | 2 |
| 51234 | **2** | 3 | **2** |
| 998877 | **2** | 2 | 3 |

Decimal is never worse and sometimes better, so the ID is printed as-is. `4821` and `1Fl` both cost 2 tokens despite `1Fl` being 25% shorter in characters. (Caveat: cl100k is not Claude's tokenizer, but digit-run packing is common to this BPE family.)

Incidentally, `🗜️` itself costs 4 tokens — more than the ID being added. If marker cost is ever worth optimising, that is the line item, not the encoding.

## Testing

`cargo fmt --all` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace` → 57 suites, **2308 passed, 0 failed**.

Unit tests cover marker rendering: indicator disabled emits nothing (with or without an ID), no ID falls back to plain `🗜️`, an ID renders `🗜️#42 `, and `i64::MAX` formats without panic. The prune fix has a regression test asserting the just-created row survives `retention = 0`.

## Follow-up

The `show_hint` line (`🗜️ compressed — run tokf raw <id> for full output`) still exists and is now arguably redundant with the marker. Left alone deliberately — removing it is a separate behaviour decision, not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7fCGepMs4wjMoobLE3wKN
