### PR TITLE
ci: batch dependency updates and harden the supply chain

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "schedule": [
     "before 6am on monday"
@@ -9,43 +10,50 @@
   "labels": [
     "dependencies"
   ],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "description": "Security fixes skip the quarantine and the weekly window — a known-exploited hole is worse than an unvetted release.",
+    "minimumReleaseAge": null,
+    "schedule": [
+      "at any time"
+    ],
+    "labels": [
+      "dependencies",
+      "security"
+    ]
+  },
   "packageRules": [
     {
       "description": "Group all GitHub Actions updates together",
       "matchManagers": [
         "github-actions"
       ],
-      "groupName": "GitHub Actions",
-      "automerge": true,
-      "automergeType": "pr"
+      "groupName": "GitHub Actions"
     },
     {
-      "description": "Automerge Cargo patch updates",
+      "description": "Batch every non-major cargo update into a single PR",
       "matchManagers": [
         "cargo"
       ],
       "matchUpdateTypes": [
-        "patch"
+        "patch",
+        "minor",
+        "digest",
+        "pin"
       ],
-      "automerge": true,
-      "automergeType": "pr"
+      "groupName": "cargo dependencies"
     },
     {
-      "description": "Group Cargo minor updates into one PR",
-      "matchManagers": [
-        "cargo"
-      ],
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "groupName": "Cargo dependencies (minor)"
-    },
-    {
-      "description": "Major updates always get individual PRs",
+      "description": "Major updates always get individual PRs, so a breaking bump cannot block the batch",
       "matchUpdateTypes": [
         "major"
       ],
-      "automerge": false
+      "labels": [
+        "dependencies",
+        "major"
+      ]
     },
     {
       "description": "rusqlite is held below 0.40: it requires libsqlite3-sys 0.38, which collides with sqlx-sqlite (<0.38) on the `links = \"sqlite3\"` constraint. Lift once sqlx-sqlite allows 0.38.",

--- a/.github/workflows/backfill-v1-hashes.yml
+++ b/.github/workflows/backfill-v1-hashes.yml
@@ -11,14 +11,21 @@ jobs:
     name: Backfill canonical v1 hashes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Do not leave the token in .git/config. Build scripts and proc
+          # macros compiled in this job run arbitrary code with access to the
+          # workspace and could otherwise read it back out.
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Run backfill
-        run: cargo run -p tokf --features stdlib-publish -- backfill-v1-hashes
+        run: cargo run --locked -p tokf --features stdlib-publish -- backfill-v1-hashes
         env:
           TOKF_SERVICE_TOKEN: ${{ secrets.TOKF_SERVICE_TOKEN }}
           TOKF_REGISTRY_URL: https://api.tokf.net

--- a/.github/workflows/backfill-versions.yml
+++ b/.github/workflows/backfill-versions.yml
@@ -11,16 +11,22 @@ jobs:
     name: Backfill version history
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+          # Do not leave the token in .git/config. Build scripts and proc
+          # macros compiled in this job run arbitrary code with access to the
+          # workspace and could otherwise read it back out.
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Run backfill
-        run: cargo run -p tokf --features stdlib-publish -- backfill-versions
+        run: cargo run --locked -p tokf --features stdlib-publish -- backfill-versions
         env:
           TOKF_SERVICE_TOKEN: ${{ secrets.TOKF_SERVICE_TOKEN }}
           TOKF_REGISTRY_URL: https://api.tokf.net

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege by default. No job here writes to the repo; the jobs that do
+# (release, release-please, docs-dispatch) run in their own workflows and use a
+# scoped app token rather than GITHUB_TOKEN.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -14,42 +20,52 @@ env:
   CARGO_TERM_COLOR: always
   SQLX_OFFLINE: "true"
 
+# Every action below is pinned to a full commit SHA, with the human-readable
+# version in a trailing comment. A tag like @v6 or @master is mutable — whoever
+# controls the action repository can repoint it at new code, which then runs
+# here with our token and cache. Renovate keeps these digests current via the
+# helpers:pinGitHubActionDigests preset.
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Do not leave the token in .git/config. A build script or proc macro
+          # compiled during this job runs arbitrary code with access to the
+          # workspace, and would otherwise be able to read it back out.
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: "1.96.1"
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Check formatting
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --locked --workspace --all-targets -- -D warnings
 
       - name: Clippy (otel feature)
-        run: cargo clippy -p tokf --features otel -- -D warnings
+        run: cargo clippy --locked -p tokf --features otel -- -D warnings
 
       - name: Clippy (otel-grpc feature)
-        run: cargo clippy -p tokf --features otel-grpc -- -D warnings
+        run: cargo clippy --locked -p tokf --features otel-grpc -- -D warnings
 
       - name: Clippy (tokenizer feature)
         run: |
-          cargo clippy -p tokf-common --features tokenizer --all-targets -- -D warnings
-          cargo clippy -p tokf --features tokenizer --all-targets -- -D warnings
+          cargo clippy --locked -p tokf-common --features tokenizer --all-targets -- -D warnings
+          cargo clippy --locked -p tokf --features tokenizer --all-targets -- -D warnings
 
       # CI-only commands (publish-stdlib, backfill-*). Nothing else compiles
       # this code, so without this step it can break on main unnoticed and only
       # fail when an operator dispatches the workflow that needs it.
       - name: Clippy (stdlib-publish feature)
-        run: cargo clippy -p tokf --features stdlib-publish --all-targets -- -D warnings
+        run: cargo clippy --locked -p tokf --features stdlib-publish --all-targets -- -D warnings
 
       - name: Check file sizes
         run: bash scripts/check-file-sizes.sh
@@ -58,7 +74,7 @@ jobs:
         run: bash scripts/check-runtime-seam.sh
 
       - name: Check for code duplication
-        uses: baptiste0928/cargo-install@v3
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
         with:
           crate: cargo-dupes
 
@@ -68,42 +84,70 @@ jobs:
       - name: Check README is up-to-date
         run: bash scripts/generate-readme.sh --check
 
+  supply-chain:
+    name: Supply chain
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2
+        with:
+          tool: cargo-deny
+
+      # advisories — RustSec vulnerability reports, plus yanked crates, which is
+      #               how a compromised release is withdrawn from crates.io.
+      # bans        — wildcard version requirements, which accept any future
+      #               release sight-unseen.
+      # sources     — everything must come from crates.io and nowhere else.
+      # Policy and rationale live in deny.toml.
+      - name: cargo-deny
+        run: cargo deny check advisories bans sources
+
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: "1.96.1"
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2
+        with:
+          tool: nextest
 
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2
+        with:
+          tool: just
 
       - name: Run tests
-        run: cargo nextest run --workspace --exclude e2e-tests --profile ci
+        run: cargo nextest run --locked --workspace --exclude e2e-tests --profile ci
 
       - name: Run tests (otel feature)
-        run: cargo nextest run -p tokf --features otel --profile ci
+        run: cargo nextest run --locked -p tokf --features otel --profile ci
 
       - name: Run tests (otel-grpc feature)
-        run: cargo nextest run -p tokf --features otel-grpc --profile ci
+        run: cargo nextest run --locked -p tokf --features otel-grpc --profile ci
 
       # The tokenizer feature is calibration-only and off by default. Without
       # these steps none of it is ever compiled or run and the divisor
       # silently rots. The calibration harness is #[ignore]d, so run it
       # explicitly — it needs no database and fails if the divisor drifts.
       - name: Run tests (tokenizer feature)
-        run: cargo nextest run -p tokf-common -p tokf --features tokenizer --profile ci
+        run: cargo nextest run --locked -p tokf-common -p tokf --features tokenizer --profile ci
 
       - name: Token estimator calibration
-        run: cargo test -p tokf --features tokenizer --test calibration -- --ignored --nocapture
+        run: cargo test --locked -p tokf --features tokenizer --test calibration -- --ignored --nocapture
 
       - name: Verify filter test suites
         id: verify
@@ -130,7 +174,7 @@ jobs:
 
       - name: Upload verify results
         if: github.event_name == 'pull_request' && always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: verify-results
           path: /tmp/verify-artifact/
@@ -158,33 +202,39 @@ jobs:
     env:
       DATABASE_URL: postgresql://root@localhost:26257/tokf_test?sslmode=disable
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: "1.96.1"
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Create CockroachDB test database
         run: psql "$DATABASE_URL" -c "SELECT 1" 2>/dev/null || psql "postgresql://root@localhost:26257/defaultdb?sslmode=disable" -c "CREATE DATABASE IF NOT EXISTS tokf_test"
 
       - name: Run DB integration tests
-        run: cargo test -p tokf-server -- --ignored
+        run: cargo test --locked -p tokf-server -- --ignored
 
       - name: Run E2E integration tests
-        run: cargo test -p e2e-tests -- --ignored
+        run: cargo test --locked -p e2e-tests -- --ignored
 
   check:
     name: Check
     if: always()
-    needs: [lint, test, db-test, docker]
+    needs: [lint, supply-chain, test, db-test, docker]
     runs-on: ubuntu-latest
     steps:
       - name: All jobs passed
         run: |
           if [[ "${{ needs.lint.result }}" != "success" ]]; then
             echo "Lint failed"
+            exit 1
+          fi
+          if [[ "${{ needs.supply-chain.result }}" != "success" ]]; then
+            echo "Supply chain failed"
             exit 1
           fi
           if [[ "${{ needs.test.result }}" != "success" ]]; then
@@ -205,13 +255,15 @@ jobs:
     name: Docker build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: false

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -25,9 +25,13 @@ jobs:
       group: deploy-server
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Do not leave the token in .git/config — the remote build that
+          # follows has access to the workspace.
+          persist-credentials: false
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - run: flyctl deploy --remote-only
         env:

--- a/.github/workflows/docs-dispatch.yml
+++ b/.github/workflows/docs-dispatch.yml
@@ -6,20 +6,24 @@ on:
     paths:
       - 'docs/**'
 
+# Nothing here touches this repository — the cross-repo dispatch below uses a
+# scoped app token, not GITHUB_TOKEN.
+permissions: {}
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.REPOSITORY_BUTLER_APP_ID }}
           private-key: ${{ secrets.REPOSITORY_BUTLER_PEM }}
           repositories: tokf-net
 
       - name: Trigger tokf-net deploy
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: mpecan/tokf-net

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.REPOSITORY_BUTLER_APP_ID }}
           private-key: ${{ secrets.REPOSITORY_BUTLER_PEM }}
 
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: .release-please-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,19 @@ jobs:
     if: startsWith(inputs.tag || github.event.release.tag_name, 'tokf-v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ env.RELEASE_TAG }}
+          # Do not leave the token in .git/config. Build scripts and proc
+          # macros compiled in this job run arbitrary code with access to the
+          # workspace and could otherwise read it back out.
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Publish tokf-common
         run: |
@@ -88,10 +94,11 @@ jobs:
       contents: read
       id-token: write   # mint the OIDC token for npm trusted publishing
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ env.RELEASE_TAG }}
-      - uses: actions/setup-node@v6
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
@@ -117,15 +124,17 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ env.RELEASE_TAG }}
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           key: ${{ matrix.target }}
 
