### PR TITLE
fix(config): stop unit tests writing to the real keychain and shims dir

### DIFF
--- a/crates/tokf-cli/src/auth/credentials.rs
+++ b/crates/tokf-cli/src/auth/credentials.rs
@@ -71,7 +71,7 @@ pub fn save(
     token_expires_in: i64,
 ) -> anyhow::Result<()> {
     // Store token in OS keyring
-    let entry = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER)?;
+    let entry = keyring_entry()?;
     entry
         .set_password(token)
         .map_err(|e| anyhow::anyhow!("could not access system keyring: {e}"))?;
@@ -202,7 +202,7 @@ pub fn load() -> Option<LoadedAuth> {
     let content = fs::read_to_string(&path).ok()?;
     let meta: StoredAuth = toml::from_str(&content).ok()?;
 
-    let entry = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER).ok()?;
+    let entry = keyring_entry().ok()?;
     let token = entry.get_password().ok()?;
 
     Some(LoadedAuth {
@@ -215,18 +215,67 @@ pub fn load() -> Option<LoadedAuth> {
     })
 }
 
+/// Guards mock-store installation so it happens exactly once per process.
+///
+/// `keyring_core`'s default store is process-global and first-write-wins, so
+/// installing it more than once would either be ignored or swap in a fresh,
+/// empty store underneath a test that had already saved a credential.
+#[cfg(any(test, feature = "test-keyring"))]
+static MOCK_STORE_INIT: std::sync::Once = std::sync::Once::new();
+
 /// Switch the keyring to an in-memory backend that persists across entries.
 ///
-/// Must be called before any keyring operations in tests to avoid touching
-/// real OS credentials. Safe to call multiple times.
+/// Idempotent: the store is installed on the first call and every later call
+/// is a no-op, so concurrent callers all observe the same store.
 ///
 /// Uses `keyring_core`'s mock store, which reuses one credential per
 /// `(service, user)` pair, so `save()` + `load()` round-trips work in tests
 /// (its persistence is `ProcessOnly`).
 #[cfg(any(test, feature = "test-keyring"))]
 pub fn use_mock_keyring() {
-    if let Ok(store) = keyring_core::mock::Store::new() {
-        keyring_core::set_default_store(store);
+    MOCK_STORE_INIT.call_once(|| {
+        if let Ok(store) = keyring_core::mock::Store::new() {
+            keyring_core::set_default_store(store);
+        }
+    });
+}
+
+/// The entry type used to reach the credential store.
+///
+/// Test builds deliberately use `keyring_core::Entry` rather than
+/// `keyring::Entry`; see [`keyring_entry`] for why that distinction matters.
+#[cfg(any(test, feature = "test-keyring"))]
+type KeyringEntry = keyring_core::Entry;
+#[cfg(not(any(test, feature = "test-keyring")))]
+type KeyringEntry = keyring::Entry;
+
+/// Construct the keyring entry holding the auth token.
+///
+/// Every keyring access in this module goes through here.
+///
+/// **Why test builds bypass `keyring::Entry`.** `keyring` 4's `v1` wrapper opens
+/// `Entry::new` with `SET_CREDENTIAL_STORE.call_once(set_credential_store)`,
+/// which calls `keyring_core::set_default_store(platform_store)` — and that
+/// setter overwrites unconditionally. So the *first* `keyring::Entry::new`
+/// anywhere in the process replaces whatever store was installed, including a
+/// mock. Installing the mock earlier cannot win that race; the wrapper always
+/// clobbers it, which is why tests reached the real OS keychain (prompting for
+/// access, and failing with "item already exists" against leftover state).
+///
+/// Going through `keyring_core::Entry` in test builds skips that `call_once`
+/// entirely, so the mock store installed by [`use_mock_keyring`] is the one
+/// actually used. Production builds keep the `keyring::Entry` wrapper and its
+/// platform-store selection, unchanged.
+fn keyring_entry() -> keyring::Result<KeyringEntry> {
+    #[cfg(any(test, feature = "test-keyring"))]
+    {
+        use_mock_keyring();
+        keyring_core::Entry::new(KEYRING_SERVICE, KEYRING_USER)
+    }
+
+    #[cfg(not(any(test, feature = "test-keyring")))]
+    {
+        keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER)
     }
 }
 
