### PR TITLE
fix(hook): stop --no-cache from enabling verbose rewrite diagnostics (#431)

### DIFF
--- a/crates/tokf-cli/src/hook/mod.rs
+++ b/crates/tokf-cli/src/hook/mod.rs
@@ -575,6 +575,22 @@ fn decide<R: serde::Serialize>(
     // `tokf run` invocation (including each member of a compound command) —
     // otherwise the flag is silently dropped and exit codes stay masked (#414).
     let options = rewrite::types::RewriteOptions { no_mask_exit_code };
+    // `verbose` is `false`: hook rewrites must not emit diagnostics to the
+    // agent's stderr, and `no_cache` rides in `RewriteCtx`, not the old
+    // positional bool that used to be mistaken for it (#431).
+    let rewrite_cmd = |cmd: &str| {
+        rewrite::rewrite_with_config_and_options(
+            rewrite::RewriteCtx {
+                rt,
+                user_config,
+                search_dirs,
+                no_cache,
+            },
+            cmd,
+            false,
+            &options,
+        )
+    };
     // When an external permission engine is configured, consult it on every
     // command — even ones tokf has no filter for.
     if let Some(verdict) = query_external_engine(rt, command, json, format, user_config) {
@@ -585,16 +601,7 @@ fn decide<R: serde::Serialize>(
             }
             return (HookOutcome::PassThrough, None);
         }
-        let rewritten = rewrite::rewrite_with_config_and_options(
-            rewrite::RewriteCtx {
-                rt,
-                user_config,
-                search_dirs,
-            },
-            command,
-            no_cache,
-            &options,
-        );
+        let rewritten = rewrite_cmd(command);
         let rewrite_changed = rewritten != command;
         let output_cmd = if rewrite_changed {
             rewritten
@@ -620,16 +627,7 @@ fn decide<R: serde::Serialize>(
     }
 
     // No external engine — only act when tokf has a matching filter.
-    let rewritten = rewrite::rewrite_with_config_and_options(
-        rewrite::RewriteCtx {
-            rt,
-            user_config,
-            search_dirs,
-        },
-        command,
-        no_cache,
-        &options,
-    );
+    let rewritten = rewrite_cmd(command);
     if rewritten == command {
         return (HookOutcome::PassThrough, None);
     }

--- a/crates/tokf-cli/src/rewrite/mod.rs
+++ b/crates/tokf-cli/src/rewrite/mod.rs
@@ -55,10 +55,15 @@ fn build_wrapper_rules() -> Vec<RewriteRule> {
 /// These patterns are matched using [`config::pattern_matches_prefix`] — the
 /// same authoritative matching logic used by `tokf run` and `tokf which` — so
 /// that `tokf -c` (shell mode) and `tokf rewrite` produce identical results.
-fn collect_filter_patterns(rt: &Runtime, search_dirs: &[PathBuf]) -> Vec<String> {
+fn collect_filter_patterns(rt: &Runtime, search_dirs: &[PathBuf], no_cache: bool) -> Vec<String> {
     let mut patterns = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let Ok(filters) = config::cache::discover_with_cache(rt, search_dirs) else {
+    let discovered = if no_cache {
+        config::discover_all_filters(search_dirs)
+    } else {
+        config::cache::discover_with_cache(rt, search_dirs)
+    };
+    let Ok(filters) = discovered else {
         return patterns;
     };
     for filter in filters {
@@ -132,6 +137,10 @@ pub fn rewrite_with_options(
             rt,
             user_config: &user_config,
             search_dirs: &config::default_search_dirs(rt),
+            // `--no-cache` is not threaded through the `tokf rewrite` subcommand
+            // or the `tokf -c` shell path yet (see #431 follow-up); those callers
+            // always use the cache. The hook path sets this explicitly.
+            no_cache: false,
         },
         command,
         verbose,
@@ -298,6 +307,11 @@ pub(crate) struct RewriteCtx<'a> {
     pub rt: &'a Runtime,
     pub user_config: &'a RewriteConfig,
     pub search_dirs: &'a [PathBuf],
+    /// Bypass the on-disk filter discovery cache (honours `--no-cache`).
+    /// Kept in the context — rather than as a positional `bool` argument next to
+    /// `verbose` — so call sites name the flag and can't silently swap the two
+    /// (the exact footgun behind #431).
+    pub no_cache: bool,
 }
 
 /// Testable version with explicit config, search dirs, and rewrite options.
@@ -307,11 +321,7 @@ pub(crate) fn rewrite_with_config_and_options(
     verbose: bool,
     options: &RewriteOptions,
 ) -> String {
-    let RewriteCtx {
-        rt,
-        user_config,
-        search_dirs,
-    } = ctx;
+    let user_config = ctx.user_config;
     let user_skip_patterns = user_config
         .skip
         .as_ref()
@@ -342,7 +352,7 @@ pub(crate) fn rewrite_with_config_and_options(
     }
 
     let wrapper_rules = build_wrapper_rules();
-    let filter_patterns = collect_filter_patterns(rt, search_dirs);
+    let filter_patterns = collect_filter_patterns(ctx.rt, ctx.search_dirs, ctx.no_cache);
     let local_wrapper = user_config.local_wrapper.clone().unwrap_or_default();
     let log_parse_failures = user_config
         .debug
@@ -422,6 +432,7 @@ pub(crate) fn rewrite_isolated_with_options(
             rt: &rt,
             user_config,
             search_dirs,
+            no_cache: false,
         },
         command,
         verbose,
@@ -432,7 +443,7 @@ pub(crate) fn rewrite_isolated_with_options(
 #[cfg(test)]
 pub(crate) fn collect_filter_patterns_isolated(search_dirs: &[PathBuf]) -> Vec<String> {
     let rt = Runtime::isolated();
-    collect_filter_patterns(&rt, search_dirs)
+    collect_filter_patterns(&rt, search_dirs, false)
 }
 
 #[cfg(test)]

--- a/crates/tokf-cli/tests/cli_hook_handle.rs
+++ b/crates/tokf-cli/tests/cli_hook_handle.rs
@@ -236,6 +236,32 @@ fn hook_handle_no_cache_skips_project_cache_for_matching_command() {
 }
 
 #[test]
+fn hook_handle_no_cache_does_not_enable_verbose_pipe_diagnostics() {
+    // Regression for #431: --no-cache was mis-mapped into rewrite's `verbose`
+    // parameter, so the hook path silently emitted `[tokf] stripped pipe …`
+    // diagnostics to stderr. --no-cache must not enable verbose rewrite
+    // diagnostics on stderr.
+    let dir = tempfile::TempDir::new().unwrap();
+    let json = r#"{"tool_name":"Bash","tool_input":{"command":"cargo test | grep FAILED"}}"#;
+
+    let (stdout, stderr, success) = hook_handle_format_with_args(
+        dir.path(),
+        json,
+        &["--no-cache", "hook", "handle", "--format", "claude-code"],
+    );
+
+    assert!(success);
+    assert!(
+        stderr.trim().is_empty(),
+        "--no-cache must not enable verbose rewrite diagnostics on stderr, got: {stderr}"
+    );
+    assert!(
+        stdout.contains("tokf run --baseline-pipe 'grep FAILED' cargo test"),
+        "expected the pipe rewrite to still work, got: {stdout}"
+    );
+}
+
+#[test]
 fn hook_handle_non_bash_tool_silent() {
     let json = r#"{"tool_name":"Read","tool_input":{"file_path":"/tmp/foo"}}"#;
     let (stdout, success) = hook_handle_with_stdlib(json);


### PR DESCRIPTION
Closes #431

## Summary
`tokf hook handle --no-cache` mis-mapped the `no_cache` flag into `rewrite`'s positional `verbose` parameter, causing `--no-cache` to silently enable `[tokf] stripped pipe …` verbose diagnostics on stderr. `no_cache` is now threaded through `RewriteCtx` as a named field (instead of a positional bool sitting next to `verbose`), so the hook path passes `no_cache` correctly and `verbose` is no longer accidentally set from it.

## Test plan
- `cargo test -p tokf-cli hook_handle_no_cache_does_not_enable_verbose_pipe_diagnostics` — new regression test, passes
- `cargo test` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)