@@ -133,7 +142,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }} -p tokf
+        run: cargo build --locked --release --target ${{ matrix.target }} -p tokf
 
       - name: Package binary
         shell: bash
@@ -184,21 +193,25 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.REPOSITORY_BUTLER_APP_ID }}
           private-key: ${{ secrets.REPOSITORY_BUTLER_PEM }}
           repositories: homebrew-tokf,homebrew-tools
 
+      # These two taps deliberately keep their credentials: the "Commit and
+      # push" steps below push the regenerated formula back with them. They are
+      # the only checkouts in the repo that do, which is why they are the only
+      # ones without persist-credentials: false.
       - name: Checkout homebrew-tokf tap
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           repository: mpecan/homebrew-tokf
           token: ${{ steps.app-token.outputs.token }}
           path: homebrew-tokf
 
       - name: Checkout homebrew-tools tap
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           repository: mpecan/homebrew-tools
           token: ${{ steps.app-token.outputs.token }}
@@ -281,16 +294,19 @@ jobs:
     if: startsWith(inputs.tag || github.event.release.tag_name, 'tokf-v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: Publish stdlib filters
-        run: cargo run -p tokf --features stdlib-publish -- publish-stdlib
+        run: cargo run --locked -p tokf --features stdlib-publish -- publish-stdlib
         env:
           TOKF_SERVICE_TOKEN: ${{ secrets.TOKF_SERVICE_TOKEN }}
           TOKF_REGISTRY_URL: https://api.tokf.net
@@ -303,7 +319,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.REPOSITORY_BUTLER_APP_ID }}
           private-key: ${{ secrets.REPOSITORY_BUTLER_PEM }}