@@ -237,8 +286,13 @@ pub fn use_mock_keyring() {
 pub fn remove() -> bool {
     let had_credentials = load().is_some();
 
-    // Remove keyring entry (ignore errors — may already be absent)
-    if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER) {
+    // Remove keyring entry (ignore errors — may already be absent).
+    //
+    // Deliberately unconditional, not gated on `had_credentials`: the TOML file
+    // and the keyring entry can go out of sync (a hand-deleted auth.toml leaves
+    // the token orphaned), and `load()` reports None whenever the TOML is gone.
+    // Gating here would silently strand that token forever.
+    if let Ok(entry) = keyring_entry() {
         let _ = entry.delete_credential();
     }
 
@@ -383,6 +437,53 @@ mod tests {
 
         let after = load();
         assert!(after.is_none(), "credentials should be gone after remove");
+    }
+
+    /// Deliberately NOT `#[serial]`: this asserts that a keyring access racing
+    /// the serial auth tests still lands on the mock store.
+    ///
+    /// Before `keyring_entry()` existed, `load()` here could construct an entry
+    /// against the real OS keychain, and because `keyring_core`'s default store
+    /// is process-global and first-write-wins, that pinned the real store for
+    /// every test that ran afterwards — the cause of the intermittent
+    /// "item already exists in the keychain" failures.
+    /// `#[serial]` because it writes the shared `(service, user)` credential
+    /// that the other auth tests round-trip; without it this would clobber
+    /// their state mid-test. It does not touch `crate::paths`, whose override
+    /// is also process-global.
+    #[test]
+    #[serial]
+    fn keyring_entry_installs_the_mock_store_without_an_explicit_call() {
+        // No use_mock_keyring() call: keyring_entry() must install it.
+        let entry = keyring_entry().expect("keyring entry should be constructible");
+
+        // Against the mock this round-trips; against a real keychain it would
+        // prompt for access or fail outright.
+        entry
+            .set_password("mock-store-probe")
+            .expect("mock store should accept a write");
+        assert_eq!(
+            entry.get_password().expect("mock store should read back"),
+            "mock-store-probe"
+        );
+        let _ = entry.delete_credential();
+    }
+
+    #[test]
+    #[serial]
+    fn use_mock_keyring_is_idempotent_and_preserves_state() {
+        use_mock_keyring();
+        let entry = keyring_entry().unwrap();
+        entry.set_password("first-write").unwrap();
+
+        // A second call must NOT swap in a fresh, empty store underneath us.
+        use_mock_keyring();
+        assert_eq!(
+            keyring_entry().unwrap().get_password().unwrap(),
+            "first-write",
+            "re-installing the mock store must not discard existing credentials"
+        );
+        let _ = entry.delete_credential();
     }
 
     #[test]

--- a/crates/tokf-cli/src/config/cache.rs
+++ b/crates/tokf-cli/src/config/cache.rs
@@ -157,6 +157,31 @@ fn write_manifest_bytes(path: &Path, data: &[u8]) -> anyhow::Result<()> {
         .map_err(|err| anyhow::Error::new(err.error).context("rename cache tmp to final"))
 }
 
+/// Generate shims from a cache-discovery path, unless this is a unit-test build.
+///
+/// [`generate_shims`] writes into [`crate::paths::shims_dir`], which is
+/// *process-global* and redirected by `HomeGuard` in tests. `discover_with_cache`
+/// is production code exercised by many non-serial unit tests, so letting it
+/// generate shims meant those tests wrote into whichever temp directory a
+/// concurrently-running serial shim test had `HomeGuard` pointing at — deleting
+/// or adding shims underneath it. That is the source of the intermittent
+/// `generate_shims_*` failures ("only basename shim should exist", and a
+/// vanishing shims directory).
+///
+/// Skipping it under `cfg(test)` costs no coverage: the `generate_shims_*` tests
+/// call [`generate_shims`] directly, and the integration tests exercise this path
+/// through the real binary, which is not a `cfg(test)` build.
+// Under `cfg(test)` the body collapses to a discard, which clippy would rather
+// see as a `const fn`; that is an artefact of the test build, not the real one.
+#[cfg_attr(test, allow(clippy::missing_const_for_fn))]
+fn generate_shims_from_discovery(filters: &[ResolvedFilter]) {
+    #[cfg(not(test))]
+    generate_shims(filters);
+
+    #[cfg(test)]
+    let _ = filters;
+}
+
 /// Generate shim scripts for all filter command basenames.
 ///
 /// Each shim is a small shell script that redirects through `tokf -c`,
@@ -259,7 +284,7 @@ pub fn discover_with_cache(search_dirs: &[PathBuf]) -> anyhow::Result<Vec<Resolv
         if let Ok(filters) = result {
             // Regenerate shims if the directory was manually deleted
             if crate::paths::shims_dir().is_some_and(|d| !d.exists()) {
-                generate_shims(&filters);
+                generate_shims_from_discovery(&filters);
             }
             return Ok(filters);
         }
@@ -267,7 +292,7 @@ pub fn discover_with_cache(search_dirs: &[PathBuf]) -> anyhow::Result<Vec<Resolv
     }
 
     let filters = discover_all_filters(search_dirs)?;
-    generate_shims(&filters);
+    generate_shims_from_discovery(&filters);
     if let Err(e) = write_manifest(&path, &filters, search_dirs) {
         eprintln!("[tokf] cache write failed ({}): {e:#}", path.display());
         eprintln!(


### PR DESCRIPTION
## Summary

Fixes two independent leaks that let unit tests write to **process-global** state — the developer's real OS keychain, and whichever directory `HomeGuard` currently points at. Closes #422.

### 1. `use_mock_keyring()` has never worked

`keyring` 4's `v1` wrapper (`keyring-4.1.1/src/v1.rs:47-48`) opens `Entry::new` with:

```rust
SET_CREDENTIAL_STORE.call_once(set_credential_store);
```

which calls `keyring_core::set_default_store(platform_store)` — and that setter overwrites unconditionally. So the **first** `keyring::Entry::new` anywhere in the process clobbers any mock store, regardless of how early the mock was installed.

Unit tests therefore used the **real macOS keychain**: prompting for access on every rebuilt binary (ACLs are per-binary-signature), and failing intermittently with `Platform failure: The specified item already exists in the keychain` against state left by earlier runs.

This was easy to miss because the `test-keyring` feature *is* correctly enabled on the bin target under `cargo test` — verified via `cargo test --message-format=json`. The feature works; the call it enables was simply being overridden.

**Fix:** all keyring access routes through one `keyring_entry()` helper. Test builds use `keyring_core::Entry` directly, skipping the wrapper's `call_once` so the mock is honoured; production keeps `keyring::Entry` and its platform-store selection, byte-for-byte unchanged. `use_mock_keyring()` is now `Once`-guarded so a later call cannot swap a fresh, empty store under a test that already saved a credential.

### 2. `discover_with_cache` wrote shims to global state from non-serial tests

`discover_with_cache()` called `generate_shims()`, which writes into `paths::shims_dir()` — process-global, redirected by `HomeGuard` in tests. It is production code exercised by **many non-serial** unit tests, so they wrote into whichever temp dir a concurrently-running `#[serial]` shim test was using, adding or deleting shims underneath it.

`#[serial]` could not prevent this: it orders the annotated tests against each other, not against every other test that reaches the same global.

**Fix:** that path routes through `generate_shims_from_discovery()`, a no-op under `cfg(test)`. No coverage lost — the `generate_shims_*` tests call `generate_shims()` directly, and integration tests drive it through the real binary, which is not a `cfg(test)` build.

## Why both were needed

Bug 2 was **latent on `main`** (~1 in 10 runs of the `config::cache` tests alone) and became frequent once bug 1 was fixed, because auth tests that previously failed fast at the keyring step now succeed and do real filesystem work, widening the race window. Landing bug 1's fix alone would have made the suite visibly flaky.

## Testing

Repeated full parallel runs of `cargo test -p tokf --lib`:

| build | failures | keychain errors |
|---|---|---|
| `main` | 0 / 12 | n/a (silently using the real keychain) |
| bug 1 fix only | **8 / 12** | 0 |
| both fixes | **0 / 14** | 0 |

Plus the full gate: `cargo fmt --all` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace` → 57 suites, 2305 passed, 0 failed.

Two regression tests added: `keyring_entry()` installs the mock without an explicit call, and re-installing the mock preserves existing state.

## Deliberately out of scope

- **Integration-test isolation.** 23 of 32 files in `crates/tokf-cli/tests/` spawn the binary without `TOKF_HOME`, and only 6 set `TOKF_DB_PATH`, so tests can still read the real config dir and write the real `tracking.db` (polluting `tokf gain` stats). Unrelated to the keychain; deserves its own issue.
- **`credentials::remove()` touching the keychain unconditionally**, so `tokf auth logout` prompts even with nothing stored. Left as-is on purpose: gating it on `had_credentials` (which requires `auth.toml`) would strand an orphaned token whenever the TOML is deleted by hand. Noted in a code comment.

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7fCGepMs4wjMoobLE3wKN
