### PR TITLE
feat(tracking): verify and recalibrate the bytes/4 token estimator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Clippy (otel-grpc feature)
         run: cargo clippy -p tokf --features otel-grpc -- -D warnings
 
+      - name: Clippy (tokenizer feature)
+        run: |
+          cargo clippy -p tokf-common --features tokenizer --all-targets -- -D warnings
+          cargo clippy -p tokf --features tokenizer --all-targets -- -D warnings
+
       - name: Check file sizes
         run: bash scripts/check-file-sizes.sh
 
@@ -80,6 +85,16 @@ jobs:
 
       - name: Run tests (otel-grpc feature)
         run: cargo nextest run -p tokf --features otel-grpc --profile ci
+
+      # The tokenizer feature is calibration-only and off by default. Without
+      # these steps none of it is ever compiled or run and the divisor
+      # silently rots. The calibration harness is #[ignore]d, so run it
+      # explicitly — it needs no database and fails if the divisor drifts.
+      - name: Run tests (tokenizer feature)
+        run: cargo nextest run -p tokf-common -p tokf --features tokenizer --profile ci
+
+      - name: Token estimator calibration
+        run: cargo test -p tokf --features tokenizer --test calibration -- --ignored --nocapture
 
       - name: Verify filter test suites
         id: verify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,20 @@ See `docs/lua-escape-hatch.md` for the full API, globals, and examples.
 
 ---
 
+## Token estimator calibration
+
+tokf estimates tokens from byte counts (see `crates/tokf-common/src/tokens.rs`). An optional
+`tokenizer` cargo feature adds a real cl100k counter so that constant can be verified:
+
+```sh
+cargo test -p tokf --features tokenizer --test calibration -- --ignored --nocapture
+```
+
+The feature is **off by default and must stay that way**. It is for calibration only — nothing in
+the runtime path may use it. In particular, never add `features = ["tokenizer"]` to any workspace
+member's `tokf-common` dependency: cargo feature unification is additive, so one such entry would
+drag the tokenizer's vocabulary build into every default build.
+
 ## Database & end-to-end tests
 
 `tokf-server` uses CockroachDB. The DB integration tests and end-to-end tests are `#[ignore]`d by default — they only run when `DATABASE_URL` is set and you pass `--ignored`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +42,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "aneubeck-daachorse"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a902604543851c9ccc59d6252eb77502a9e01d6bf7205dd2ab4b543bd22cbda3"
 
 [[package]]
 name = "anstream"