--- a/.github/workflows/verify-comment.yml
+++ b/.github/workflows/verify-comment.yml
@@ -7,6 +7,15 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+# This workflow is privileged: workflow_run runs in the base repo with secrets
+# even when the triggering CI run came from a fork. GITHUB_TOKEN therefore gets
+# the minimum needed to read the artifact — `actions: read` for the artifact
+# and `contents: read` for the checkout. The comment itself is posted with a
+# scoped app token, not GITHUB_TOKEN, so no write scope is granted here.
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   comment:
     name: Post verify comment
@@ -15,11 +24,15 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion != 'cancelled'
     steps:
-      - uses: actions/checkout@v6
+      # Checks out the BASE repo at the default branch, never the fork's head —
+      # the script run below must be ours, not a contributor's.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Download verify results
         id: download
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: verify-results
           path: /tmp/verify-artifact
@@ -30,14 +43,14 @@ jobs:
       - name: Generate GitHub App token
         if: steps.download.outcome == 'success'
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.REPOSITORY_BUTLER_APP_ID }}
           private-key: ${{ secrets.REPOSITORY_BUTLER_PEM }}
 
       - name: Post filter verification PR comment
         if: steps.download.outcome == 'success'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,50 @@ cargo dupes stats        # statistics only
 cargo dupes check        # CI gate — fails if thresholds exceeded
 ```
 
+### Supply chain
+
+A dependency is executable code: `build.rs` scripts and proc macros run
+arbitrary code on your machine and in CI the moment you build. CI therefore
+gates on [cargo-deny](https://crates.io/crates/cargo-deny):
+
+```sh
+cargo install cargo-deny --locked
+cargo deny check advisories bans sources
+```
+
+Three checks run, with the policy and the reasoning behind each in `deny.toml`:
+
+- **advisories** — RustSec vulnerability reports, and **yanked** crates. A yank
+  is how a compromised release is withdrawn from crates.io, so a yanked version
+  in `Cargo.lock` fails the build.
+- **bans** — wildcard version requirements, which accept any future release
+  sight-unseen.
+- **sources** — every crate must come from crates.io. A dependency that
+  suddenly resolves to a git repository is the shape a takeover attack takes,
+  and it would otherwise pass unnoticed in a lockfile diff.
+
+If it fails on a *yanked* crate, the fix is usually
+`cargo update -p <crate>@<version> --precise <newer>` — check for a non-yanked
+release inside the same semver range first. If it fails on a real advisory with
+no fix available, add an entry to `ignore` in `deny.toml` **with a reason and a
+condition for revisiting it**. An entry there is a decision, not a TODO.
+
+Two related rules apply to anything under `.github/`:
+
+- **Actions are pinned to full commit SHAs**, with the version in a trailing
+  comment (`uses: actions/checkout@d23441a… # v6`). A tag like `@v6` or
+  `@master` is mutable, so whoever controls that repository can repoint it at
+  new code that then runs with our token. Renovate keeps the digests current.
+- **`persist-credentials: false` on every checkout** except the two Homebrew
+  taps in `release.yml`, which push with those credentials. Without it the token
+  is left in `.git/config`, where a build script compiled later in the same job
+  can read it.
+
+Dependency updates are batched by Renovate into a single weekly PR, and new
+releases are quarantined for 7 days (`minimumReleaseAge`) so that a malicious
+version has time to be caught and yanked before it reaches us. Security fixes
+skip both the quarantine and the weekly window.
+
 ### Writing an isolated test
 
 tokf keeps its runtime configuration **explicit**. User directories, the

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,49 @@
+# cargo-deny configuration — supply-chain checks for the dependency tree.
+#
+# CI runs `cargo deny check advisories bans sources` (see .github/workflows/ci.yml).
+# The licences check is deliberately not run: this file exists to catch
+# compromised, vulnerable, or untrusted dependencies, and licence policy is a
+# separate concern that would only add noise to that signal.
+#
+# Run locally with:
+#   cargo install cargo-deny --locked
+#   cargo deny check advisories bans sources
+
+[graph]
+# Check every feature. otel, otel-grpc, tokenizer and stdlib-publish are all
+# off by default, so without this their dependencies are never audited — and
+# stdlib-publish is the one that runs against the production registry.
+all-features = true
+# Dev-dependencies are excluded: crates/tokf-server dev-depends on itself under
+# an alias to enable its `test-helpers` feature, and krates (inside cargo-deny)
+# hits an unreachable!() on that node. See the note in .github/workflows/ci.yml.
+exclude-dev = true
+
+[advisories]
+# RustSec advisory database.
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# A yanked crate is the strongest signal we get that a release was pulled —
+# it is how a compromised version disappears from crates.io. Fail on it.
+yanked = "deny"
+# Advisories consciously accepted, each with a reason and a revisit condition.
+# Keep this list empty where possible; an entry here is a decision, not a TODO.
+ignore = []
+
+[bans]
+# The workspace legitimately carries duplicate versions (sqlx and rusqlite
+# share libsqlite3-sys under a version pin — see .github/renovate.json).
+# Duplicate tracking lives in dupes.toml / `cargo dupes check` instead.
+multiple-versions = "allow"
+# A wildcard version requirement means any future release is accepted
+# sight-unseen, including a malicious one. Never acceptable here.
+wildcards = "deny"
+deny = []
+
+[sources]
+# Only crates.io. A dependency that suddenly resolves to a git repository or a
+# private registry is the shape a dependency-confusion or takeover attack
+# takes, and it would otherwise pass unnoticed in a lockfile diff.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
Two asks, one branch: make renovate open a single batched PR, and harden dependency upgrades against compromised releases.

