### PR TITLE
fix(server): stop v1-hash backfill being cancelled mid-batch

### DIFF
--- a/.github/workflows/backfill-v1-hashes.yml
+++ b/.github/workflows/backfill-v1-hashes.yml
@@ -22,3 +22,7 @@ jobs:
         env:
           TOKF_SERVICE_TOKEN: ${{ secrets.TOKF_SERVICE_TOKEN }}
           TOKF_REGISTRY_URL: https://api.tokf.net
+          # Each round fetches and hashes up to `limit` filters from R2. The
+          # 5s CLI default cancels the request mid-batch, so the server never
+          # gets to reply and the backfill can't converge.
+          TOKF_HTTP_TIMEOUT: "300"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4095,6 +4095,7 @@ dependencies = [
  "chrono",
  "clap",
  "crdb-test-macro",
+ "futures-util",
  "hex",
  "http-body-util",
  "rand 0.10.1",

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -195,3 +195,28 @@ string with DDL privileges (`CREATE TABLE`, `ALTER TABLE`, etc.) and keep
 `DATABASE_URL` restricted to DML (`SELECT`, `INSERT`, `UPDATE`, `DELETE`). This
 follows the principle of least privilege — the running application never has
 schema-altering permissions.
+
+## 10. Backfilling canonical v1 hashes
+
+Rows published before the canonical v1 hash shipped (see
+[ADR-0002](docs/adr/0002-canonical-v1-hash.md)) have `v1_hash IS NULL`. The
+**Backfill v1 Hashes** workflow (`workflow_dispatch`) drains them by calling
+`POST /api/filters/backfill-v1-hashes` in a loop until a round reports
+`updated == 0`.
+
+Each round fetches up to `--limit` filter TOMLs from R2 (16 concurrently),
+recomputes the hash, and writes it back. The handler logs
+`backfill-v1-hashes request received`, a `backfill-v1-hashes progress` line
+every 25 rows, and `backfill-v1-hashes complete` at the end.
+
+**If you only ever see the `request received` line**, the client hung up
+mid-batch and axum cancelled the handler. The CLI's default HTTP timeout is 5s
+— far too short for a batch of R2 fetches — so the workflow sets
+`TOKF_HTTP_TIMEOUT: "300"`. Raise it, or lower `--limit`, if batches still time
+out. Progress is never lost: each row commits its own `UPDATE`, so re-running
+picks up where the last attempt stopped.
+
+A round that reports `updated == 0` with a non-empty `failed` list means only
+permanently-broken rows remain (missing R2 object, or TOML that no longer
+canonicalises). The workflow exits non-zero so these get triaged rather than
+silently ignored.

--- a/crates/tokf-cli/src/backfill_cmd.rs
+++ b/crates/tokf-cli/src/backfill_cmd.rs
@@ -284,6 +284,11 @@ struct BackfillV1Response {
 ///
 /// Exit code is non-zero when rows remain unprocessable after the run, so a
 /// CI invocation goes red and an operator triages the reported failures.
+///
+/// Each round is a synchronous request that fetches `limit` filters from R2
+/// server-side, so the caller must raise `TOKF_HTTP_TIMEOUT` well above the 5s
+/// default — otherwise the request is cancelled mid-batch and the round fails
+/// even though the server made progress. The backfill workflow sets it to 300.
 fn backfill_v1_hashes(registry_url: &str, token: &str, limit: usize) -> anyhow::Result<i32> {
     let client = Client::new(registry_url, Some(token))?;
     let mut total_updated = 0usize;

--- a/crates/tokf-cli/src/cli_args.rs
+++ b/crates/tokf-cli/src/cli_args.rs
@@ -267,8 +267,10 @@ pub enum Commands {
     BackfillV1Hashes {
         #[command(flatten)]
         auth: RegistryAuthArgs,
-        /// Rows to process per request (server caps at 500)
-        #[arg(long, default_value_t = 500)]
+        /// Rows to process per request (server caps at 500). Kept small so a
+        /// round completes well inside the HTTP timeout; the command loops
+        /// until the backlog is drained regardless of batch size.
+        #[arg(long, default_value_t = 100)]
         limit: usize,
     },
     /// Telemetry configuration and diagnostics

--- a/crates/tokf-server/Cargo.toml
+++ b/crates/tokf-server/Cargo.toml
@@ -31,6 +31,7 @@ sha2 = "0.11"
 rand = "0.10"
 hex = "0.4"
 async-trait = "0.1"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 chrono = { version = "0.4", features = ["serde"] }
 aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"] }
 tokf-common = { path = "../tokf-common", version = "0.2.50", features = ["validation"] }

--- a/crates/tokf-server/src/routes/filters/backfill.rs
+++ b/crates/tokf-server/src/routes/filters/backfill.rs
@@ -1,4 +1,5 @@
 use axum::{Json, extract::State, http::StatusCode};
+use futures_util::{StreamExt, stream};
 use serde::{Deserialize, Serialize};
 
 use crate::auth::service_token::ServiceAuth;
@@ -115,6 +116,15 @@ const fn default_v1_batch_size() -> usize {
     100
 }
 
+/// How many rows are fetched-and-hashed at once. The work is I/O-bound on R2,
+/// so serial processing made a 300-row batch take minutes and get cancelled by
+/// client timeouts before the handler could reply.
+const V1_CONCURRENCY: usize = 16;
+
+/// Emit a progress log every N completed rows, so a stalled batch is visible
+/// rather than a silent gap between "request received" and "complete".
+const V1_PROGRESS_INTERVAL: usize = 25;
+
 #[derive(Debug, Serialize)]
 pub struct BackfillV1Response {
     pub processed: usize,
@@ -138,10 +148,19 @@ pub struct BackfillV1Failure {
 /// `updated_at` is still bumped so they rotate to the back of the queue
 /// and don't starve newer rows.
 ///
+/// Rows are processed [`V1_CONCURRENCY`] at a time — the work is I/O-bound on
+/// R2 and a serial batch is slow enough that clients time out and cancel the
+/// handler before it can reply.
+///
 /// Operator runbook: invoke repeatedly until `updated == 0`. A response
 /// with `updated == 0` and a non-empty `failed` list means only
 /// permanently-failing rows remain — triage those manually; further calls
 /// will not make progress. Failures don't stop the batch.
+///
+/// Callers must allow a generous request timeout (the `tokf` CLI defaults to
+/// 5s; the backfill workflow raises it via `TOKF_HTTP_TIMEOUT`). A cancelled
+/// request loses no work — each row commits its own `UPDATE` — but the
+/// response, and the `failed` list with it, is lost.
 pub async fn backfill_v1_hashes(
     _auth: ServiceAuth,
     State(state): State<AppState>,
@@ -173,25 +192,7 @@ pub async fn backfill_v1_hashes(
         "backfill-v1-hashes request received"
     );
 
-    let mut updated = 0usize;
-    let mut failed = Vec::new();
-
-    for (content_hash, r2_key) in &rows {
-        match compute_and_store_v1(&state, content_hash, r2_key).await {
-            Ok(()) => updated += 1,
-            Err(e) => {
-                tracing::warn!(hash = %content_hash, "backfill-v1 failed: {e}");
-                // Bump `updated_at` so this row rotates to the back of the
-                // cursor and doesn't starve newer rows on the next call. The
-                // row's `v1_hash` stays NULL, so it remains a candidate.
-                touch_updated_at(&state, content_hash).await;
-                failed.push(BackfillV1Failure {
-                    content_hash: content_hash.clone(),
-                    error: e.to_string(),
-                });
-            }
-        }
-    }
+    let (updated, failed) = process_v1_batch(&state, &rows).await;
 
     tracing::info!(
         processed = rows.len(),
@@ -208,6 +209,67 @@ pub async fn backfill_v1_hashes(
             failed,
         }),
     ))
+}
+
+/// Fetch, hash and store `v1_hash` for every row in `rows`, up to
+/// [`V1_CONCURRENCY`] at a time. Returns `(updated, failures)`.
+///
+/// Failures never abort the batch: the row's `updated_at` is bumped so it
+/// rotates to the back of the cursor, and it is reported to the caller.
+/// Progress is logged every [`V1_PROGRESS_INTERVAL`] completions so a batch
+/// that stalls mid-flight is diagnosable from the logs alone.
+async fn process_v1_batch(
+    state: &AppState,
+    rows: &[(String, String)],
+) -> (usize, Vec<BackfillV1Failure>) {
+    let total = rows.len();
+    // Each future owns its inputs (cloned `AppState`, owned hash/key) rather
+    // than borrowing from the enclosing frame: a borrowing async block here
+    // makes the handler future fail axum's higher-ranked lifetime check.
+    let mut results = stream::iter(rows.to_vec())
+        .map(|(content_hash, r2_key)| {
+            let state = state.clone();
+            async move {
+                match compute_and_store_v1(&state, &content_hash, &r2_key).await {
+                    Ok(()) => None,
+                    Err(e) => {
+                        tracing::warn!(hash = %content_hash, "backfill-v1 failed: {e}");
+                        // Bump `updated_at` so this row rotates to the back of
+                        // the cursor and doesn't starve newer rows on the next
+                        // call. The row's `v1_hash` stays NULL, so it remains
+                        // a candidate.
+                        touch_updated_at(&state, &content_hash).await;
+                        Some(BackfillV1Failure {
+                            content_hash,
+                            error: e.to_string(),
+                        })
+                    }
+                }
+            }
+        })
+        .buffer_unordered(V1_CONCURRENCY);
+
+    let mut updated = 0usize;
+    let mut failed = Vec::new();
+    let mut done = 0usize;
+    while let Some(outcome) = results.next().await {
+        match outcome {
+            None => updated += 1,
+            Some(f) => failed.push(f),
+        }
+        done += 1;
+        if done.is_multiple_of(V1_PROGRESS_INTERVAL) && done < total {
+            tracing::info!(
+                done,
+                total,
+                updated,
+                failed = failed.len(),
+                "backfill-v1-hashes progress"
+            );
+        }
+    }
+
+    (updated, failed)
 }
 
 async fn compute_and_store_v1(

--- a/crates/tokf-server/src/routes/filters/backfill_tests.rs
+++ b/crates/tokf-server/src/routes/filters/backfill_tests.rs
@@ -368,3 +368,55 @@ async fn backfill_v1_caps_limit_at_max(pool: PgPool) {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["processed"], 0);
 }
+
+/// Batches are processed concurrently (16 in flight), so a batch larger than
+/// the concurrency window exercises more than one wave. Verify the counts and
+/// the failure list stay correct when rows complete out of submission order.
+#[crdb_test_macro::crdb_test(migrations = "./migrations")]
+async fn backfill_v1_batch_exceeding_concurrency_window(pool: PgPool) {
+    const ROWS: usize = 20;
+
+    let storage = Arc::new(InMemoryStorageClient::new());
+    let (_, user) = insert_test_user(&pool, "conc_bf").await;
+    let service_token = insert_service_token(&pool, "bf-conc").await;
+
+    let mut hashes = Vec::new();
+    for i in 0..ROWS {
+        let toml = format!("command = \"conc-tool-{i}\"\n");
+        hashes
+            .push(publish_then_null_v1(&pool, Arc::clone(&storage), &user, toml.as_bytes()).await);
+    }
+
+    // Corrupt one row in the middle so a failure has to survive interleaving
+    // with successes from both the first and second wave.
+    let failing_hash = hashes[7].clone();
+    let failing_key = r2_key_for(&pool, &failing_hash).await;
+    storage.delete(&failing_key).await.unwrap();
+
+    let app =
+        crate::routes::create_router(make_state_with_storage(pool.clone(), Arc::clone(&storage)));
+    let resp = post_json(
+        app,
+        &service_token,
+        URI,
+        &serde_json::json!({ "limit": 100 }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["processed"], ROWS);
+    assert_eq!(json["updated"], ROWS - 1);
+
+    let failed = json["failed"].as_array().unwrap();
+    assert_eq!(failed.len(), 1);
+    assert_eq!(failed[0]["content_hash"], failing_hash);
+
+    // Every healthy row got its v1_hash; only the corrupt one stayed NULL.
+    let still_null: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM filters WHERE v1_hash IS NULL")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(still_null, 1);
+}


### PR DESCRIPTION
## Problem

The `Backfill v1 Hashes` workflow only ever emitted one log line:

```
INFO tokf_server::routes::filters::backfill: backfill-v1-hashes request received candidates=329 limit=500
```

`backfill-v1-hashes complete` never appeared.

The handler wasn't hanging — it was being **cancelled**. It processed all 329 candidates serially, each one an R2 fetch + canonicalise + `UPDATE`, while the CLI gave it the default **5 second** HTTP timeout (`remote/http.rs:10`, never overridden by the workflow). The client hung up long before the batch finished, axum cancelled the handler future mid-loop, and no response was sent. `POST` isn't retried either (only GET/PUT go through `execute_idempotent`), so the CLI errored on round 1 and the operator loop could never converge.

No work was actually lost — each row commits its own `UPDATE`, so reruns resumed where the last attempt stopped. Only the response, and the `failed[]` list with it, was discarded.

## Changes

1. **Timeout** — the workflow sets `TOKF_HTTP_TIMEOUT: "300"`. This is the fix; the rest is hardening.
2. **Smaller rounds** — CLI `--limit` default 500 → 100. The command loops until the backlog drains, so a large batch only widened the window for a cancellation.
3. **Concurrency** — the serial loop becomes `process_v1_batch`, a `buffer_unordered(16)` stream. The work is I/O-bound on R2, which is where the wall-clock actually went.
4. **Progress logging** — `backfill-v1-hashes progress done=N total=M …` every 25 completions, so a stalled batch is diagnosable rather than a silent gap.

Adds a `DEPLOY.md` §10 runbook, which previously existed only as doc comments on the handler.

### Note on the concurrency change

The obvious implementation — an async block borrowing `&state` — fails axum's higher-ranked lifetime check with `implementation of FnOnce is not general enough`. Each future now owns a cloned `AppState` and owned hash/key, with a comment at the call site so it doesn't get "simplified" back.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 2410 passed
- `cargo test -p tokf-server --lib -- --ignored` against local CockroachDB — **119 passed**
- `scripts/check-file-sizes.sh` — passed, no new warnings

New test `backfill_v1_batch_exceeding_concurrency_window`: 20 rows (more than the 16-wide window) with a corrupted row at index 7, asserting `processed`/`updated` counts and the `failed[]` list stay correct when rows complete out of submission order.

Caveat: that test guards correctness of the concurrent path but would also pass under the old serial code — it's a regression guard, not proof that concurrency is engaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7fCGepMs4wjMoobLE3wKN