@@ -73,7 +85,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -84,7 +96,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -740,6 +752,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "bpe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f0f0ef446ddbb042aac62a2da0b680e116b6cb2b1f79c20eda2a9107611408"
+dependencies = [
+ "aneubeck-daachorse",
+ "base64",
+ "fnv",
+ "itertools",
+ "serde",
+]
+
+[[package]]
+name = "bpe-openai"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25deec0a72cf5d8b66a6e487c5ee9757b0639f3e16d687f6c6dea834812000c"
+dependencies = [
+ "base64",
+ "bpe",
+ "either",
+ "flate2",
+ "regex-automata",
+ "rmp-serde",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,7 +995,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1171,7 +1212,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1281,7 +1322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1348,6 +1389,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -2275,6 +2326,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2394,7 +2455,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3090,6 +3151,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,7 +3219,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3197,7 +3277,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3528,6 +3608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3571,7 +3657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3849,10 +3935,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3992,6 +4078,7 @@ dependencies = [
 name = "tokf-common"
 version = "0.2.50"
 dependencies = [
+ "bpe-openai",
  "regex",
  "serde",
  "serde_json",
@@ -4386,7 +4473,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4642,7 +4729,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1223,6 +1223,76 @@ tokf gain --by-filter  # breakdown by filter
 tokf gain --json       # machine-readable output
 ```
 
+## How tokens are estimated
+
+tokf does not run a tokenizer. Token counts are derived from byte counts with one constant:
+
+```
+tokens ≈ bytes / 3.5
+```
+
+That is why every token figure `tokf gain` prints is labelled **`est.`**, and why it will keep being labelled that way for as long as this estimator ships. It is a heuristic, not a measurement.
+
+### Where 3.5 comes from
+
+The constant used to be `4`, and nothing had ever checked it. It was measured against a real cl100k tokenizer across the whole tokf corpus — every filter `_test/` case (both the raw input and the filtered output) plus every fixture under `tests/fixtures/` — which gives the *implied* divisor, i.e. bytes per real token:
+
+| corpus | implied divisor |
+|---|---|
+| raw command output | 3.67 |
+| filtered output | 2.98 |
+| combined (byte-weighted) | 3.53 |
+| spread across items | p10 2.72 · median 3.39 · p90 4.62 |
+
+`3.5` is the combined figure rounded. The old `4` undercounted real cl100k tokens by roughly 8% on raw output and 25% on filtered output; `3.5` lands within 1% of the corpus aggregate.
+
+Two honest caveats:
+
+- **cl100k is not Claude's tokenizer.** Even the "real" numbers we calibrated against are an approximation of the thing users actually care about. The goal was removing a large systematic bias, not achieving exactness.
+- **The corpus is what it is** — heavily weighted toward `cargo`, `git`, `npm` and `docker` output. The p10/p90 spread above shows the per-item divisor genuinely ranges from under 2.8 to over 4.6 depending on output shape: prose is cheap per byte to tokenize, dense symbolic output is expensive. One constant cannot capture that, and tokf deliberately does not try. It says `est.` instead.
+
+### Percentages are more reliable than absolute counts — except when filters rewrite
+
+The savings *percentage* divides two counts that share the divisor, so most of the error cancels out. That holds well for filters that mostly **delete** lines:
+
+| case | est. reduction | real reduction | error |
+|---|---|---|---|
+| `cargo/check` (successful check collapses) | 84.4% | 84.6% | −0.2 pt |
+| `cargo/clippy` (grouped by lint rule) | 78.5% | 78.2% | +0.3 pt |
+| `cargo/build` (failure output) | 23.3% | 24.2% | −0.9 pt |
+
+It stops holding for filters that **rewrite** content — replacing English prose with a dense symbolic summary. Prose tokenizes cheaply per byte; the summary does not, so the byte ratio overstates the token ratio and the filter flatters itself:
+
+| case | est. reduction | real reduction | error |
+|---|---|---|---|
+| `docker/ps` (no running containers → zero count) | 0.0% | −300.0% | +300 pt |
+| `git/push` (up-to-date → friendly message) | 33.3% | −50.0% | +83 pt |
+| `git/status` (clean repo → branch marker) | 50.0% | 0.0% | +50 pt |
+
+Those are worst cases on tiny outputs, where a handful of tokens swings the percentage wildly — but the direction of the bias is consistent, and it is upward. **Treat reduction percentages on rewriting filters as indicative, not as a claim.**
+
+### Verifying the estimate yourself
+
+The tokenizer is a contributor tool, not a runtime feature. It sits behind an optional cargo feature that is **off by default**, so normal builds take no tokenizer dependency at all:
+
+```sh
+cargo test -p tokf --features tokenizer --test calibration -- --ignored --nocapture
+```
+
+That prints the full per-item table and the aggregates above, and fails if the shipped constant drifts more than 25% from what the corpus implies. There is no way to enable a real tokenizer at runtime, and no plan to add one — carrying a vocabulary table in the shipping binary to serve a statistic is not a trade tokf wants to make.
+
+### Estimates changed: a deliberate discontinuity
+
+Changing the divisor changes the numbers. Being explicit about what that means:
+
+- Rows recorded **before** the change keep their old `bytes / 4` token counts. They are not rewritten.
+- Rows recorded **after** use `bytes / 3.5`.
+- `tokf gain` totals spanning the changeover therefore show a **step increase in absolute token counts**. Nothing is being saved differently; the estimate simply got less wrong.
+- Savings **percentages** are essentially unaffected, because both sides of the ratio scale together. That is the reason the discontinuity is tolerable.
+- The same applies to server-side aggregates, which receive already-computed token columns via sync.
+
+We deliberately did **not**: version the estimator in the SQLite schema (real surface area across three crates for a statistic), rewrite historical rows (local history would then diverge from already-synced server rows — worse than one honest step), or recompute tokens at read time (touches every aggregate query and still cannot fix the server side). One documented step change beat all three.
+
 ## Remote gain
 
 View aggregate savings across all your registered machines via the tokf server:
@@ -2529,6 +2599,8 @@ Total unfiltered output: 28.1k tokens across 443 commands
 4. Matches remaining commands against available tokf filters
 5. By default shows only commands with no matching filter
 6. Aggregates and ranks by estimated token count
+
+Token counts are estimates derived from byte counts, not tokenizer output — see [How tokens are estimated](#how-tokens-are-estimated) under Token Savings Tracking for the constant, its measured accuracy, and its limits.
 
 ---
 

--- a/crates/e2e-tests/tests/auth_flow.rs
+++ b/crates/e2e-tests/tests/auth_flow.rs
@@ -6,6 +6,8 @@
 
 mod harness;
 
+use tokf_common::tokens::estimate_tokens_from_bytes;
+
 use tokf::auth::client::{self, PollResult};
 use tokf::remote::client as machine_client;
 use tokf::remote::http::Client;
@@ -152,6 +154,8 @@ async fn auth_then_register_machine_then_sync(pool: PgPool) {
     let gain = h.blocking_gain_with_token(&token).await;
 
     assert_eq!(gain.total_commands, 2);
-    assert_eq!(gain.total_input_tokens, 3000); // 1000 + 2000
-    assert_eq!(gain.total_output_tokens, 350); // 100 + 250
+    // Token counts derive from the shared estimator, never hardcoded.
+    let est = |b: usize| i64::try_from(estimate_tokens_from_bytes(b)).unwrap();
+    assert_eq!(gain.total_input_tokens, est(4000) + est(8000));
+    assert_eq!(gain.total_output_tokens, est(400) + est(1000));
 }

--- a/crates/e2e-tests/tests/gain_flow.rs
+++ b/crates/e2e-tests/tests/gain_flow.rs
@@ -6,11 +6,14 @@
 
 mod harness;
 
+use tokf_common::tokens::estimate_tokens_from_bytes;
+
 /// Record two standard events and sync them to the server.
 /// Returns `(input_tokens_total, output_tokens_total)` for assertion reference.
 async fn seed_two_events(h: &harness::TestHarness) -> (i64, i64) {
     let conn = h.open_tracking_db();
-    // git/status: 4000 bytes → 1000 tokens in, 400 bytes → 100 tokens out
+    // git/status: 4000 bytes in, 400 bytes out; token counts come from the
+    // shared estimator (tokf_common::tokens), never hardcoded.
     h.record_event(
         &conn,
         "git status",
@@ -19,7 +22,7 @@ async fn seed_two_events(h: &harness::TestHarness) -> (i64, i64) {
         4000,
         400,
     );
-    // cargo/test: 8000 bytes → 2000 tokens in, 1000 bytes → 250 tokens out
+    // cargo/test: 8000 bytes in, 1000 bytes out.
     h.record_event(
         &conn,
         "cargo test",
@@ -30,7 +33,8 @@ async fn seed_two_events(h: &harness::TestHarness) -> (i64, i64) {
     );
     let req = h.build_sync_request(&conn);
     h.blocking_sync_request(&req).await;
-    (3000, 350)
+    let est = |b: usize| i64::try_from(estimate_tokens_from_bytes(b)).unwrap();
+    (est(4000) + est(8000), est(400) + est(1000))
 }
 
 /// Fresh user with no events → GET /api/gain → all zeros.
@@ -159,7 +163,10 @@ async fn gain_raw_tokens_propagated(pool: PgPool) {
     let gain = h.blocking_gain().await;
 
     assert_eq!(gain.total_commands, 1);
-    assert_eq!(gain.total_input_tokens, 1000); // 4000 bytes ≈ 1000 tokens (÷4)
+    assert_eq!(
+        gain.total_input_tokens,
+        i64::try_from(estimate_tokens_from_bytes(4000)).unwrap()
+    );
     assert!(
         gain.total_raw_tokens > gain.total_input_tokens,
         "total_raw_tokens ({}) should be > total_input_tokens ({}) when baseline adjustment occurred",

--- a/crates/e2e-tests/tests/sync_flow.rs
+++ b/crates/e2e-tests/tests/sync_flow.rs
@@ -7,6 +7,7 @@
 mod harness;
 
 use tokf::tracking;
+use tokf_common::tokens::estimate_tokens_from_bytes;
 
 /// Record 3 events → build sync request → POST /api/sync → assert accepted count & cursor.
 #[crdb_test_macro::crdb_test(migrations = "../tokf-server/migrations")]
@@ -55,7 +56,8 @@ async fn sync_then_gain_reflects_totals(pool: PgPool) {
     let h = harness::TestHarness::new(pool).await;
     let conn = h.open_tracking_db();
 
-    // input_bytes=4000 → input_tokens=1000, output_bytes=400 → output_tokens=100
+    // input_bytes=4000, output_bytes=400; token estimates derive from the
+    // shared estimator (tokf_common::tokens).
     h.record_event(
         &conn,
         "git status",
@@ -64,7 +66,6 @@ async fn sync_then_gain_reflects_totals(pool: PgPool) {
         4000,
         400,
     );
-    // input_bytes=8000 → input_tokens=2000, output_bytes=1000 → output_tokens=250
     h.record_event(
         &conn,
         "git push",
@@ -79,8 +80,10 @@ async fn sync_then_gain_reflects_totals(pool: PgPool) {
 
     let gain = h.blocking_gain().await;
 
-    assert_eq!(gain.total_input_tokens, 3000); // 1000 + 2000
-    assert_eq!(gain.total_output_tokens, 350); // 100 + 250
+    // Token counts derive from the shared estimator, never hardcoded.
+    let est = |b: usize| i64::try_from(estimate_tokens_from_bytes(b)).unwrap();
+    assert_eq!(gain.total_input_tokens, est(4000) + est(8000));
+    assert_eq!(gain.total_output_tokens, est(400) + est(1000));
     assert_eq!(gain.total_commands, 2);
     assert!(!gain.by_filter.is_empty());
 }
@@ -143,7 +146,8 @@ async fn sync_multiple_batches_advances_cursor(pool: PgPool) {
     let gain = h.blocking_gain().await;
 
     assert_eq!(gain.total_commands, 3);
-    assert_eq!(gain.total_input_tokens, 6000); // 1000 + 2000 + 3000
+    let est = |b: usize| i64::try_from(estimate_tokens_from_bytes(b)).unwrap();
+    assert_eq!(gain.total_input_tokens, est(4000) + est(8000) + est(12000));
 }
 
 /// Sync with an invalid token → expect an error.
@@ -206,5 +210,8 @@ async fn sync_replay_is_idempotent(pool: PgPool) {
     // Gain should reflect exactly the original sync — no double-counting.
     let gain = h.blocking_gain().await;
     assert_eq!(gain.total_commands, 1);
-    assert_eq!(gain.total_input_tokens, 1000); // 4000 bytes / 4
+    assert_eq!(
+        gain.total_input_tokens,
+        i64::try_from(estimate_tokens_from_bytes(4000)).unwrap()
+    );
 }

--- a/crates/tokf-cli/Cargo.toml
+++ b/crates/tokf-cli/Cargo.toml
@@ -56,6 +56,8 @@ tonic             = { version = "0.14", optional = true, default-features = fals
 [features]
 default = []
 stdlib-publish = []
+# Calibration only — off by default, never enabled by another crate.
+tokenizer = ["tokf-common/tokenizer"]
 test-keyring = []
 otel = ["otel-http"]
 otel-http = [

--- a/crates/tokf-cli/src/discover/mod.rs
+++ b/crates/tokf-cli/src/discover/mod.rs
@@ -7,6 +7,7 @@ pub mod types;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use tokf_common::tokens::estimate_tokens_from_bytes;
 use types::{CommandAnalysis, DiscoverResult, DiscoverSummary, ExtractedCommand};
 
 use crate::config::{self, ResolvedFilter};
@@ -136,7 +137,7 @@ fn build_results(aggregated: HashMap<(String, String), AggBucket>) -> Vec<Discov
     let mut results: Vec<DiscoverResult> = aggregated
         .into_iter()
         .map(|((filter_name, command_pattern), bucket)| {
-            let estimated_tokens = bucket.total_output_bytes / 4;
+            let estimated_tokens = estimate_tokens_from_bytes(bucket.total_output_bytes);
             #[allow(
                 clippy::cast_possible_truncation,
                 clippy::cast_sign_loss,

--- a/crates/tokf-cli/src/discover/tests.rs
+++ b/crates/tokf-cli/src/discover/tests.rs
@@ -397,3 +397,25 @@ fn discover_sessions_counts_already_filtered() {
     assert_eq!(summary.already_filtered, 1);
     assert_eq!(summary.filterable_commands, 0);
 }
+
+/// `tokf discover`'s estimated token counts must come from the same shared
+/// estimator as `tokf gain` — this arithmetic used to be duplicated inline.
+#[test]
+fn build_results_uses_the_shared_token_estimator() {
+    let mut agg = HashMap::new();
+    agg.insert(
+        ("git/status".to_string(), "git status".to_string()),
+        AggBucket {
+            occurrences: 3,
+            total_output_bytes: 4000,
+            savings_pct: 50.0,
+            has_filter: true,
+        },
+    );
+    let results = build_results(agg);
+    assert_eq!(results.len(), 1);
+    assert_eq!(
+        results[0].estimated_tokens,
+        estimate_tokens_from_bytes(4000)
+    );
+}

--- a/crates/tokf-cli/src/discover/types.rs
+++ b/crates/tokf-cli/src/discover/types.rs
@@ -39,7 +39,7 @@ pub struct DiscoverResult {
     pub occurrences: usize,
     /// Total output bytes across all occurrences.
     pub total_output_bytes: usize,
-    /// Estimated tokens (`output_bytes / 4`).
+    /// Estimated tokens from output bytes (see `tokf_common::tokens`).
     pub estimated_tokens: usize,
     /// Estimated tokens that would be saved.
     pub estimated_savings: usize,

--- a/crates/tokf-cli/src/lib.rs
+++ b/crates/tokf-cli/src/lib.rs
@@ -13,6 +13,7 @@ pub mod rewrite;
 pub mod runner;
 pub mod setup;
 pub mod skill;
+pub mod suite_discovery;
 pub mod sync_core;
 pub mod telemetry;
 pub mod tracking;

--- a/crates/tokf-cli/src/suite_discovery.rs
+++ b/crates/tokf-cli/src/suite_discovery.rs
@@ -1,0 +1,148 @@
+//! Corpus discovery for filter `_test/` suites.
+//!
+//! Lives in the library crate (rather than inside the binary-only
+//! `verify_cmd` module) so integration tests — notably the token-estimator
+//! calibration harness — can walk the same corpora `tokf verify` does without
+//! duplicating a ~90-line directory walk.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+// --- All-filter coverage discovery (for --require-all) ---
+
+fn collect_all_filters(
+    root: &Path,
+    dir: &Path,
+    result: &mut Vec<(String, bool)>,
+    seen: &mut HashSet<String>,
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.filter_map(Result::ok).collect();
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+    for entry in &entries {
+        let path = entry.path();
+        let name_str = entry.file_name().to_string_lossy().to_string();
+        if name_str.starts_with('.') {
+            continue;
+        }
+        if path.is_file() && path.extension().is_some_and(|e| e == "toml") {
+            let stem = path.file_stem().unwrap_or_default().to_string_lossy();
+            let suite_dir = path.parent().unwrap_or(dir).join(format!("{stem}_test"));
+            let filter_name = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .with_extension("")
+                .to_string_lossy()
+                .into_owned();
+            #[cfg(windows)]
+            let filter_name = filter_name.replace('\\', "/");
+            if seen.insert(filter_name.clone()) {
+                result.push((filter_name, suite_dir.is_dir()));
+            }
+        } else if path.is_dir() && !name_str.ends_with("_test") {
+            collect_all_filters(root, &path, result, seen);
+        }
+    }
+}
+
+pub fn discover_all_filters_with_coverage(
+    search_dirs: &[PathBuf],
+    prefix: Option<&str>,
+) -> Vec<(String, bool)> {
+    let mut result = Vec::new();
+    let mut seen = HashSet::new();
+    for dir in search_dirs {
+        if !dir.exists() {
+            continue;
+        }
+        collect_all_filters(dir, dir, &mut result, &mut seen);
+    }
+    if let Some(pfx) = prefix {
+        result.retain(|(name, _)| name == pfx || name.starts_with(&format!("{pfx}/")));
+    }
+    result
+}
+
+// --- Suite discovery ---
+
+/// A discovered suite: filter TOML path, suite directory, and filter name.
+pub struct DiscoveredSuite {
+    pub filter_path: PathBuf,
+    pub suite_dir: PathBuf,
+    pub filter_name: String,
+}
+
+pub fn discover_suites(search_dirs: &[PathBuf], filter_arg: Option<&str>) -> Vec<DiscoveredSuite> {
+    let mut result = Vec::new();
+
+    for dir in search_dirs {
+        if !dir.exists() {
+            continue;
+        }
+        collect_suites(dir, dir, &mut result);
+    }
+
+    // Remove duplicates: prefer first occurrence (higher priority dir).
+    // HashSet tracks seen names; retain() preserves insertion order.
+    let mut seen = HashSet::new();
+    result.retain(|s| seen.insert(s.filter_name.clone()));
+
+    if let Some(name) = filter_arg {
+        result.retain(|s| s.filter_name == name);
+    }
+
+    result
+}
+
+fn collect_suites(root: &Path, dir: &Path, result: &mut Vec<DiscoveredSuite>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    let mut entries: Vec<_> = entries.filter_map(Result::ok).collect();
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    for entry in &entries {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        if name_str.starts_with('.') {
+            continue;
+        }
+
+        if path.is_file() && path.extension().is_some_and(|e| e == "toml") {
+            let stem = path
+                .file_stem()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            // Suite directories use the convention <stem>_test/ adjacent to <stem>.toml.
+            let suite_dir = path.parent().unwrap_or(dir).join(format!("{stem}_test"));
+            if suite_dir.is_dir() {
+                let filter_name = path
+                    .strip_prefix(root)
+                    .unwrap_or(&path)
+                    .with_extension("")
+                    .to_string_lossy()
+                    .into_owned();
+                // Normalize path separators on Windows so filter names are always "foo/bar".
+                #[cfg(windows)]
+                let filter_name = filter_name.replace('\\', "/");
+                result.push(DiscoveredSuite {
+                    filter_path: path,
+                    suite_dir,
+                    filter_name,
+                });
+            }
+        } else if path.is_dir() {
+            // Skip _test directories — they are suite dirs, not filter category dirs.
+            if name_str.ends_with("_test") {
+                continue;
+            }
+            collect_suites(root, &path, result);
+        }
+    }
+}

--- a/crates/tokf-cli/src/telemetry/mod.rs
+++ b/crates/tokf-cli/src/telemetry/mod.rs
@@ -10,6 +10,8 @@
 
 pub mod config;
 
+use tokf_common::tokens::estimate_tokens_from_bytes;
+
 #[cfg(any(feature = "otel", feature = "otel-grpc", feature = "otel-http"))]
 mod otel;
 
@@ -23,11 +25,11 @@ pub struct TelemetryEvent {
     pub input_lines: u64,
     /// Line count after filtering.
     pub output_lines: u64,
-    /// Estimated input tokens (bytes / 4).
+    /// Estimated input tokens (see `tokf_common::tokens`).
     pub input_tokens: u64,
-    /// Estimated output tokens (bytes / 4).
+    /// Estimated output tokens (see `tokf_common::tokens`).
     pub output_tokens: u64,
-    /// Estimated raw tokens before baseline adjustment (`raw_bytes / 4`).
+    /// Estimated raw tokens before baseline adjustment (see `tokf_common::tokens`).
     pub raw_tokens: u64,
     /// Wall-clock time spent in the filter pipeline (seconds).
     pub filter_duration_secs: f64,
@@ -40,7 +42,7 @@ pub struct TelemetryEvent {
 impl TelemetryEvent {
     /// Build a `TelemetryEvent` from raw execution data.
     ///
-    /// Centralizes the `bytes / 4` token estimation, `.lines().count()`, and
+    /// Centralizes the token estimation (`tokf_common::tokens`), `.lines().count()`, and
     /// `TOKF_OTEL_PIPELINE` env-var read so callers don't duplicate these.
     #[allow(
         clippy::cast_possible_truncation,
@@ -63,9 +65,9 @@ impl TelemetryEvent {
             command,
             input_lines: raw_output.lines().count() as u64,
             output_lines: filtered_output.lines().count() as u64,
-            input_tokens: (input_bytes / 4) as u64,
-            output_tokens: (output_bytes / 4) as u64,
-            raw_tokens: (raw_bytes / 4) as u64,
+            input_tokens: estimate_tokens_from_bytes(input_bytes) as u64,
+            output_tokens: estimate_tokens_from_bytes(output_bytes) as u64,
+            raw_tokens: estimate_tokens_from_bytes(raw_bytes) as u64,
             filter_duration_secs: filter_duration.as_secs_f64(),
             exit_code,
             pipeline: std::env::var("TOKF_OTEL_PIPELINE").ok(),
@@ -203,8 +205,8 @@ mod tests {
         );
         assert_eq!(event.input_lines, 3);
         assert_eq!(event.output_lines, 1);
-        assert_eq!(event.input_tokens, 100); // 400 / 4
-        assert_eq!(event.output_tokens, 25); // 100 / 4
+        assert_eq!(event.input_tokens, estimate_tokens_from_bytes(400) as u64);
+        assert_eq!(event.output_tokens, estimate_tokens_from_bytes(100) as u64);
         assert!((event.filter_duration_secs - 0.005).abs() < 0.001);
         assert_eq!(event.exit_code, 0);
         assert_eq!(event.filter_name, Some("cargo/build".to_string()));
@@ -239,5 +241,41 @@ mod tests {
         let reporter = init(true); // otel_export_requested=true, but feature not compiled in
         // endpoint_description() returns None for NoopReporter
         assert!(reporter.endpoint_description().is_none());
+    }
+
+    /// Anti-divergence net: `TelemetryEvent::new` and `tracking::build_event`
+    /// must report identical token counts for identical byte counts. These
+    /// were independently duplicated `bytes / 4` expressions once; they now
+    /// share `tokf_common::tokens`, and this test keeps them sharing it.
+    #[test]
+    fn telemetry_and_tracking_agree_on_token_estimates() {
+        for (i, o, r) in [
+            (0, 0, 0),
+            (1, 1, 1),
+            (400, 100, 400),
+            (98_765, 4_321, 98_765),
+        ] {
+            let ev = TelemetryEvent::new(
+                None,
+                "cmd".to_string(),
+                i,
+                o,
+                r,
+                "",
+                "",
+                std::time::Duration::ZERO,
+                0,
+            );
+            let tr = crate::tracking::build_event("cmd", None, None, i, o, r, 0, 0, false);
+            assert_eq!(
+                i64::try_from(ev.input_tokens).ok(),
+                Some(tr.input_tokens_est)
+            );
+            assert_eq!(
+                i64::try_from(ev.output_tokens).ok(),
+                Some(tr.output_tokens_est)
+            );
+            assert_eq!(i64::try_from(ev.raw_tokens).ok(), Some(tr.raw_tokens_est));
+        }
     }
 }

--- a/crates/tokf-cli/src/tracking/mod.rs
+++ b/crates/tokf-cli/src/tracking/mod.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context as _;
 use rusqlite::{Connection, OptionalExtension as _};
 
+use tokf_common::tokens::estimate_tokens_from_bytes;
 pub use tokf_common::tracking::types::{DailyGain, FilterGain, GainSummary, TrackingEvent};
 
 /// Returns the DB path: `TOKF_DB_PATH` env var overrides; else
@@ -156,11 +157,11 @@ pub fn build_event(
     pipe_override: bool,
 ) -> TrackingEvent {
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    let input_tokens_est = (input_bytes / 4) as i64;
+    let input_tokens_est = estimate_tokens_from_bytes(input_bytes) as i64;
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    let output_tokens_est = (output_bytes / 4) as i64;
+    let output_tokens_est = estimate_tokens_from_bytes(output_bytes) as i64;
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    let raw_tokens_est = (raw_bytes / 4) as i64;
+    let raw_tokens_est = estimate_tokens_from_bytes(raw_bytes) as i64;
     #[allow(clippy::cast_possible_truncation)]
     let filter_time_ms_i64 = filter_time_ms.min(i64::MAX as u128) as i64;
     TrackingEvent {

--- a/crates/tokf-cli/src/tracking/tests.rs
+++ b/crates/tokf-cli/src/tracking/tests.rs
@@ -3,6 +3,13 @@
 use super::*;
 use serial_test::serial;
 use tempfile::TempDir;
+use tokf_common::tokens::estimate_tokens_from_bytes;
+
+/// Shared estimator as `i64`, so assertions never hardcode the divisor.
+#[allow(clippy::cast_possible_wrap)]
+fn est_i64(bytes: usize) -> i64 {
+    estimate_tokens_from_bytes(bytes) as i64
+}
 
 fn temp_db() -> (TempDir, Connection) {
     let dir = TempDir::new().expect("tempdir");
@@ -127,8 +134,8 @@ fn record_event_all_fields_persisted() {
     assert_eq!(fname.as_deref(), Some("git status"));
     assert_eq!(ib, 400);
     assert_eq!(ob, 200);
-    assert_eq!(it, 100); // 400 / 4
-    assert_eq!(ot, 50); // 200 / 4
+    assert_eq!(it, est_i64(400));
+    assert_eq!(ot, est_i64(200));
     assert_eq!(ft, 10);
     assert_eq!(ec, 0);
 }
@@ -179,10 +186,14 @@ fn record_event_timestamp_iso8601() {
 
 #[test]
 fn build_event_token_estimation() {
+    // Assert against the shared estimator, never a literal: the divisor is a
+    // calibrated constant and these tests must survive recalibrating it.
     let ev = build_event("x", None, None, 400, 0, 400, 0, 0, false);
-    assert_eq!(ev.input_tokens_est, 100);
+    assert_eq!(ev.input_tokens_est, est_i64(400));
     let ev2 = build_event("x", None, None, 399, 0, 399, 0, 0, false);
-    assert_eq!(ev2.input_tokens_est, 99);
+    assert_eq!(ev2.input_tokens_est, est_i64(399));
+    // Truncating, so a slightly smaller input never estimates more tokens.
+    assert!(ev2.input_tokens_est <= ev.input_tokens_est);
 }
 
 #[test]
@@ -208,15 +219,16 @@ fn query_summary_empty_db() {
 #[test]
 fn query_summary_with_events() {
     let (_dir, conn) = temp_db();
-    // input_tokens 100, output_tokens 25 → saved 75
     let ev = build_event("cmd", Some("f"), None, 400, 100, 400, 5, 0, false);
     record_event(&conn, &ev).expect("record");
     let s = query_summary(&conn).expect("summary");
     assert_eq!(s.total_commands, 1);
-    assert_eq!(s.total_input_tokens, 100);
-    assert_eq!(s.total_output_tokens, 25);
-    assert_eq!(s.tokens_saved, 75);
-    assert!((s.savings_pct - 75.0).abs() < 0.01);
+    assert_eq!(s.total_input_tokens, est_i64(400));
+    assert_eq!(s.total_output_tokens, est_i64(100));
+    assert_eq!(s.tokens_saved, est_i64(400) - est_i64(100));
+    // 400 -> 100 bytes is a 75% reduction; the ratio is divisor-independent
+    // up to truncation, which is why percentages barely move when it changes.
+    assert!((s.savings_pct - 75.0).abs() < 1.0);
 }
 
 #[test]
@@ -246,10 +258,12 @@ fn query_summary_accumulates_multiple_events() {
     }
     let s = query_summary(&conn).expect("summary");
     assert_eq!(s.total_commands, 3);
-    assert_eq!(s.total_input_tokens, 600); // (400+800+1200)/4
-    assert_eq!(s.total_output_tokens, 125); // (100+400+0)/4
-    assert_eq!(s.tokens_saved, 475); // 600-125
-    assert!((s.savings_pct - 79.166_666).abs() < 0.01);
+    let inp = est_i64(400) + est_i64(800) + est_i64(1200);
+    let out = est_i64(100) + est_i64(400) + est_i64(0);
+    assert_eq!(s.total_input_tokens, inp);
+    assert_eq!(s.total_output_tokens, out);
+    assert_eq!(s.tokens_saved, inp - out);
+    assert!((s.savings_pct - 79.166_666).abs() < 1.0);
 }
 
 // --- query_by_filter ---

--- a/crates/tokf-cli/src/tracking/tests_raw_bytes.rs
+++ b/crates/tokf-cli/src/tracking/tests_raw_bytes.rs
@@ -2,6 +2,13 @@
 
 use super::*;
 use tempfile::TempDir;
+use tokf_common::tokens::estimate_tokens_from_bytes;
+
+/// Shared estimator as `i64`, so assertions never hardcode the divisor.
+#[allow(clippy::cast_possible_wrap)]
+fn est_i64(bytes: usize) -> i64 {
+    estimate_tokens_from_bytes(bytes) as i64
+}
 
 fn temp_db() -> (TempDir, Connection) {
     let dir = TempDir::new().expect("tempdir");
@@ -22,21 +29,33 @@ fn record_event_raw_bytes_persisted() {
         })
         .expect("select");
     assert_eq!(rb, 400, "raw_bytes should be persisted");
-    assert_eq!(rt, 100, "raw_tokens_est should be raw_bytes / 4");
+    assert_eq!(
+        rt,
+        est_i64(400),
+        "raw_tokens_est should be the shared byte estimate of raw_bytes"
+    );
 }
 
 #[test]
 fn query_summary_includes_raw_tokens() {
     let (_dir, conn) = temp_db();
-    // ev1: input=200B (50 tokens), raw=400B (100 tokens)
-    // ev2: input=800B (200 tokens), raw=1200B (300 tokens)
+    // Token counts are derived from bytes via the shared estimator; assert
+    // against it rather than literals so the divisor can be recalibrated.
     let ev1 = build_event("cmd1", Some("f"), None, 200, 50, 400, 5, 0, false);
     let ev2 = build_event("cmd2", Some("f"), None, 800, 100, 1200, 5, 0, false);
     record_event(&conn, &ev1).expect("record");
     record_event(&conn, &ev2).expect("record");
     let s = query_summary(&conn).expect("summary");
-    assert_eq!(s.total_raw_tokens, 400, "total_raw_tokens: 100 + 300");
-    assert_eq!(s.total_input_tokens, 250, "total_input_tokens: 50 + 200");
+    assert_eq!(
+        s.total_raw_tokens,
+        est_i64(400) + est_i64(1200),
+        "total_raw_tokens sums the per-event raw estimates"
+    );
+    assert_eq!(
+        s.total_input_tokens,
+        est_i64(200) + est_i64(800),
+        "total_input_tokens sums the per-event input estimates"
+    );
 }
 
 #[test]

--- a/crates/tokf-cli/src/verify_cmd/discovery.rs
+++ b/crates/tokf-cli/src/verify_cmd/discovery.rs
@@ -1,62 +1,13 @@
-use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+//! Verify-specific search-dir resolution.
+//!
+//! The reusable corpus walker lives in [`tokf::suite_discovery`]; this module
+//! keeps only the parts that depend on verify's own CLI types.
 
-// --- All-filter coverage discovery (for --require-all) ---
+use std::path::PathBuf;
 
-pub(super) fn collect_all_filters(
-    root: &Path,
-    dir: &Path,
-    result: &mut Vec<(String, bool)>,
-    seen: &mut HashSet<String>,
-) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    let mut entries: Vec<_> = entries.filter_map(Result::ok).collect();
-    entries.sort_by_key(std::fs::DirEntry::file_name);
-    for entry in &entries {
-        let path = entry.path();
-        let name_str = entry.file_name().to_string_lossy().to_string();
-        if name_str.starts_with('.') {
-            continue;
-        }
-        if path.is_file() && path.extension().is_some_and(|e| e == "toml") {
-            let stem = path.file_stem().unwrap_or_default().to_string_lossy();
-            let suite_dir = path.parent().unwrap_or(dir).join(format!("{stem}_test"));
-            let filter_name = path
-                .strip_prefix(root)
-                .unwrap_or(&path)
-                .with_extension("")
-                .to_string_lossy()
-                .into_owned();
-            #[cfg(windows)]
-            let filter_name = filter_name.replace('\\', "/");
-            if seen.insert(filter_name.clone()) {
-                result.push((filter_name, suite_dir.is_dir()));
-            }
-        } else if path.is_dir() && !name_str.ends_with("_test") {
-            collect_all_filters(root, &path, result, seen);
-        }
-    }
-}
-
-pub(super) fn discover_all_filters_with_coverage(
-    search_dirs: &[PathBuf],
-    prefix: Option<&str>,
-) -> Vec<(String, bool)> {
-    let mut result = Vec::new();
-    let mut seen = HashSet::new();
-    for dir in search_dirs {
-        if !dir.exists() {
-            continue;
-        }
-        collect_all_filters(dir, dir, &mut result, &mut seen);
-    }
-    if let Some(pfx) = prefix {
-        result.retain(|(name, _)| name == pfx || name.starts_with(&format!("{pfx}/")));
-    }
-    result
-}
+pub(super) use tokf::suite_discovery::{
+    DiscoveredSuite, discover_all_filters_with_coverage, discover_suites,
+};
 
 // --- Search dirs for verify ---
 
@@ -101,91 +52,6 @@ pub(super) fn verify_search_dirs(scope: Option<&super::VerifyScope>) -> Vec<Path
                 dirs.push(user.join("filters"));
             }
             dirs
-        }
-    }
-}
-
-// --- Suite discovery ---
-
-/// A discovered suite: filter TOML path, suite directory, and filter name.
-pub(super) struct DiscoveredSuite {
-    pub filter_path: PathBuf,
-    pub suite_dir: PathBuf,
-    pub filter_name: String,
-}
-
-pub(super) fn discover_suites(
-    search_dirs: &[PathBuf],
-    filter_arg: Option<&str>,
-) -> Vec<DiscoveredSuite> {
-    let mut result = Vec::new();
-
-    for dir in search_dirs {
-        if !dir.exists() {
-            continue;
-        }
-        collect_suites(dir, dir, &mut result);
-    }
-
-    // Remove duplicates: prefer first occurrence (higher priority dir).
-    // HashSet tracks seen names; retain() preserves insertion order.
-    let mut seen = HashSet::new();
-    result.retain(|s| seen.insert(s.filter_name.clone()));
-
-    if let Some(name) = filter_arg {
-        result.retain(|s| s.filter_name == name);
-    }
-
-    result
-}
-
-fn collect_suites(root: &Path, dir: &Path, result: &mut Vec<DiscoveredSuite>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-
-    let mut entries: Vec<_> = entries.filter_map(Result::ok).collect();
-    entries.sort_by_key(std::fs::DirEntry::file_name);
-
-    for entry in &entries {
-        let path = entry.path();
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-
-        if name_str.starts_with('.') {
-            continue;
-        }
-
-        if path.is_file() && path.extension().is_some_and(|e| e == "toml") {
-            let stem = path
-                .file_stem()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string();
-            // Suite directories use the convention <stem>_test/ adjacent to <stem>.toml.
-            let suite_dir = path.parent().unwrap_or(dir).join(format!("{stem}_test"));
-            if suite_dir.is_dir() {
-                let filter_name = path
-                    .strip_prefix(root)
-                    .unwrap_or(&path)
-                    .with_extension("")
-                    .to_string_lossy()
-                    .into_owned();
-                // Normalize path separators on Windows so filter names are always "foo/bar".
-                #[cfg(windows)]
-                let filter_name = filter_name.replace('\\', "/");
-                result.push(DiscoveredSuite {
-                    filter_path: path,
-                    suite_dir,
-                    filter_name,
-                });
-            }
-        } else if path.is_dir() {
-            // Skip _test directories — they are suite dirs, not filter category dirs.
-            if name_str.ends_with("_test") {
-                continue;
-            }
-            collect_suites(root, &path, result);
         }
     }
 }

--- a/crates/tokf-cli/tests/calibration.rs
+++ b/crates/tokf-cli/tests/calibration.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 
 use tokf::runner::CommandResult;
 use tokf::suite_discovery::discover_suites;
+use tokf_common::examples::reduction_pct;
 use tokf_common::test_case::TestCase;
 use tokf_common::tokens::{
     ArithmeticTokenCounter, Cl100kTokenCounter, DIVISOR, TokenCounter, estimate_tokens,
@@ -237,13 +238,6 @@ fn spread(samples: &[&Sample]) -> (f64, f64, f64) {
         percentile(&d, 0.50),
         percentile(&d, 0.90),
     )
-}
-
-fn reduction_pct(before: usize, after: usize) -> f64 {
-    if before == 0 {
-        return 0.0;
-    }
-    (1.0 - after as f64 / before as f64) * 100.0
 }
 
 fn truncate(s: &str, n: usize) -> String {

--- a/crates/tokf-cli/tests/calibration.rs
+++ b/crates/tokf-cli/tests/calibration.rs
@@ -1,0 +1,387 @@
+//! Token-estimator calibration harness.
+//!
+//! Compares the shipping arithmetic estimator (`bytes / DIVISOR`) against a
+//! real cl100k tokenizer across the whole tokf corpus — every filter `_test/`
+//! case (raw *and* filtered) and every file under `tests/fixtures/` — and
+//! reports the implied divisor so the constant can be recalibrated and
+//! re-checked later.
+//!
+//! This is a diagnostic, not a user-facing feature: it deliberately adds no
+//! CLI surface. It only compiles under the optional, off-by-default
+//! `tokenizer` feature. Run it with:
+//!
+//! ```sh
+//! cargo test -p tokf --features tokenizer --test calibration -- --ignored --nocapture
+//! ```
+#![cfg(feature = "tokenizer")]
+#![allow(clippy::cast_precision_loss, clippy::unwrap_used)]
+
+use std::path::{Path, PathBuf};
+
+use tokf::runner::CommandResult;
+use tokf::suite_discovery::discover_suites;
+use tokf_common::test_case::TestCase;
+use tokf_common::tokens::{
+    ArithmeticTokenCounter, Cl100kTokenCounter, DIVISOR, TokenCounter, estimate_tokens,
+    estimate_tokens_from_bytes,
+};
+
+/// One measured string: its bytes, its real cl100k token count, and a label.
+struct Sample {
+    label: String,
+    bytes: usize,
+    real_tokens: usize,
+}
+
+impl Sample {
+    /// Returns `None` for empty input, which would make the implied divisor a
+    /// division by zero.
+    fn new(label: String, text: &str) -> Option<Self> {
+        if text.is_empty() {
+            return None;
+        }
+        let real_tokens = Cl100kTokenCounter.count(text);
+        if real_tokens == 0 {
+            return None;
+        }
+        Some(Self {
+            label,
+            bytes: text.len(),
+            real_tokens,
+        })
+    }
+
+    /// Bytes per real token for this sample.
+    fn implied_divisor(&self) -> f64 {
+        self.bytes as f64 / self.real_tokens as f64
+    }
+
+    /// Signed percentage error of the arithmetic estimate against the truth.
+    fn error_pct(&self) -> f64 {
+        let est = estimate_tokens_from_bytes(self.bytes) as f64;
+        (est - self.real_tokens as f64) / self.real_tokens as f64 * 100.0
+    }
+}
+
+/// A filter test case measured before and after filtering.
+struct Pair {
+    filter: String,
+    case: String,
+    raw: Sample,
+    filtered: Option<Sample>,
+}
+
+fn repo_filters_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("filters")
+}
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+}
+
+/// Mirrors `verify_cmd::runner::load_fixture` minus the assertion machinery.
+/// A missing or unreadable fixture warns and is skipped — one bad case must
+/// not hide the whole report.
+fn load_case_text(case: &TestCase, case_path: &Path) -> Option<String> {
+    if let Some(inline) = &case.inline {
+        return Some(inline.trim_end().to_string());
+    }
+    let fixture = case.fixture.as_ref()?;
+    let case_dir = case_path.parent().unwrap_or_else(|| Path::new("."));
+    for candidate in [case_dir.join(fixture), PathBuf::from(fixture)] {
+        if candidate.exists() {
+            match std::fs::read_to_string(&candidate) {
+                Ok(s) => return Some(s.trim_end().to_string()),
+                Err(e) => {
+                    eprintln!("  warning: cannot read {}: {e}", candidate.display());
+                    return None;
+                }
+            }
+        }
+    }
+    eprintln!("  warning: fixture not found: {fixture}");
+    None
+}
+
+/// Corpus A — every filter `_test/` case, measured raw and filtered.
+fn collect_pairs() -> Vec<Pair> {
+    let suites = discover_suites(&[repo_filters_dir()], None);
+    let mut pairs = Vec::new();
+
+    for suite in &suites {
+        let cfg = match tokf::config::try_load_filter(&suite.filter_path) {
+            Ok(Some(c)) => c,
+            Ok(None) => continue,
+            Err(e) => {
+                eprintln!("  warning: {} failed to load: {e:#}", suite.filter_name);
+                continue;
+            }
+        };
+
+        let Ok(entries) = std::fs::read_dir(&suite.suite_dir) else {
+            continue;
+        };
+        let mut case_files: Vec<PathBuf> = entries
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|e| e == "toml"))
+            .collect();
+        case_files.sort();
+
+        for case_path in &case_files {
+            let Ok(bytes) = std::fs::read_to_string(case_path) else {
+                continue;
+            };
+            let Ok(case) = toml::from_str::<TestCase>(&bytes) else {
+                eprintln!("  warning: cannot parse case {}", case_path.display());
+                continue;
+            };
+            let Some(raw_text) = load_case_text(&case, case_path) else {
+                continue;
+            };
+            let label = format!("{}::{}", suite.filter_name, case.name);
+            let Some(raw) = Sample::new(label.clone(), &raw_text) else {
+                continue;
+            };
+
+            let cmd_result = CommandResult {
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: case.exit_code,
+                combined: raw_text.clone(),
+            };
+            let filtered = tokf::filter::apply(
+                &cfg,
+                &cmd_result,
+                &case.args,
+                &tokf::filter::FilterOptions::default(),
+            );
+
+            pairs.push(Pair {
+                filter: suite.filter_name.clone(),
+                case: case.name.clone(),
+                raw,
+                filtered: Sample::new(format!("{label} (filtered)"), &filtered.output),
+            });
+        }
+    }
+
+    pairs
+}
+
+/// Corpus B — every `.txt` under `tests/fixtures/`, raw only. Fixtures that a
+/// suite case references explicitly are already covered by corpus A; no
+/// pairing heuristic is invented here.
+fn collect_fixture_samples() -> Vec<Sample> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        let mut entries: Vec<_> = entries.filter_map(Result::ok).map(|e| e.path()).collect();
+        entries.sort();
+        for path in entries {
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().is_some_and(|e| e == "txt") {
+                out.push(path);
+            }
+        }
+    }
+
+    let root = fixtures_dir();
+    let mut paths = Vec::new();
+    walk(&root, &mut paths);
+
+    paths
+        .iter()
+        .filter_map(|p| {
+            let text = std::fs::read_to_string(p).ok()?;
+            let label = p
+                .strip_prefix(&root)
+                .unwrap_or(p)
+                .to_string_lossy()
+                .into_owned();
+            Sample::new(label, text.trim_end())
+        })
+        .collect()
+}
+
+/// Byte-weighted implied divisor: total bytes / total real tokens.
+fn aggregate_divisor(samples: &[&Sample]) -> f64 {
+    let bytes: usize = samples.iter().map(|s| s.bytes).sum();
+    let tokens: usize = samples.iter().map(|s| s.real_tokens).sum();
+    if tokens == 0 {
+        return f64::NAN;
+    }
+    bytes as f64 / tokens as f64
+}
+
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return f64::NAN;
+    }
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let idx = ((sorted.len() - 1) as f64 * p).round() as usize;
+    sorted[idx]
+}
+
+/// (p10, median, p90) of the per-item implied divisor, so the spread that one
+/// constant cannot capture is visible.
+fn spread(samples: &[&Sample]) -> (f64, f64, f64) {
+    let mut d: Vec<f64> = samples.iter().map(|s| s.implied_divisor()).collect();
+    d.sort_by(f64::total_cmp);
+    (
+        percentile(&d, 0.10),
+        percentile(&d, 0.50),
+        percentile(&d, 0.90),
+    )
+}
+
+fn reduction_pct(before: usize, after: usize) -> f64 {
+    if before == 0 {
+        return 0.0;
+    }
+    (1.0 - after as f64 / before as f64) * 100.0
+}
+
+fn truncate(s: &str, n: usize) -> String {
+    if s.chars().count() <= n {
+        return s.to_owned();
+    }
+    s.chars().take(n.saturating_sub(1)).collect::<String>() + "…"
+}
+
+fn print_sample_table(title: &str, samples: &[&Sample]) {
+    println!("\n### {title} ({} items)", samples.len());
+    println!(
+        "{:<58} {:>9} {:>8} {:>8} {:>9} {:>8}",
+        "item", "bytes", "real", "impl.div", "est.", "err%"
+    );
+    for s in samples {
+        println!(
+            "{:<58} {:>9} {:>8} {:>8.2} {:>9} {:>7.1}%",
+            truncate(&s.label, 58),
+            s.bytes,
+            s.real_tokens,
+            s.implied_divisor(),
+            estimate_tokens_from_bytes(s.bytes),
+            s.error_pct(),
+        );
+    }
+    let (p10, p50, p90) = spread(samples);
+    println!(
+        "-> aggregate implied divisor {:.3} | p10 {p10:.2} median {p50:.2} p90 {p90:.2}",
+        aggregate_divisor(samples)
+    );
+}
+
+/// Per-case estimated reduction% vs real reduction%, so the
+/// deleting-vs-rewriting asymmetry shows up in our own data.
+fn print_reduction_table(pairs: &[Pair]) {
+    println!("\n### Reduction accuracy per case (est. vs real)");
+    println!(
+        "{:<58} {:>9} {:>9} {:>9}",
+        "case", "est.red%", "real.red%", "err(pt)"
+    );
+    let mut worst: Vec<(f64, String)> = Vec::new();
+    for p in pairs {
+        let Some(f) = &p.filtered else { continue };
+        let est = reduction_pct(
+            estimate_tokens_from_bytes(p.raw.bytes),
+            estimate_tokens_from_bytes(f.bytes),
+        );
+        let real = reduction_pct(p.raw.real_tokens, f.real_tokens);
+        let err = est - real;
+        println!(
+            "{:<58} {est:>8.1}% {real:>8.1}% {err:>+8.1}",
+            truncate(&format!("{}::{}", p.filter, p.case), 58)
+        );
+        worst.push((
+            err.abs(),
+            format!("{}::{} ({err:+.1} pt)", p.filter, p.case),
+        ));
+    }
+    worst.sort_by(|a, b| b.0.total_cmp(&a.0));
+    println!("\nLargest reduction-% errors (rewriting filters flatter themselves):");
+    for (_, label) in worst.iter().take(10) {
+        println!("  {label}");
+    }
+}
+
+#[test]
+#[ignore = "calibration harness; run with --features tokenizer -- --ignored --nocapture"]
+fn calibrate_token_divisor() {
+    println!("Shipping DIVISOR = {DIVISOR}");
+
+    let pairs = collect_pairs();
+    let fixtures = collect_fixture_samples();
+
+    // A broken walker must fail loudly rather than pass with zero items.
+    assert!(
+        pairs.len() >= 40,
+        "corpus looks broken: only {} filter test cases discovered",
+        pairs.len()
+    );
+    assert!(
+        fixtures.len() >= 20,
+        "corpus looks broken: only {} fixture files discovered",
+        fixtures.len()
+    );
+
+    let raw: Vec<&Sample> = pairs
+        .iter()
+        .map(|p| &p.raw)
+        .chain(fixtures.iter())
+        .collect();
+    let filtered: Vec<&Sample> = pairs.iter().filter_map(|p| p.filtered.as_ref()).collect();
+    let combined: Vec<&Sample> = raw
+        .iter()
+        .copied()
+        .chain(filtered.iter().copied())
+        .collect();
+
+    print_sample_table("RAW inputs (filter cases + fixtures)", &raw);
+    print_sample_table("FILTERED outputs", &filtered);
+    print_reduction_table(&pairs);
+
+    let raw_div = aggregate_divisor(&raw);
+    let filtered_div = aggregate_divisor(&filtered);
+    let combined_div = aggregate_divisor(&combined);
+
+    println!("\n=== AGGREGATES ===");
+    println!("raw implied divisor       : {raw_div:.3}");
+    println!("filtered implied divisor  : {filtered_div:.3}");
+    println!("combined implied divisor  : {combined_div:.3}");
+    let (p10, p50, p90) = spread(&combined);
+    println!("combined spread           : p10 {p10:.2} median {p50:.2} p90 {p90:.2}");
+    println!("shipping DIVISOR          : {DIVISOR:.3}");
+    println!(
+        "shipping error vs combined: {:+.1}%",
+        (combined_div - DIVISOR) / combined_div * 100.0
+    );
+
+    // Regression tripwire: the shipped constant must stay within a generous
+    // band of what the corpus actually implies. Wide enough not to be flaky
+    // when fixtures change; tight enough to catch real drift. If it proves
+    // noisy, widen it rather than deleting it.
+    let ratio = combined_div / DIVISOR;
+    assert!(
+        (0.75..=1.25).contains(&ratio),
+        "shipped DIVISOR {DIVISOR} is more than 25% away from the corpus-implied \
+         divisor {combined_div:.3} — recalibrate it"
+    );
+}
+
+/// The point of the abstraction: both counters are usable through the same
+/// `&dyn TokenCounter` at a call site.
+#[test]
+fn counters_are_swappable_at_the_call_site() {
+    let text = "error[E0308]: mismatched types\n  --> src/main.rs:4:5\n";
+    let counters: [&dyn TokenCounter; 2] = [&ArithmeticTokenCounter, &Cl100kTokenCounter];
+    for c in counters {
+        assert!(c.count(text) > 0);
+    }
+    assert_eq!(ArithmeticTokenCounter.count(text), estimate_tokens(text));
+}