> **Depends on #452.** The new `cargo deny` job fails on this branch alone, because `main` currently pins two **yanked** versions of `spin`. #452 clears them. Merge that first and this goes green; the failure is the new check doing its job.

---

## 1. Renovate: one PR instead of six

| | Before | After |
|---|---|---|
| Cargo patch updates | one PR each | batched into a single `cargo dependencies` PR |
| Cargo minor updates | grouped separately | same batch |
| Major updates | individual | individual (unchanged) |
| New release age | none — proposed within hours | **quarantined 7 days** |
| Security fixes | same queue as everything | exempt from quarantine *and* schedule |
| Automerge | configured, never fired | removed |

**Batching.** The old config grouped only *minor* updates, so patch bumps — the overwhelming majority — each got a PR. Six were open when I started, all touching only `Cargo.lock`, so merging any one put the other five into conflict.

**Quarantine.** `minimumReleaseAge: "7 days"` holds a new version back before proposing it. A compromised release is usually caught and yanked within a day or two; against the existing Monday schedule this costs no real latency. `vulnerabilityAlerts` overrides both the age and the schedule so security fixes come through immediately — a known-exploited hole is worse than an unvetted release. `osvVulnerabilityAlerts` adds the OSV database as a source for those.

**Automerge removed.** It could never fire — see the analysis in #452. Rather than grant the bot a ruleset bypass, I dropped the dead config: auto-merging dependency bumps with nobody looking is precisely what the quarantine exists to prevent. If you'd rather have working automerge, say so and I'll add renovate as a bypass actor instead.

