### PR TITLE
fix(cli): repair stdlib-publish build broken by the Runtime refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
           cargo clippy -p tokf-common --features tokenizer --all-targets -- -D warnings
           cargo clippy -p tokf --features tokenizer --all-targets -- -D warnings
 
+      # CI-only commands (publish-stdlib, backfill-*). Nothing else compiles
+      # this code, so without this step it can break on main unnoticed and only
+      # fail when an operator dispatches the workflow that needs it.
+      - name: Clippy (stdlib-publish feature)
+        run: cargo clippy -p tokf --features stdlib-publish --all-targets -- -D warnings
+
       - name: Check file sizes
         run: bash scripts/check-file-sizes.sh
 

--- a/crates/tokf-cli/src/backfill_cmd.rs
+++ b/crates/tokf-cli/src/backfill_cmd.rs
@@ -3,11 +3,12 @@ use std::process::Command;
 
 use serde::Serialize;
 use tokf::remote::http::Client;
+use tokf::runtime::Runtime;
 use tokf_common::hash::canonical_hash;
 
 /// Entry point for the `tokf backfill-versions` subcommand.
 pub fn cmd_backfill_versions(rt: &Runtime, registry_url: &str, token: &str, dry_run: bool) -> i32 {
-    match backfill_versions(registry_url, token, dry_run) {
+    match backfill_versions(rt, registry_url, token, dry_run) {
         Ok(code) => code,
         Err(e) => {
             eprintln!("[tokf] error: {e:#}");
@@ -42,7 +43,18 @@ struct BackfillResponse {
 
 // ── Core logic ──────────────────────────────────────────────────────────────
 
-fn backfill_versions(registry_url: &str, token: &str, dry_run: bool) -> anyhow::Result<i32> {
+/// The set of filters present at one release tag: `(content_hash, command_pattern)`.
+type TagFilters = Vec<(String, String)>;
+
+/// A filter snapshot per release tag, oldest tag first: `(tag, filters)`.
+type TagSnapshots = Vec<(String, TagFilters)>;
+
+fn backfill_versions(
+    rt: &Runtime,
+    registry_url: &str,
+    token: &str,
+    dry_run: bool,
+) -> anyhow::Result<i32> {
     let tags = list_release_tags()?;
     if tags.is_empty() {
         eprintln!("[backfill] No release tags found.");
@@ -51,7 +63,7 @@ fn backfill_versions(registry_url: &str, token: &str, dry_run: bool) -> anyhow::
     eprintln!("[backfill] Found {} release tags", tags.len());
 
     // Build per-tag filter snapshots.
-    let mut tag_snapshots: Vec<(String, Vec<(String, String)>)> = Vec::new();
+    let mut tag_snapshots: TagSnapshots = Vec::new();
     for tag in &tags {
         let filters = list_filters_at_tag(tag)?;
         eprintln!("[backfill]   {tag}: {} filters", filters.len());
@@ -66,15 +78,13 @@ fn backfill_versions(registry_url: &str, token: &str, dry_run: bool) -> anyhow::
     );
 
     if dry_run {
-        let payload = serde_json::to_string_pretty(&BackfillVersionsRequest {
-            entries: entries.clone(),
-        })?;
+        let payload = serde_json::to_string_pretty(&BackfillVersionsRequest { entries })?;
         println!("{payload}");
         eprintln!("[backfill] Dry run — payload printed above.");
         return Ok(0);
     }
 
-    let client = Client::new(registry_url, Some(token))?;
+    let client = Client::new(rt, registry_url, Some(token))?;
     let resp = client.post::<_, BackfillResponse>(
         "/api/filters/backfill-versions",
         &BackfillVersionsRequest { entries },
@@ -130,7 +140,7 @@ fn compare_semver(a: &str, b: &str) -> std::cmp::Ordering {
 /// List filter TOML files at a given git tag and compute their content hashes.
 ///
 /// Returns `Vec<(content_hash, command_pattern)>`.
-fn list_filters_at_tag(tag: &str) -> anyhow::Result<Vec<(String, String)>> {
+fn list_filters_at_tag(tag: &str) -> anyhow::Result<TagFilters> {
     // Try workspace path first; fall back to pre-workspace path when empty.
     // `git ls-tree` returns exit 0 with empty output for non-existent paths,
     // so we check `is_empty()` rather than relying on `or_else`.
@@ -141,14 +151,12 @@ fn list_filters_at_tag(tag: &str) -> anyhow::Result<Vec<(String, String)>> {
 
     let mut results = Vec::new();
     for path in &paths {
-        if let Ok(content) = git_show(tag, path) {
-            if let Ok(config) = toml::from_str::<tokf_common::config::types::FilterConfig>(&content)
-            {
-                if let Ok(hash) = canonical_hash(&config) {
-                    let cmd_pattern = config.command.first().to_string();
-                    results.push((hash, cmd_pattern));
-                }
-            }
+        if let Ok(content) = git_show(tag, path)
+            && let Ok(config) = toml::from_str::<tokf_common::config::types::FilterConfig>(&content)
+            && let Ok(hash) = canonical_hash(&config)
+        {
+            let cmd_pattern = config.command.first().to_string();
+            results.push((hash, cmd_pattern));
         }
     }
     Ok(results)
@@ -164,7 +172,12 @@ fn list_filter_paths_at_tag(tag: &str, prefix: &str) -> anyhow::Result<Vec<Strin
     let text = String::from_utf8(output.stdout)?;
     Ok(text
         .lines()
-        .filter(|l| l.ends_with(".toml") && !l.contains("_test/"))
+        .filter(|l| {
+            std::path::Path::new(l)
+                .extension()
+                .is_some_and(|e| e.eq_ignore_ascii_case("toml"))
+                && !l.contains("_test/")
+        })
         .map(String::from)
         .collect())
 }
@@ -181,11 +194,11 @@ fn git_show(tag: &str, path: &str) -> anyhow::Result<String> {
 
 /// Compute version timeline from tag snapshots.
 ///
-/// For each unique content_hash, determines:
+/// For each unique `content_hash`, determines:
 /// - `introduced_at`: first tag where this hash appears
 /// - `deprecated_at`: first tag where this hash disappears (and a successor exists)
-/// - `successor_hash`: the hash with the same command_pattern at `deprecated_at`
-fn compute_version_timeline(snapshots: &[(String, Vec<(String, String)>)]) -> Vec<BackfillEntry> {
+/// - `successor_hash`: the hash with the same `command_pattern` at `deprecated_at`
+fn compute_version_timeline(snapshots: &[(String, TagFilters)]) -> Vec<BackfillEntry> {
     // Track: hash -> (first_seen_version, command_pattern)
     let mut first_seen: BTreeMap<String, (String, String)> = BTreeMap::new();
     // Track: hash -> (deprecated_version, successor_hash)
@@ -249,7 +262,7 @@ const MAX_V1_ROUNDS: usize = 10_000;
 
 /// Entry point for the `tokf backfill-v1-hashes` subcommand.
 pub fn cmd_backfill_v1_hashes(rt: &Runtime, registry_url: &str, token: &str, limit: usize) -> i32 {
-    match backfill_v1_hashes(registry_url, token, limit) {
+    match backfill_v1_hashes(rt, registry_url, token, limit) {
         Ok(code) => code,
         Err(e) => {
             eprintln!("[tokf] error: {e:#}");
@@ -289,8 +302,13 @@ struct BackfillV1Response {
 /// server-side, so the caller must raise `TOKF_HTTP_TIMEOUT` well above the 5s
 /// default — otherwise the request is cancelled mid-batch and the round fails
 /// even though the server made progress. The backfill workflow sets it to 300.
-fn backfill_v1_hashes(registry_url: &str, token: &str, limit: usize) -> anyhow::Result<i32> {
-    let client = Client::new(registry_url, Some(token))?;
+fn backfill_v1_hashes(
+    rt: &Runtime,
+    registry_url: &str,
+    token: &str,
+    limit: usize,
+) -> anyhow::Result<i32> {
+    let client = Client::new(rt, registry_url, Some(token))?;
     let mut total_updated = 0usize;
 
     for round in 1..=MAX_V1_ROUNDS {

--- a/crates/tokf-cli/src/publish_stdlib_cmd.rs
+++ b/crates/tokf-cli/src/publish_stdlib_cmd.rs
@@ -4,10 +4,11 @@ use serde::{Deserialize, Serialize};
 
 use tokf::publish_shared::collect_test_files_resolved;
 use tokf::remote::http::Client;
+use tokf::runtime::Runtime;
 
 /// Entry point for the `tokf publish-stdlib` subcommand.
 pub fn cmd_publish_stdlib(rt: &Runtime, registry_url: &str, token: &str, dry_run: bool) -> i32 {
-    match publish_stdlib(registry_url, token, dry_run) {
+    match publish_stdlib(rt, registry_url, token, dry_run) {
         Ok(code) => code,
         Err(e) => {
             eprintln!("[tokf] error: {e:#}");
@@ -52,7 +53,12 @@ struct StdlibFailure {
 
 // ── Core logic ──────────────────────────────────────────────────────────────
 
-fn publish_stdlib(registry_url: &str, token: &str, dry_run: bool) -> anyhow::Result<i32> {
+fn publish_stdlib(
+    rt: &Runtime,
+    registry_url: &str,
+    token: &str,
+    dry_run: bool,
+) -> anyhow::Result<i32> {
     let filters_dir = Path::new("crates/tokf-cli/filters");
     if !filters_dir.is_dir() {
         anyhow::bail!(
@@ -82,7 +88,7 @@ fn publish_stdlib(registry_url: &str, token: &str, dry_run: bool) -> anyhow::Res
         return Ok(0);
     }
 
-    let client = Client::new(registry_url, Some(token))?;
+    let client = Client::new(rt, registry_url, Some(token))?;
     let tally = publish_entries_one_by_one(&client, entries, &version);
 
     eprintln!();
@@ -201,7 +207,7 @@ fn collect_stdlib_entries(filters_dir: &Path) -> anyhow::Result<Vec<StdlibFilter
     Ok(entries)
 }
 
-fn count_test_files(files: &[StdlibTestFile]) -> usize {
+const fn count_test_files(files: &[StdlibTestFile]) -> usize {
     files.len()
 }
 


### PR DESCRIPTION
## Problem

`main` does not compile with `--features stdlib-publish`. Reproduce on a clean checkout of `main`:

```sh
cargo check -p tokf --features stdlib-publish
# error[E0425]: cannot find type `Runtime` in this scope  (×3)
# error[E0061]: this function takes 3 arguments but 2 arguments were supplied  (×3)
```

#432 threaded an explicit `Runtime` through the CLI, adding `rt: &Runtime` to `Client::new` and to the entry points in `backfill_cmd.rs` and `publish_stdlib_cmd.rs` — but not the `use` for `Runtime`, nor the argument at the `Client::new` call sites.

Both modules are behind `#[cfg(feature = "stdlib-publish")]`. CI runs clippy for `otel`, `otel-grpc`, and `tokenizer`, but never `stdlib-publish` — so this code is compiled by nothing in the pipeline. The only consumers are `workflow_dispatch` jobs (`publish-stdlib`, `backfill-v1-hashes`), so the breakage surfaced as a failed operator run rather than a red PR.

Found while running the backfill from #433.

## Changes

- Import `Runtime` and thread `rt` through to the `Client::new` calls in both modules, matching the existing pattern in `publish_cmd.rs`.
- Clear the lints this code accumulated while nothing was linting it: a redundant clone, a redundant field name, a case-sensitive `.toml` extension comparison, and two `Vec<(String, Vec<(String, String)>)>` types (now the `TagFilters` / `TagSnapshots` aliases).
- **Add a `Clippy (stdlib-publish feature)` CI step** — this is the part that stops it recurring. Comment at the step explains why it exists.

## Verification

- `cargo clippy -p tokf --features stdlib-publish --all-targets -- -D warnings` — clean (previously: 6 compile errors)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test -p tokf --features stdlib-publish` — 1748 passed
- `cargo test --workspace` — 2441 passed

No behaviour change — the fix is purely making already-intended code compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7fCGepMs4wjMoobLE3wKN