--- a/crates/tokf-cli/tests/verify_cmd.rs
+++ b/crates/tokf-cli/tests/verify_cmd.rs
@@ -164,11 +164,11 @@ contains = "OK"
     let suite = &parsed.as_array().unwrap()[0];
     let case = &suite["cases"].as_array().unwrap()[0];
 
-    // Input tokens should be > 0 (40 bytes / 4 = 10)
+    // Input tokens should be > 0.
     let input_tokens = case["input_tokens"].as_u64().unwrap();
     assert!(input_tokens > 0, "input_tokens should be > 0");
 
-    // Output tokens should be small (2 bytes / 4 = 0, but "OK" is the template)
+    // Output tokens should be small — "OK" is the whole template.
     let output_tokens = case["output_tokens"].as_u64().unwrap();
     assert!(
         output_tokens < input_tokens,

--- a/crates/tokf-common/Cargo.toml
+++ b/crates/tokf-common/Cargo.toml
@@ -16,10 +16,20 @@ sha2 = "0.11"
 toml = { version = "1.0", optional = true }
 regex = { version = "1", optional = true }
 unicode-normalization = "0.1"
+# Calibration-only, OFF by default (`tokenizer` feature). Fully offline:
+# ships gzipped .tiktoken vocabs and decodes them in a build script (contrary
+# to some claims, it is NOT build-script-free), no network, no model download.
+# ~15 small transitive crates, several already in our tree (serde,
+# regex-automata, memchr, unicode-normalization). MUST NOT be enabled by any
+# workspace member unconditionally — cargo feature unification is additive and
+# one such entry would drag the vocab build into every default build.
+bpe-openai = { version = "0.3", optional = true }
 
 [features]
 default = []
 validation = ["toml", "regex"]
+# Calibration only. See crates/tokf-cli/tests/calibration.rs.
+tokenizer = ["dep:bpe-openai"]
 
 [lints]
 workspace = true

--- a/crates/tokf-common/src/examples.rs
+++ b/crates/tokf-common/src/examples.rs
@@ -2,11 +2,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::safety::SafetyWarning;
 
-/// Estimate token count from a string using the bytes/4 heuristic.
+/// Estimate token count from a string.
 ///
-/// This matches the estimation used by the tracking module.
-pub const fn estimate_tokens(s: &str) -> usize {
-    s.len() / 4
+/// Delegates to [`crate::tokens::estimate_tokens`] so every token count tokf
+/// reports comes from a single implementation.
+pub fn estimate_tokens(s: &str) -> usize {
+    crate::tokens::estimate_tokens(s)
 }
 
 /// Compute the reduction percentage between raw and filtered token estimates.
@@ -44,11 +45,11 @@ pub struct FilterExample {
     /// Number of lines in filtered output.
     #[cfg_attr(test, ts(type = "number"))]
     pub filtered_line_count: usize,
-    /// Estimated tokens in raw input (bytes / 4).
+    /// Estimated tokens in raw input (see [`crate::tokens`]).
     #[serde(default)]
     #[cfg_attr(test, ts(type = "number"))]
     pub raw_tokens_est: usize,
-    /// Estimated tokens in filtered output (bytes / 4).
+    /// Estimated tokens in filtered output (see [`crate::tokens`]).
     #[serde(default)]
     #[cfg_attr(test, ts(type = "number"))]
     pub filtered_tokens_est: usize,
@@ -176,5 +177,35 @@ mod tests {
         let dto = SafetyWarningDto::from(&warning);
         assert_eq!(dto.kind, "template_injection");
         assert_eq!(dto.message, "bad template");
+    }
+
+    /// `examples::estimate_tokens` must not re-derive the heuristic — it
+    /// delegates, so registry counts and `tokf gain` never disagree.
+    #[test]
+    fn estimate_tokens_delegates_to_the_shared_counter() {
+        for s in ["", "a", "hello world", "error[E0308]: mismatched types"] {
+            assert_eq!(estimate_tokens(s), crate::tokens::estimate_tokens(s));
+        }
+    }
+
+    /// Reduction percentages are ratios of two counts that share the divisor,
+    /// so recalibrating the divisor barely moves them. This pins that claim:
+    /// published filter-registry percentages need no regeneration.
+    #[test]
+    fn reduction_pct_is_insensitive_to_the_divisor() {
+        let raw = "noise\n".repeat(200);
+        let filtered = "kept\n".repeat(20);
+        #[allow(
+            clippy::cast_precision_loss,
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss
+        )]
+        let with = |d: f64| {
+            reduction_pct(
+                (raw.len() as f64 / d) as usize,
+                (filtered.len() as f64 / d) as usize,
+            )
+        };
+        assert!((with(4.0) - with(crate::tokens::DIVISOR)).abs() < 0.5);
     }
 }

