### PR TITLE
fix(hook): propagate --no-mask-exit-code into hook-generated rewrites (#414)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ This copies the filter TOML and its test suite to your config directory, where i
 | `--verbose` | Show which filter was matched (also explains skipped rewrites) |
 | `--no-filter` | Pass output through without filtering |
 | `--no-cache` | Bypass the filter discovery cache |
-| `--no-mask-exit-code` | Disable exit-code masking. By default tokf exits 0 and prepends `Error: Exit code N` on failure |
+| `--no-mask-exit-code` | Disable exit-code masking. By default tokf exits 0 and prepends `Error: Exit code N` on failure. Also propagates into hook-emitted `tokf run` rewrites (`tokf hook --no-mask-exit-code handle`), including each segment of compound `&&`/`;`/`\|\|` commands |
 | `--preserve-color` | Preserve ANSI color codes in filtered output (env: `TOKF_PRESERVE_COLOR=1`). See [Color passthrough](#color-passthrough) below |
 | `--baseline-pipe` | Pipe command for fair baseline accounting (injected by rewrite) |
 | `--prefer-less` | Compare filtered vs piped output and use whichever is smaller (requires `--baseline-pipe`) |

--- a/crates/tokf-cli/src/commands.rs
+++ b/crates/tokf-cli/src/commands.rs
@@ -555,12 +555,17 @@ pub fn cmd_skill_install(rt: &Runtime, global: bool) -> i32 {
     }
 }
 
-pub fn cmd_hook_handle(rt: &Runtime, format: &HookFormat, no_cache: bool) -> i32 {
+pub fn cmd_hook_handle(
+    rt: &Runtime,
+    format: &HookFormat,
+    no_cache: bool,
+    no_mask_exit_code: bool,
+) -> i32 {
     let outcome = match format {
-        HookFormat::ClaudeCode => hook::handle(rt, no_cache),
-        HookFormat::Gemini => hook::handle_gemini(rt, no_cache),
-        HookFormat::Cursor => hook::handle_cursor(rt, no_cache),
-        HookFormat::Codex => hook::handle_codex(rt, no_cache),
+        HookFormat::ClaudeCode => hook::handle(rt, no_cache, no_mask_exit_code),
+        HookFormat::Gemini => hook::handle_gemini(rt, no_cache, no_mask_exit_code),
+        HookFormat::Cursor => hook::handle_cursor(rt, no_cache, no_mask_exit_code),
+        HookFormat::Codex => hook::handle_codex(rt, no_cache, no_mask_exit_code),
     };
     hook_outcome_exit_code(format, outcome)
 }

--- a/crates/tokf-cli/src/hook/mod.rs
+++ b/crates/tokf-cli/src/hook/mod.rs
@@ -95,37 +95,44 @@ impl CodexRewriteMode {
 ///
 /// Returns the outcome of the hook (allow/ask/deny/pass-through).
 /// Errors are intentionally swallowed to never block commands.
-pub fn handle(rt: &Runtime, no_cache: bool) -> HookOutcome {
-    handle_from_reader_with_cache(rt, &mut std::io::stdin(), no_cache)
+pub fn handle(rt: &Runtime, no_cache: bool, no_mask_exit_code: bool) -> HookOutcome {
+    handle_from_reader_with_cache(rt, &mut std::io::stdin(), no_cache, no_mask_exit_code)
 }
 
 fn handle_from_reader_with_cache<R: Read>(
     rt: &Runtime,
     reader: &mut R,
     no_cache: bool,
+    no_mask_exit_code: bool,
 ) -> HookOutcome {
     let mut input = String::new();
     if reader.read_to_string(&mut input).is_err() {
         return HookOutcome::PassThrough;
     }
 
-    handle_json_with_cache(rt, &input, no_cache)
+    handle_json_with_cache(rt, &input, no_cache, no_mask_exit_code)
 }
 
 /// Core handle logic operating on a JSON string.
 #[cfg(test)]
 pub(crate) fn handle_json(json: &str) -> HookOutcome {
     let rt = &Runtime::isolated();
-    handle_json_with_cache(rt, json, false)
+    handle_json_with_cache(rt, json, false, false)
 }
 
-fn handle_json_with_cache(rt: &Runtime, json: &str, no_cache: bool) -> HookOutcome {
+fn handle_json_with_cache(
+    rt: &Runtime,
+    json: &str,
+    no_cache: bool,
+    no_mask_exit_code: bool,
+) -> HookOutcome {
     handle_with_autodiscovery(
         rt,
         json,
         "Bash",
         HookFormat::ClaudeCode,
         no_cache,
+        no_mask_exit_code,
         HookResponse::rewrite,
         HookResponse::rewrite_ask,
         HookResponse::deny,
@@ -150,6 +157,7 @@ pub(crate) fn handle_json_with_rules(
         user_config,
         search_dirs,
         false,
+        false,
         HookResponse::rewrite,
         HookResponse::rewrite_ask,
         HookResponse::deny,
@@ -159,28 +167,34 @@ pub(crate) fn handle_json_with_rules(
 }
 
 /// Process a Gemini CLI `BeforeTool` hook invocation.
-pub fn handle_gemini(rt: &Runtime, no_cache: bool) -> HookOutcome {
+pub fn handle_gemini(rt: &Runtime, no_cache: bool, no_mask_exit_code: bool) -> HookOutcome {
     let mut input = String::new();
     if std::io::stdin().read_to_string(&mut input).is_err() {
         return HookOutcome::PassThrough;
     }
-    handle_gemini_json_with_cache(rt, &input, no_cache)
+    handle_gemini_json_with_cache(rt, &input, no_cache, no_mask_exit_code)
 }
 
 /// Core Gemini handle logic operating on a JSON string.
 #[cfg(test)]
 pub(crate) fn handle_gemini_json(json: &str) -> HookOutcome {
     let rt = &Runtime::isolated();
-    handle_gemini_json_with_cache(rt, json, false)
+    handle_gemini_json_with_cache(rt, json, false, false)
 }
 
-fn handle_gemini_json_with_cache(rt: &Runtime, json: &str, no_cache: bool) -> HookOutcome {
+fn handle_gemini_json_with_cache(
+    rt: &Runtime,
+    json: &str,
+    no_cache: bool,
+    no_mask_exit_code: bool,
+) -> HookOutcome {
     handle_with_autodiscovery(
         rt,
         json,
         "run_shell_command",
         HookFormat::Gemini,
         no_cache,
+        no_mask_exit_code,
         GeminiHookResponse::rewrite,
         GeminiHookResponse::rewrite_ask,
         GeminiHookResponse::deny,
@@ -205,6 +219,7 @@ pub(crate) fn handle_gemini_json_with_rules(
         user_config,
         search_dirs,
         false,
+        false,
         GeminiHookResponse::rewrite,
         GeminiHookResponse::rewrite_ask,
         GeminiHookResponse::deny,
@@ -222,6 +237,7 @@ fn handle_with_autodiscovery<R: serde::Serialize>(
     expected_tool: &str,
     format: HookFormat,
     no_cache: bool,
+    no_mask_exit_code: bool,
     build_allow: impl FnOnce(String, Option<String>) -> R,
     build_ask: impl FnOnce(String, Option<String>) -> R,
     build_deny: impl FnOnce(String, Option<String>) -> R,
@@ -238,6 +254,7 @@ fn handle_with_autodiscovery<R: serde::Serialize>(
         &user_config,
         &search_dirs,
         no_cache,
+        no_mask_exit_code,
         build_allow,
         build_ask,
         build_deny,
@@ -247,12 +264,12 @@ fn handle_with_autodiscovery<R: serde::Serialize>(
 }
 
 /// Process a Cursor `preToolUse` hook invocation.
-pub fn handle_cursor(rt: &Runtime, no_cache: bool) -> HookOutcome {
+pub fn handle_cursor(rt: &Runtime, no_cache: bool, no_mask_exit_code: bool) -> HookOutcome {
     let mut input = String::new();
     if std::io::stdin().read_to_string(&mut input).is_err() {
         return HookOutcome::PassThrough;
     }
-    handle_cursor_json_with_cache(rt, &input, no_cache)
+    handle_cursor_json_with_cache(rt, &input, no_cache, no_mask_exit_code)
 }
 
 /// Core Cursor handle logic operating on a JSON string.
@@ -262,13 +279,25 @@ pub fn handle_cursor(rt: &Runtime, no_cache: bool) -> HookOutcome {
 #[cfg(test)]
 pub(crate) fn handle_cursor_json(json: &str) -> HookOutcome {
     let rt = &Runtime::isolated();
-    handle_cursor_json_with_cache(rt, json, false)
+    handle_cursor_json_with_cache(rt, json, false, false)
 }
 
-fn handle_cursor_json_with_cache(rt: &Runtime, json: &str, no_cache: bool) -> HookOutcome {
+fn handle_cursor_json_with_cache(
+    rt: &Runtime,
+    json: &str,
+    no_cache: bool,
+    no_mask_exit_code: bool,
+) -> HookOutcome {
     let user_config = rewrite::load_user_config(rt).unwrap_or_default();
     let search_dirs = crate::config::default_search_dirs(rt);
-    handle_cursor_json_inner(rt, json, &user_config, &search_dirs, no_cache)
+    handle_cursor_json_inner(
+        rt,
+        json,
+        &user_config,
+        &search_dirs,
+        no_cache,
+        no_mask_exit_code,
+    )
 }
 
 /// Fully injectable Cursor handle logic with explicit config (hermetic).
@@ -279,33 +308,45 @@ pub(crate) fn handle_cursor_json_with_rules(
     search_dirs: &[PathBuf],
 ) -> HookOutcome {
     let rt = &Runtime::isolated();
-    handle_cursor_json_inner(rt, json, user_config, search_dirs, false)
+    handle_cursor_json_inner(rt, json, user_config, search_dirs, false, false)
 }
 
 /// Process an `OpenAI` Codex CLI `PreToolUse` hook invocation.
-pub fn handle_codex(rt: &Runtime, no_cache: bool) -> HookOutcome {
+pub fn handle_codex(rt: &Runtime, no_cache: bool, no_mask_exit_code: bool) -> HookOutcome {
     let mut input = String::new();
     if std::io::stdin().read_to_string(&mut input).is_err() {
         return HookOutcome::PassThrough;
     }
-    handle_codex_json_with_cache(rt, &input, no_cache)
+    handle_codex_json_with_cache(rt, &input, no_cache, no_mask_exit_code)
 }
 
 /// Core Codex handle logic operating on a JSON string.
 #[cfg(test)]
 pub(crate) fn handle_codex_json(json: &str) -> HookOutcome {
     let rt = &Runtime::isolated();
-    handle_codex_json_with_cache(rt, json, false)
+    handle_codex_json_with_cache(rt, json, false, false)
 }
 
-fn handle_codex_json_with_cache(rt: &Runtime, json: &str, no_cache: bool) -> HookOutcome {
-    handle_codex_json_with_mode(rt, json, no_cache, CodexRewriteMode::from_runtime(rt))
+fn handle_codex_json_with_cache(
+    rt: &Runtime,
+    json: &str,
+    no_cache: bool,
+    no_mask_exit_code: bool,
+) -> HookOutcome {
+    handle_codex_json_with_mode(
+        rt,
+        json,
+        no_cache,
+        no_mask_exit_code,
+        CodexRewriteMode::from_runtime(rt),
+    )
 }
 
 fn handle_codex_json_with_mode(
     rt: &Runtime,
     json: &str,
     no_cache: bool,
+    no_mask_exit_code: bool,
     mode: CodexRewriteMode,
 ) -> HookOutcome {
     match mode {
@@ -315,6 +356,7 @@ fn handle_codex_json_with_mode(
             "Bash",
             HookFormat::Codex,
             no_cache,
+            no_mask_exit_code,
             CodexHookResponse::rewrite,
             CodexHookResponse::rewrite_ask,
             CodexHookResponse::deny,
@@ -327,6 +369,7 @@ fn handle_codex_json_with_mode(
             "Bash",
             HookFormat::Codex,
             no_cache,
+            no_mask_exit_code,
             CodexHookResponse::rewrite_deny_rerun,
             CodexHookResponse::rewrite_ask,
             CodexHookResponse::deny,
@@ -337,12 +380,14 @@ fn handle_codex_json_with_mode(
 }
 
 /// Cursor handle logic with explicit permission rules.
+#[allow(clippy::too_many_arguments)]
 fn handle_cursor_json_inner(
     rt: &Runtime,
     json: &str,
     user_config: &RewriteConfig,
     search_dirs: &[PathBuf],
     no_cache: bool,
+    no_mask_exit_code: bool,
 ) -> HookOutcome {
     let Ok(input) = serde_json::from_str::<CursorInput>(json) else {
         return HookOutcome::PassThrough;
@@ -361,6 +406,7 @@ fn handle_cursor_json_inner(
         user_config,
         search_dirs,
         no_cache,
+        no_mask_exit_code,
         CursorHookResponse::rewrite,
         CursorHookResponse::rewrite_ask,
         CursorHookResponse::deny,
@@ -418,6 +464,7 @@ fn handle_generic<R: serde::Serialize>(
     user_config: &RewriteConfig,
     search_dirs: &[PathBuf],
     no_cache: bool,
+    no_mask_exit_code: bool,
     build_allow: impl FnOnce(String, Option<String>) -> R,
     build_ask: impl FnOnce(String, Option<String>) -> R,
     build_deny: impl FnOnce(String, Option<String>) -> R,
@@ -445,6 +492,7 @@ fn handle_generic<R: serde::Serialize>(
         user_config,
         search_dirs,
         no_cache,
+        no_mask_exit_code,
         build_allow,
         build_ask,
         build_deny,
@@ -469,6 +517,7 @@ fn process_command<R: serde::Serialize>(
     user_config: &RewriteConfig,
     search_dirs: &[PathBuf],
     no_cache: bool,
+    no_mask_exit_code: bool,
     build_allow: impl FnOnce(String, Option<String>) -> R,
     build_ask: impl FnOnce(String, Option<String>) -> R,
     build_deny: impl FnOnce(String, Option<String>) -> R,
@@ -483,6 +532,7 @@ fn process_command<R: serde::Serialize>(
         user_config,
         search_dirs,
         no_cache,
+        no_mask_exit_code,
         build_allow,
         build_ask,
         build_deny,
@@ -514,12 +564,17 @@ fn decide<R: serde::Serialize>(
     user_config: &RewriteConfig,
     search_dirs: &[PathBuf],
     no_cache: bool,
+    no_mask_exit_code: bool,
     build_allow: impl FnOnce(String, Option<String>) -> R,
     build_ask: impl FnOnce(String, Option<String>) -> R,
     build_deny: impl FnOnce(String, Option<String>) -> R,
     allow_outcome: HookOutcome,
     ask_outcome: HookOutcome,
 ) -> (HookOutcome, Option<String>) {
+    // Propagate `tokf hook --no-mask-exit-code handle` into every generated
+    // `tokf run` invocation (including each member of a compound command) —
+    // otherwise the flag is silently dropped and exit codes stay masked (#414).
+    let options = rewrite::types::RewriteOptions { no_mask_exit_code };
     // When an external permission engine is configured, consult it on every
     // command — even ones tokf has no filter for.
     if let Some(verdict) = query_external_engine(rt, command, json, format, user_config) {
@@ -530,7 +585,7 @@ fn decide<R: serde::Serialize>(
             }
             return (HookOutcome::PassThrough, None);
         }
-        let rewritten = rewrite::rewrite_with_config(
+        let rewritten = rewrite::rewrite_with_config_and_options(
             rewrite::RewriteCtx {
                 rt,
                 user_config,
@@ -538,6 +593,7 @@ fn decide<R: serde::Serialize>(
             },
             command,
             no_cache,
+            &options,
         );
         let rewrite_changed = rewritten != command;
         let output_cmd = if rewrite_changed {
@@ -564,7 +620,7 @@ fn decide<R: serde::Serialize>(
     }
 
     // No external engine — only act when tokf has a matching filter.
-    let rewritten = rewrite::rewrite_with_config(
+    let rewritten = rewrite::rewrite_with_config_and_options(
         rewrite::RewriteCtx {
             rt,
             user_config,
@@ -572,6 +628,7 @@ fn decide<R: serde::Serialize>(
         },
         command,
         no_cache,
+        &options,
     );
     if rewritten == command {
         return (HookOutcome::PassThrough, None);

--- a/crates/tokf-cli/src/main.rs
+++ b/crates/tokf-cli/src/main.rs
@@ -137,7 +137,9 @@ fn main() {
             eject_cmd::cmd_eject(&rt, filter, *global, cli.no_cache)
         }
         Commands::Hook { action } => match action {
-            HookAction::Handle { format } => cmd_hook_handle(&rt, format, cli.no_cache),
+            HookAction::Handle { format } => {
+                cmd_hook_handle(&rt, format, cli.no_cache, cli.no_mask_exit_code)
+            }
             HookAction::Install {
                 global,
                 tool,

--- a/crates/tokf-cli/src/rewrite/mod.rs
+++ b/crates/tokf-cli/src/rewrite/mod.rs
@@ -300,11 +300,6 @@ pub(crate) struct RewriteCtx<'a> {
     pub search_dirs: &'a [PathBuf],
 }
 
-/// Testable version with explicit config and search dirs (default options).
-pub(crate) fn rewrite_with_config(ctx: RewriteCtx<'_>, command: &str, verbose: bool) -> String {
-    rewrite_with_config_and_options(ctx, command, verbose, &RewriteOptions::default())
-}
-
 /// Testable version with explicit config, search dirs, and rewrite options.
 pub(crate) fn rewrite_with_config_and_options(
     ctx: RewriteCtx<'_>,

--- a/crates/tokf-cli/tests/cli_hook_handle.rs
+++ b/crates/tokf-cli/tests/cli_hook_handle.rs
@@ -504,6 +504,55 @@ fn hook_handle_stdlib_yarn_test_rewrites() {
     );
 }
 
+// --- --no-mask-exit-code propagation into hook rewrites (regression for #414) ---
+
+/// Issue #414: `tokf --no-mask-exit-code hook handle` must propagate the flag
+/// into the emitted `tokf run` rewrite, not silently drop it.
+#[test]
+fn hook_handle_no_mask_exit_code_propagates_to_rewrite() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let json = r#"{"tool_name":"Bash","tool_input":{"command":"git status"}}"#;
+    let (stdout, _stderr, success) =
+        hook_handle_format_with_args(dir.path(), json, &["--no-mask-exit-code", "hook", "handle"]);
+    assert!(success);
+
+    let response: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(
+        response["hookSpecificOutput"]["updatedInput"]["command"],
+        "tokf run --no-mask-exit-code git status"
+    );
+}
+
+/// Issue #414: every member of a compound command must carry the flag.
+#[test]
+fn hook_handle_no_mask_exit_code_propagates_to_compound() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let json = r#"{"tool_name":"Bash","tool_input":{"command":"git status && cargo test"}}"#;
+    let (stdout, _stderr, success) =
+        hook_handle_format_with_args(dir.path(), json, &["--no-mask-exit-code", "hook", "handle"]);
+    assert!(success);
+
+    let response: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(
+        response["hookSpecificOutput"]["updatedInput"]["command"],
+        "tokf run --no-mask-exit-code git status && tokf run --no-mask-exit-code cargo test"
+    );
+}
+
+/// Sanity: without the flag, the default masking behavior is unchanged.
+#[test]
+fn hook_handle_default_still_masks() {
+    let json = r#"{"tool_name":"Bash","tool_input":{"command":"git status"}}"#;
+    let (stdout, success) = hook_handle_with_stdlib(json);
+    assert!(success);
+
+    let response: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(
+        response["hookSpecificOutput"]["updatedInput"]["command"],
+        "tokf run git status"
+    );
+}
+
 // --- External permission engine ask verdict (regression for #343) ---
 
 /// Regression for #343: when the external permission engine returns an "ask"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -126,7 +126,7 @@ This copies the filter TOML and its test suite to your config directory, where i
 | `--verbose` | Show which filter was matched (also explains skipped rewrites) |
 | `--no-filter` | Pass output through without filtering |
 | `--no-cache` | Bypass the filter discovery cache |
-| `--no-mask-exit-code` | Disable exit-code masking. By default tokf exits 0 and prepends `Error: Exit code N` on failure |
+| `--no-mask-exit-code` | Disable exit-code masking. By default tokf exits 0 and prepends `Error: Exit code N` on failure. Also propagates into hook-emitted `tokf run` rewrites (`tokf hook --no-mask-exit-code handle`), including each segment of compound `&&`/`;`/`\|\|` commands |
 | `--preserve-color` | Preserve ANSI color codes in filtered output (env: `TOKF_PRESERVE_COLOR=1`). See [Color passthrough](#color-passthrough) below |
 | `--baseline-pipe` | Pipe command for fair baseline accounting (injected by rewrite) |
 | `--prefer-less` | Compare filtered vs piped output and use whichever is smaller (requires `--baseline-pipe`) |


### PR DESCRIPTION
Closes #414

## Summary
`tokf hook --no-mask-exit-code handle` silently dropped the flag when generating `tokf run` invocations from a `PreToolUse` hook, so exit codes stayed masked even after the user explicitly opted out of masking. This threads `no_mask_exit_code` through the hook handler chain (Claude Code, Gemini, Cursor, Codex) into `rewrite_with_config_and_options`, so it is applied to every generated `tokf run` invocation, including each member of a compound `&&`/`;`/`||` command.

## Test plan
- `cargo test --workspace hook` — 240 passed, 0 failed (54 suites), including 37 in `tests/cli_hook_handle.rs` covering the new behaviour
- `cargo fmt -- --check` / `cargo clippy` run via pre-commit hooks during commit — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)