Validated with `renovate-config-validator`.

## 2. cargo-deny gate

New `supply-chain` CI job running `cargo deny check advisories bans sources`, wired into the aggregate `Check` job so it actually blocks. Policy in `deny.toml`:

- **advisories** — RustSec reports, plus **yanked** crates. A yank is the mechanism by which a compromised release is withdrawn from crates.io.
- **bans** — wildcard version requirements, which accept any future release sight-unseen.
- **sources** — crates.io only. A dependency that suddenly resolves to a git repository is the shape a takeover attack takes, and would otherwise pass unnoticed in a lockfile diff.

It found something on its first run: two yanked `spin` versions, reached indirectly via `axum → multer` and `aws-sdk-s3 → crc-fast`. Fixed in #452.

One caveat, documented in `deny.toml`: dev-dependencies are excluded from the graph. `crates/tokf-server` dev-depends on **itself** under an alias to enable its `test-helpers` feature, and `krates` (inside cargo-deny 0.20.2) hits an `unreachable!()` on that node. Worth revisiting when that's fixed upstream.

## 3. Actions pinned to commit SHAs

All 17 actions now use a full SHA with the version in a trailing comment. **Three were on `@master`** — `dtolnay/rust-toolchain` (×5) and `superfly/flyctl-actions` — where whoever controls that repository can repoint the ref at new code, which then runs here with our token and cache. This is the `tj-actions/changed-files` attack class.