--- a/crates/tokf-common/src/lib.rs
+++ b/crates/tokf-common/src/lib.rs
@@ -4,4 +4,5 @@ pub mod hash;
 pub mod multipart;
 pub mod safety;
 pub mod test_case;
+pub mod tokens;
 pub mod tracking;

--- a/crates/tokf-common/src/tokens.rs
+++ b/crates/tokf-common/src/tokens.rs
@@ -16,13 +16,23 @@
 
 /// Bytes per estimated token.
 ///
-/// This is a heuristic, not a measurement. Nothing has ever verified it
-/// against a real tokenizer.
+/// This is a heuristic, not a measurement — but it is a *calibrated* one.
+/// Measured against a real cl100k tokenizer over the whole tokf corpus
+/// (every filter `_test/` case and every file under `tests/fixtures/`,
+/// before and after filtering), the corpus implies 3.53 bytes per token
+/// overall: 3.67 on raw command output, 2.98 on filtered output, with a
+/// per-item spread of p10 2.72 / median 3.39 / p90 4.62. 3.5 is that
+/// combined figure rounded; the previous value of 4.0 systematically
+/// undercounted. See `docs/token-tracking.md` for the caveats.
+///
+/// Reproduce with:
+/// `cargo test -p tokf --features tokenizer --test calibration -- --ignored --nocapture`
 ///
 /// NOTE: while [`ArithmeticTokenCounter`] is the shipping default, every
 /// user-facing surface that prints these numbers (notably `tokf gain`) must