Two of these derive their behaviour from the *ref name*: `dtolnay/rust-toolchain@stable` and `taiki-e/install-action@nextest` read the ref to pick a default. The defaults turn out to be baked into `action.yml` at each pinned SHA (verified), so pinning alone doesn't break them — but I've made `toolchain:` and `tool:` explicit anyway, since relying on that would break silently on a future re-pin.

Renovate keeps the digests current via `helpers:pinGitHubActionDigests`.

## 4. Checkout credentials and permissions

**`persist-credentials: false`** on all 13 checkouts that don't push. Without it the token is left in `.git/config`, where a `build.rs` or proc macro compiled later in the same job can read it — a real concern for a Rust repo, where every build executes third-party code. The two Homebrew tap checkouts in `release.yml` are exempt because they push with those credentials, and now carry a comment saying so.

**Explicit `permissions:`** on the three workflows that had none. The repo default is already read-only, so no behaviour changes today — this stops a future change to that default from silently widening them. `verify-comment.yml` gets the tightest treatment as the one genuinely privileged workflow: it runs via `workflow_run` in the base repo with secrets even for fork PRs, so GITHUB_TOKEN gets only `contents: read` + `actions: read`, and the comment is posted with a scoped app token.

**`--locked`** on every cargo invocation, so CI fails rather than silently resolving versions differing from `Cargo.lock`.

## Verification

- All nine workflows parse; **no duplicate keys** (checked with a strict YAML loader, not just `safe_load`)
- No mutable action refs remain
- Every cargo invocation carries `--locked`
- `renovate-config-validator` — passes
- `cargo deny check advisories bans sources` — `bans ok, sources ok`; advisories pass once #452 lands
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` (2468 passed) — unaffected, no Rust changes

## Not done

- **`sha_pinning_required`** is available as a repo setting (currently off) and would enforce rule 3 for good. Not flipped — it's a repo setting, not a file, and it's your call.
- **`cargo vet` / `cargo crev`** — crate-level review attestations. Materially more process; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)