-/// keep labelling them `est.`.
-pub const DIVISOR: f64 = 4.0;
+/// keep labelling them `est.`. Recalibrating removed a bias; it did not make
+/// these counts exact, and the spread above shows one constant cannot.
+pub const DIVISOR: f64 = 3.5;
 
 /// Something that can count the tokens in a string.
 ///

--- a/crates/tokf-common/src/tokens.rs
+++ b/crates/tokf-common/src/tokens.rs
@@ -8,6 +8,11 @@
 //!
 //! Because it is a heuristic, every user-facing surface that prints these
 //! numbers must keep labelling them `est.`.
+//!
+//! The heuristic can be *verified* against a real cl100k tokenizer via the
+//! optional, off-by-default `tokenizer` feature (see
+//! `crates/tokf-cli/tests/calibration.rs`). cl100k is not Claude's tokenizer,
+//! so even that is an approximation — a calibration target, not truth.
 
 /// Bytes per estimated token.
 ///
@@ -63,6 +68,23 @@ pub fn estimate_tokens(s: &str) -> usize {
 )]
 pub fn estimate_tokens_from_bytes(bytes: usize) -> usize {
     (bytes as f64 / DIVISOR) as usize
+}
+
+/// A real cl100k tokenizer, for verifying and calibrating the estimator.
+///
+/// Available only under the optional, off-by-default `tokenizer` feature.
+/// Nothing in the shipping runtime path may use this — it exists so we can
+/// measure how wrong [`ArithmeticTokenCounter`] is, and re-check that later.
+#[cfg(feature = "tokenizer")]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Cl100kTokenCounter;
+
+#[cfg(feature = "tokenizer")]
+impl TokenCounter for Cl100kTokenCounter {
+    fn count(&self, text: &str) -> usize {
+        // `cl100k_base()` returns a process-wide static; construction is free.
+        bpe_openai::cl100k_base().count(text)
+    }
 }
 
 #[cfg(test)]
@@ -121,5 +143,22 @@ mod tests {
     fn counter_is_object_safe() {
         let c: &dyn TokenCounter = &ArithmeticTokenCounter;
         assert_eq!(c.count("hello world"), estimate_tokens("hello world"));
+    }
+
+    #[cfg(feature = "tokenizer")]
+    #[test]
+    fn cl100k_matches_hand_verified_counts() {
+        let c = Cl100kTokenCounter;
+        assert_eq!(c.count(""), 0);
+        // Hand-verified against the cl100k_base vocabulary.
+        assert_eq!(c.count("hello world"), 2);
+        assert_eq!(c.count("héllo wörld"), 6);
+    }
+
+    #[cfg(feature = "tokenizer")]
+    #[test]
+    fn cl100k_is_object_safe_too() {
+        let c: &dyn TokenCounter = &Cl100kTokenCounter;
+        assert!(c.count("fn main() {}") > 0);
     }
 }

--- a/crates/tokf-common/src/tokens.rs
+++ b/crates/tokf-common/src/tokens.rs
@@ -1,0 +1,125 @@
+//! Token counting.
+//!
+//! tokf reports token counts in `tokf gain`, persists them to `SQLite`, and
+//! syncs them to the server. Those numbers come from a cheap byte heuristic —
+//! `bytes / DIVISOR` — not from a real tokenizer. The default build takes no
+//! tokenizer dependency: counting tokens exactly is not worth a vocab table in
+//! the shipping binary just to serve a statistic.
+//!
+//! Because it is a heuristic, every user-facing surface that prints these
+//! numbers must keep labelling them `est.`.
+
+/// Bytes per estimated token.
+///
+/// This is a heuristic, not a measurement. Nothing has ever verified it
+/// against a real tokenizer.
+///
+/// NOTE: while [`ArithmeticTokenCounter`] is the shipping default, every
+/// user-facing surface that prints these numbers (notably `tokf gain`) must
+/// keep labelling them `est.`.
+pub const DIVISOR: f64 = 4.0;
+
+/// Something that can count the tokens in a string.
+///
+/// Object-safe on purpose: call sites take `&dyn TokenCounter` so the
+/// estimator is swappable rather than hardcoded arithmetic.
+pub trait TokenCounter {
+    /// Count the tokens in `text`.
+    fn count(&self, text: &str) -> usize;
+}
+
+/// The default, dependency-free estimator: `bytes / DIVISOR`, truncated.
+///
+/// Counts *bytes*, not characters — multi-byte UTF-8 therefore reads as more
+/// tokens than the same number of ASCII characters would.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ArithmeticTokenCounter;
+
+impl TokenCounter for ArithmeticTokenCounter {
+    fn count(&self, text: &str) -> usize {
+        estimate_tokens_from_bytes(text.len())
+    }
+}
+
+/// Estimate tokens for a string using the default arithmetic estimator.
+pub fn estimate_tokens(s: &str) -> usize {
+    estimate_tokens_from_bytes(s.len())
+}
+
+/// Estimate tokens from a byte count.
+///
+/// Exists so callers that only ever had byte counts (the tracking and
+/// telemetry event builders) share the exact same arithmetic as the
+/// string-based entry point instead of re-deriving it.
+///
+/// Truncates, matching the integer-division semantics this estimator has
+/// always had. `DIVISOR` is an `f64` so it can later be a non-integer; the
+/// single cast `#[allow]` lives here and nowhere else, so call sites stay
+/// free of casting lints.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation
+)]
+pub fn estimate_tokens_from_bytes(bytes: usize) -> usize {
+    (bytes as f64 / DIVISOR) as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_string_is_zero() {
+        assert_eq!(ArithmeticTokenCounter.count(""), 0);
+        assert_eq!(estimate_tokens(""), 0);
+        assert_eq!(estimate_tokens_from_bytes(0), 0);
+    }
+
+    #[test]
+    fn shorter_than_divisor_truncates_to_zero() {
+        // Truncation, not rounding — this is the historical behaviour and an
+        // easy accidental regression if someone reaches for `round()`.
+        assert_eq!(estimate_tokens_from_bytes(1), 0);
+    }
+
+    #[test]
+    fn scales_linearly_with_the_constant() {
+        #[allow(
+            clippy::cast_precision_loss,
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss
+        )]
+        let expected = (4000.0_f64 / DIVISOR) as usize;
+        assert_eq!(estimate_tokens_from_bytes(4000), expected);
+        assert_eq!(ArithmeticTokenCounter.count(&"a".repeat(4000)), expected);
+    }
+
+    #[test]
+    fn string_and_byte_entry_points_agree() {
+        for s in ["", "a", "hello world", &"x".repeat(1234)] {
+            assert_eq!(estimate_tokens(s), estimate_tokens_from_bytes(s.len()));
+            assert_eq!(ArithmeticTokenCounter.count(s), estimate_tokens(s));
+        }
+    }
+
+    #[test]
+    fn counts_bytes_not_chars() {
+        // "é" is two bytes; the heuristic is deliberately byte-based.
+        let s = "é".repeat(100);
+        assert_eq!(s.chars().count(), 100);
+        assert_eq!(estimate_tokens(&s), estimate_tokens_from_bytes(200));
+    }
+
+    #[test]
+    fn very_large_byte_counts_do_not_panic() {
+        let n = estimate_tokens_from_bytes(usize::MAX);
+        assert!(n > 0);
+    }
+
+    #[test]
+    fn counter_is_object_safe() {
+        let c: &dyn TokenCounter = &ArithmeticTokenCounter;
+        assert_eq!(c.count("hello world"), estimate_tokens("hello world"));
+    }
+}

--- a/crates/tokf-common/src/tracking/types.rs
+++ b/crates/tokf-common/src/tracking/types.rs
@@ -9,7 +9,7 @@ pub struct TrackingEvent {
     pub output_tokens_est: i64,
     /// Raw command output bytes before any baseline adjustment.
     pub raw_bytes: i64,
-    /// Estimated raw tokens (`raw_bytes / 4`).
+    /// Estimated raw tokens (see [`crate::tokens`]).
     pub raw_tokens_est: i64,
     pub filter_time_ms: i64,
     pub exit_code: i32,

--- a/crates/tokf-filter/src/examples.rs
+++ b/crates/tokf-filter/src/examples.rs
@@ -154,7 +154,7 @@ skip = ["^noise"]
         assert_eq!(ex.filtered, "keep this");
         assert_eq!(ex.raw_line_count, 3);
         assert_eq!(ex.filtered_line_count, 1);
-        // Token estimates: raw = 31 bytes / 4 = 7, filtered = 9 bytes / 4 = 2
+        // Token estimates always come from the shared estimator.
         assert_eq!(ex.raw_tokens_est, estimate_tokens(raw_input));
         assert_eq!(ex.filtered_tokens_est, estimate_tokens("keep this"));
         assert!(ex.reduction_pct > 0.0);

--- a/crates/tokf-server/generated/FilterExample.ts
+++ b/crates/tokf-server/generated/FilterExample.ts
@@ -29,11 +29,11 @@ raw_line_count: number,
  */
 filtered_line_count: number, 
 /**
- * Estimated tokens in raw input (bytes / 4).
+ * Estimated tokens in raw input (see [`crate::tokens`]).
  */
 raw_tokens_est: number, 
 /**
- * Estimated tokens in filtered output (bytes / 4).
+ * Estimated tokens in filtered output (see [`crate::tokens`]).
  */
 filtered_tokens_est: number, 
 /**

--- a/docs/discover.md
+++ b/docs/discover.md
@@ -63,3 +63,5 @@ Total unfiltered output: 28.1k tokens across 443 commands
 4. Matches remaining commands against available tokf filters
 5. By default shows only commands with no matching filter
 6. Aggregates and ranks by estimated token count
+
+Token counts are estimates derived from byte counts, not tokenizer output — see [How tokens are estimated](#how-tokens-are-estimated) under Token Savings Tracking for the constant, its measured accuracy, and its limits.

--- a/docs/token-tracking.md
+++ b/docs/token-tracking.md
@@ -13,6 +13,76 @@ tokf gain --by-filter  # breakdown by filter
 tokf gain --json       # machine-readable output
 ```
 
+## How tokens are estimated
+
+tokf does not run a tokenizer. Token counts are derived from byte counts with one constant:
+
+```
+tokens ≈ bytes / 3.5
+```
+
+That is why every token figure `tokf gain` prints is labelled **`est.`**, and why it will keep being labelled that way for as long as this estimator ships. It is a heuristic, not a measurement.
+
+### Where 3.5 comes from
+
+The constant used to be `4`, and nothing had ever checked it. It was measured against a real cl100k tokenizer across the whole tokf corpus — every filter `_test/` case (both the raw input and the filtered output) plus every fixture under `tests/fixtures/` — which gives the *implied* divisor, i.e. bytes per real token:
+
+| corpus | implied divisor |
+|---|---|
+| raw command output | 3.67 |
+| filtered output | 2.98 |
+| combined (byte-weighted) | 3.53 |
+| spread across items | p10 2.72 · median 3.39 · p90 4.62 |
+
+`3.5` is the combined figure rounded. The old `4` undercounted real cl100k tokens by roughly 8% on raw output and 25% on filtered output; `3.5` lands within 1% of the corpus aggregate.
+
+Two honest caveats:
+
+- **cl100k is not Claude's tokenizer.** Even the "real" numbers we calibrated against are an approximation of the thing users actually care about. The goal was removing a large systematic bias, not achieving exactness.
+- **The corpus is what it is** — heavily weighted toward `cargo`, `git`, `npm` and `docker` output. The p10/p90 spread above shows the per-item divisor genuinely ranges from under 2.8 to over 4.6 depending on output shape: prose is cheap per byte to tokenize, dense symbolic output is expensive. One constant cannot capture that, and tokf deliberately does not try. It says `est.` instead.
+
+### Percentages are more reliable than absolute counts — except when filters rewrite
+
+The savings *percentage* divides two counts that share the divisor, so most of the error cancels out. That holds well for filters that mostly **delete** lines:
+
+| case | est. reduction | real reduction | error |
+|---|---|---|---|
+| `cargo/check` (successful check collapses) | 84.4% | 84.6% | −0.2 pt |
+| `cargo/clippy` (grouped by lint rule) | 78.5% | 78.2% | +0.3 pt |
+| `cargo/build` (failure output) | 23.3% | 24.2% | −0.9 pt |
+
+It stops holding for filters that **rewrite** content — replacing English prose with a dense symbolic summary. Prose tokenizes cheaply per byte; the summary does not, so the byte ratio overstates the token ratio and the filter flatters itself:
+
+| case | est. reduction | real reduction | error |
+|---|---|---|---|
+| `docker/ps` (no running containers → zero count) | 0.0% | −300.0% | +300 pt |
+| `git/push` (up-to-date → friendly message) | 33.3% | −50.0% | +83 pt |
+| `git/status` (clean repo → branch marker) | 50.0% | 0.0% | +50 pt |
+
+Those are worst cases on tiny outputs, where a handful of tokens swings the percentage wildly — but the direction of the bias is consistent, and it is upward. **Treat reduction percentages on rewriting filters as indicative, not as a claim.**
+
+### Verifying the estimate yourself
+
+The tokenizer is a contributor tool, not a runtime feature. It sits behind an optional cargo feature that is **off by default**, so normal builds take no tokenizer dependency at all:
+
+```sh
+cargo test -p tokf --features tokenizer --test calibration -- --ignored --nocapture
+```
+
+That prints the full per-item table and the aggregates above, and fails if the shipped constant drifts more than 25% from what the corpus implies. There is no way to enable a real tokenizer at runtime, and no plan to add one — carrying a vocabulary table in the shipping binary to serve a statistic is not a trade tokf wants to make.
+
+### Estimates changed: a deliberate discontinuity
+
+Changing the divisor changes the numbers. Being explicit about what that means:
+
+- Rows recorded **before** the change keep their old `bytes / 4` token counts. They are not rewritten.
+- Rows recorded **after** use `bytes / 3.5`.
+- `tokf gain` totals spanning the changeover therefore show a **step increase in absolute token counts**. Nothing is being saved differently; the estimate simply got less wrong.
+- Savings **percentages** are essentially unaffected, because both sides of the ratio scale together. That is the reason the discontinuity is tolerable.
+- The same applies to server-side aggregates, which receive already-computed token columns via sync.
+
+We deliberately did **not**: version the estimator in the SQLite schema (real surface area across three crates for a statistic), rewrite historical rows (local history would then diverge from already-synced server rows — worse than one honest step), or recompute tokens at read time (touches every aggregate query and still cannot fix the server side). One documented step change beat all three.
+
 ## Remote gain
 
 View aggregate savings across all your registered machines via the tokf server:


### PR DESCRIPTION
## What and why

`bytes / 4` had never been checked against a real tokenizer. It has now been measured, and it was wrong: the tokf corpus implies **3.53 bytes per real cl100k token**, so the shipped constant undercounted by ~8% on raw command output and ~25% on filtered output.

Three commits:

1. **`refactor(tracking)`** — introduce `tokf_common::tokens` with a `TokenCounter` trait and an `ArithmeticTokenCounter` default. No behaviour change (divisor stays 4.0, rounding stays truncating).
2. **`feat(tracking)`** — optional, off-by-default `tokenizer` feature providing a real cl100k counter, plus a calibration harness.
3. **`perf(tracking)`** — recalibrate the divisor 4.0 → 3.5 and document the estimator honestly.

## Evidence

```
=== AGGREGATES ===
raw implied divisor       : 3.668
filtered implied divisor  : 2.982
combined implied divisor  : 3.531
combined spread           : p10 2.72 median 3.39 p90 4.62
shipping DIVISOR          : 3.500
shipping error vs combined: +0.9%
```

Corpus: 253 raw samples (every filter `_test/` case plus every `tests/fixtures/**/*.txt`) and 219 filtered outputs.

The spread is the interesting part — the per-item divisor genuinely ranges from under 2.8 to over 4.6 depending on whether output is prose-shaped or symbol-shaped. **One constant cannot capture that**, which is exactly why `est.` stays.

Reduction-percentage accuracy reproduces the issue's asymmetry in our own data. Deleting filters are near-perfect (`cargo/check` −0.2 pt, `cargo/clippy` +0.3 pt, `cargo/build` −0.9 pt); rewriting filters flatter themselves (`git/status` +50 pt, `git/push` +83 pt, `docker/ps` +300 pt on a 2-byte output). Documented with the mechanism, not just the numbers.

## Decisions you should look at

**Correction to the issue's technical note.** `bpe-openai` 0.3.0 **does** have a build script — it ships gzipped `.tiktoken` vocabs and decodes them in `build.rs`. It is still fully offline (no network, no model download) with ~15 small transitive crates, several already in our tree (serde, regex-automata, memchr, unicode-normalization) and no `tokenizers`/ONNX/protobuf. Recorded in a `Cargo.toml` comment. Practical consequence: the tokenizer CI job has a slower cold build.

**Default tree is provably untouched:**
```
$ cargo tree -p tokf | grep -ci bpe
0
$ cargo tree -p tokf --features tokenizer | grep -i bpe-openai
│   ├── bpe-openai v0.3.0
```

**Scope call — the issue cites only `tracking/mod.rs:159-163`, this PR fixes four sites.** The same arithmetic was independently duplicated in `tracking::build_event`, `TelemetryEvent::new`, `discover::build_results` and `tokf_common::examples::estimate_tokens`. Changing only the cited lines would have made `tokf gain`, `tokf verify`, `tokf discover` and the otel export report different counts for the same bytes. Consolidation of existing logic, not new scope — but flagging it rather than burying it. There is now a cross-module parity test pinning telemetry and tracking together.

**Historical SQLite rows: discontinuity accepted deliberately, not silently.** No schema column, no backfill. Absolute token counts step up across the changeover; savings percentages are essentially unaffected because both sides of the ratio scale together. Rejected alternatives are named in the commit message and in `docs/token-tracking.md` so the reasoning is on the record. Happy to do `estimator_version` as a follow-up if you'd prefer it — say the word and I'll open an issue.

**Filter registry needs no regeneration.** `examples::reduction_pct` divides two counts sharing the divisor, so published reduction percentages barely move. There's a test pinning that claim.

**Harness is an `#[ignore]`d test, not a `tokf calibrate` subcommand.** The issue permits either; a test adds no permanent CLI surface, no help text and no end-user docs for something only contributors can act on. Easy to convert if you'd rather have the subcommand.

**Small refactor to reach the corpus.** `verify_cmd::discovery`'s pure suite walker moved to `tokf::suite_discovery` so the harness can walk the same corpora without duplicating a ~90-line directory walk (which would trip `cargo dupes`). Pure move; `verify_cmd` keeps only its own search-dir resolution.

**CI additions not asked for by the issue** — mirroring the existing per-feature otel steps. Without them none of the tokenizer code is ever compiled or run and the divisor rots silently, which is the outcome the issue is trying to prevent. Decline if the extra runtime isn't worth it.

## Testing

- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 1029+ tests, green
- `cargo clippy -p tokf-common -p tokf --features tokenizer --all-targets -- -D warnings` — clean
- `cargo test -p e2e-tests -- --ignored` and `cargo test -p tokf-server -- --ignored` with CockroachDB up — green. These matter: `gain_flow`, `sync_flow` and `auth_flow` all hardcoded `/4` literals and are `#[ignore]`d, so `cargo test --workspace` would have passed while CI's db-test job failed.
- Calibration harness green, tripwire holds at ±25%.
- Every test that hardcoded `/4` now asserts against the shared estimator, so the constant can be recalibrated again without breaking assertions.

## Review round

Three independent reviews (correctness/edge-cases, project conventions, scope/UX) found **no blockers and no majors**. One nit was raised and applied:

- **`refactor(tracking)` 38b2133** — the calibration harness had its own private `reduction_pct`, logically identical to the public `tokf_common::examples::reduction_pct`. Deduped. It matters slightly more than a normal copy-paste nit: the harness exists to report drift against the percentage `tokf gain` and `FilterExample` actually publish, so a private copy could silently diverge and the report would stop describing shipping behaviour. Test-only, no behaviour change.

Two things were raised and deliberately **not** changed:

- **Corpus overlap in the harness.** `collect_pairs` (filter `_test/` cases) and `collect_fixture_samples` (`tests/fixtures/**`) are concatenated without dedup, so a filter case whose `fixture = ` pointed into `tests/fixtures/**` would be double-counted. Re-verified independently: every `fixture = ` value in the stdlib is a bare sibling filename, none path into `tests/fixtures/`, so the reported numbers are correct today. This is latent fragility for a future contributor, not a present defect, and guarding it would add scope this issue didn't ask for. Listed as follow-up below.
- **`auth::credentials` keyring flake.** Pre-existing and unrelated to token estimation — these tests share the real system keychain and collide when two test runs overlap. A `fix/keyring-test-isolation` branch already exists for it. Passes in isolation and in a clean serial run.

**Verification after the fix:** `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo clippy -p tokf --features tokenizer --all-targets -- -D warnings` all clean; `cargo test --workspace` **2314 passed / 0 failed**; the calibration harness re-run reproduces the documented figures exactly (raw 3.668, filtered 2.982, combined 3.531, p10 2.72 / median 3.39 / p90 4.62, shipping error +0.9%). `scripts/generate-readme.sh` on a clean tree regenerates `README.md` byte-identical, confirming it was never hand-edited.

## Follow-up (not in this PR)

- Dedupe the two harness corpora by resolved path, so a future filter test case pointing at `tests/fixtures/**` cannot be counted twice.
- Optional `estimator_version` column for tracking rows, if you'd prefer that over the accepted discontinuity.

## Explicitly out of scope

No runtime tokenizer in any form (no flag, no env var, no auto-detection). No second tokenizer for cross-parity. No `estimator_version` column or historical backfill. No multiple/adaptive divisors. No change to the `est.` labelling — verified it survives at all seven call sites in `gain.rs` and `gain_render/mod.rs`. No rounding-semantics change (truncation preserved).

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7fCGepMs4wjMoobLE3wKN

