### PR TITLE
fix(runner): resolve programs the way Windows does

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# Normalise line endings to LF in the working tree on every platform.
+#
+# This is not only cosmetic. Several files are embedded into the binary
+# verbatim with `include_str!` and then written to the user's disk —
+# `crates/tokf-cli/skills/**/SKILL.md` among them. Git's `core.autocrlf=true`,
+# the default on Windows installs and on the Windows CI runners, would check
+# those out as CRLF, so a build from a Windows checkout embeds CRLF and
+# `tokf skill install` writes YAML frontmatter that begins `---\r\n`.
+#
+# Filter TOMLs and their fixtures are equally sensitive: fixtures are compared
+# line by line against captured command output, and a stray CR changes the
+# comparison.
+* text=auto eol=lf
+
+# Windows shell scripts are the one thing that genuinely wants CRLF — some
+# Windows shells mis-parse an LF-only .bat/.cmd. None are checked in today;
+# this keeps that true if one ever is.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Never touch these.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.gz binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,10 +221,46 @@ jobs:
       - name: Run E2E integration tests
         run: cargo test --locked -p e2e-tests -- --ignored
 
+  # Windows is where program resolution differs most: CreateProcessW only ever
+  # appends `.exe`, PATH is `;`-separated, and `:` appears inside every absolute
+  # path. Issues #449, #450 and #451 all lived here and none were reachable from
+  # an ubuntu-only matrix — they had to be reported from outside the project.
+  #
+  # Scope note: this runs the tokf unit tests, not the whole workspace. Much of
+  # the integration suite shells out to `sh` and asserts POSIX semantics
+  # (see #360), which is a separate problem from program resolution. Widening
+  # this job is tracked rather than done here, so the gate stays green and
+  # therefore meaningful.
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: "1.96.1"
+          components: clippy
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+
+      # Catches the compile-time class of Windows breakage — an unguarded
+      # `std::os::unix` import, or one left dead by a cfg'd-out test.
+      - name: Clippy
+        run: cargo clippy --locked -p tokf --all-targets -- -D warnings
+
+      - name: Unit tests
+        run: cargo test --locked -p tokf --lib
+
+      - name: Binary-crate tests
+        run: cargo test --locked -p tokf --bin tokf
+
   check:
     name: Check
     if: always()
-    needs: [lint, supply-chain, test, db-test, docker]
+    needs: [lint, supply-chain, test, db-test, docker, windows]
     runs-on: ubuntu-latest
     steps:
       - name: All jobs passed
@@ -247,6 +283,10 @@ jobs:
           fi
           if [[ "${{ needs.docker.result }}" != "success" ]]; then
             echo "Docker build failed"
+            exit 1
+          fi
+          if [[ "${{ needs.windows.result }}" != "success" ]]; then
+            echo "Windows failed"
             exit 1
           fi
           echo "All checks passed"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,77 @@ Dependency updates are batched by Renovate into a single weekly PR, and new
 releases are quarantined for 7 days (`minimumReleaseAge`) so that a malicious
 version has time to be caught and yanked before it reaches us. Security fixes
 skip both the quarantine and the weekly window.
+### Testing on Windows
+
+Windows is where program resolution diverges most — `CreateProcessW` only ever
+appends `.exe`, `PATH` is `;`-separated, and `:` appears inside every absolute
+path. Issues #449, #450 and #451 all lived there and none were reachable from a
+Linux runner. CI now has a `windows-latest` job, but a local VM makes the loop
+minutes instead of a CI round trip.
+
+**Write the test so it does not need Windows where possible.** Several
+invariants hold on every platform and should be asserted everywhere — the
+`PATH` round-trip through `split_paths` in `path_env.rs` and the argv
+pass-through in `runner.rs` both fail on macOS if the fix regresses. Reserve
+`#[cfg(windows)]` for assertions only Windows can observe, such as a drive
+letter surviving as a single `PATH` entry.
+
+#### Setting up a disposable VM
+
+Windows evaluation images expire after 90 days, so treat the VM as disposable
+and re-create it when it lapses — that is Microsoft's intended path, not a
+workaround. On Apple Silicon you need an **ARM64** build; the ordinary x64 ISO
+will not install.
+
+```sh
+brew install --cask utm crystalfetch   # virtualiser + official ARM64 ISO downloader
+```
+
+1. Use **CrystalFetch** to build a Windows 11 ARM64 ISO. It assembles one from
+   Microsoft's official UUP update packages via UUP Dump — the payload is
+   Microsoft's, the tooling that fetches and assembles it is third-party. If you
+   would rather avoid that, Microsoft publishes ARM64 VHDX images to Windows
+   Insider members, and VMware Fusion (free, but behind a Broadcom account) can
+   download Windows 11 ARM directly.
+2. Create a UTM VM from that ISO (Virtualise, not Emulate — Apple's hypervisor
+   runs ARM64 guests at native speed). Give it 4+ CPUs, 8 GB RAM and 80 GB disk;
+   the first build compiles Luau, SQLite and aws-lc from source.
+3. In an **elevated** PowerShell inside the VM:
+
+   ```powershell
+   iwr -useb https://raw.githubusercontent.com/mpecan/tokf/main/scripts/provision-windows-dev.ps1 | iex
+   ```
+
+   That installs Git, rustup (honouring `rust-toolchain.toml`), Visual Studio
+   Build Tools with the C++ workload, CMake and NASM, then clones the repo.
+4. **Snapshot the VM once the first build succeeds.** That snapshot is what you
+   return to — both after a bad experiment and when the licence lapses.
+
+Then run what CI runs:
+
+```powershell
+cargo clippy --locked -p tokf --all-targets -- -D warnings
+cargo test   --locked -p tokf --lib
+cargo test   --locked -p tokf --bin tokf
+```
+
+Two caveats worth knowing:
+
+- A VM on Apple Silicon is **ARM64**, while CI runs **x86-64**. For OS-level
+  behaviour — `PATHEXT`, path separators, `CreateProcess` semantics — the two
+  are equivalent, which covers this whole bug class. Anything architecture-
+  specific still only shows up in CI.
+- `aws-lc-sys` is the most fragile dependency to build on Windows, ARM64
+  especially. If it fails, that is a toolchain problem in the VM (usually a
+  missing C++ workload or CMake), not a problem with your change.
+
+#### What cross-compiling from macOS cannot do
+
+`cargo check --target x86_64-pc-windows-msvc` does **not** work as a shortcut:
+`libsqlite3-sys`, `mlua-sys` and `aws-lc-sys` all run build scripts that need a
+Windows C/C++ toolchain. `cross` does not help on Apple Silicon either — its
+images are x86-64 and the host cannot install the matching toolchain. The VM
+and CI are the two real options.
 
 ### Writing an isolated test
 

--- a/README.md
+++ b/README.md
@@ -2531,6 +2531,35 @@ Records are appended; nothing rotates or trims the file, so prune it yourself if
 
 This was added in response to issue #355, where stray `1echo` files in the agent's cwd turned out to come from a multi-line rewrite collapsing newlines into adjacent tokens — the kind of bug that's invisible in `tokf rewrite "..."` runs but obvious in a hook log.
 
+## Windows notes
+
+`tokf run` resolves a bare program name the way the platform does, which on
+Windows means consulting `PATHEXT`. That matters because most of the Node
+ecosystem ships as `.cmd` shims rather than `.exe` files:
+
+```console
+> tokf run npm --version
+11.11.0
+```
+
+Earlier versions could only find `.exe` programs, so `npm`, `npx`, `pnpm`,
+`tsc`, `eslint` and `gradlew` all failed with `program not found` unless you
+spelled out the extension (`npm.cmd`). If you added a `run =` line to a filter
+purely to work around that, it is no longer needed — though it is harmless.
+
+Two related fixes landed at the same time:
+
+- A program whose **path contains a space** — anything under
+  `C:\Program Files\` — is passed through whole. It used to be cut at the first
+  space, and the leading half reported as the program.
+- The **shims `PATH`** built for `inject_path = true` filters now uses `;`, the
+  Windows separator. With `:` the shims entry and the first real entry were both
+  lost, so shim injection silently did nothing.
+
+Still outstanding on Windows: filters that carry a `run =` line execute through
+`powershell.exe`, and a few built-ins assume POSIX shell syntax. Track that in
+[#360](https://github.com/mpecan/tokf/issues/360).
+
 ---
 
 

--- a/crates/tokf-cli/src/config/cache.rs
+++ b/crates/tokf-cli/src/config/cache.rs
@@ -408,6 +408,9 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    // Used only by the Unix-gated parallel-writers test below; without the same
+    // guard these are dead code on Windows and `-D warnings` fails the build.
+    #[cfg(unix)]
     fn write_payloads_in_parallel(path: &Path, payloads: &[Vec<u8>]) {
         std::thread::scope(|scope| {
             let handles = payloads
@@ -424,6 +427,7 @@ mod tests {
         });
     }
 
+    #[cfg(unix)]
     fn leftover_paths(dir: &Path, final_path: &Path) -> Vec<PathBuf> {
         fs::read_dir(dir)
             .unwrap()
@@ -432,6 +436,14 @@ mod tests {
             .collect()
     }
 
+    // Unix-only: the write is tmp-file-then-rename, and on Windows `fs::rename`
+    // fails with "Access is denied" when another handle has the destination
+    // open, which is exactly what concurrent writers produce. That is a real
+    // (if minor) Windows defect rather than a test artefact — `discover_with_cache`
+    // catches the error and warns on stderr, so the cache is skipped rather than
+    // the command failing. Tracked separately; gating the test keeps the Windows
+    // job honest about what it does and does not cover. See #455.
+    #[cfg(unix)]
     #[test]
     fn manifest_write_allows_parallel_writers() {
         let tmp = TempDir::new().unwrap();

--- a/crates/tokf-cli/src/history/config_tests.rs
+++ b/crates/tokf-cli/src/history/config_tests.rs
@@ -485,9 +485,16 @@ fn try_record_returns_id_on_success() {
 
 #[test]
 fn try_record_does_not_panic_on_unwritable_db_path() {
-    // Point to a path whose parent cannot be created.
+    // Point to a path whose parent cannot be created. Using a regular *file* as
+    // the parent directory works on every platform: `/dev/null/...` only fails
+    // this way on Unix, and on Windows the path is merely unusual, so the
+    // directory got created and the test asserted the wrong thing.
+    let dir = TempDir::new().unwrap();
+    let blocker = dir.path().join("not-a-directory");
+    std::fs::write(&blocker, b"x").unwrap();
+
     let rt = Runtime::builder()
-        .db_path("/dev/null/no-such-dir/tracking.db")
+        .db_path(blocker.join("no-such-dir").join("tracking.db"))
         .debug(false)
         .build();
     // Must not panic — errors are silently swallowed when TOKF_DEBUG is unset.

--- a/crates/tokf-cli/src/main.rs
+++ b/crates/tokf-cli/src/main.rs
@@ -18,6 +18,7 @@ mod install_cmd;
 mod issue_cmd;
 mod marker;
 mod output;
+mod path_env;
 mod publish_cmd;
 #[cfg(feature = "stdlib-publish")]
 mod publish_stdlib_cmd;

--- a/crates/tokf-cli/src/path_env.rs
+++ b/crates/tokf-cli/src/path_env.rs
@@ -1,0 +1,92 @@
+//! Building `PATH`-style environment values.
+//!
+//! Split out of `resolve.rs`: assembling a search path is its own concern, and
+//! it is the one piece of the shim injection with platform-specific rules.
+
+/// Prepend `dir` to a `PATH`-style variable using the platform's separator.
+///
+/// `std::env::join_paths` picks `;` on Windows and `:` elsewhere, matching the
+/// `std::env::split_paths` that reads the value back in `runner::resolve_program`.
+/// Hard-coding `:` produced a malformed `PATH` on Windows, where `:` also occurs
+/// inside every absolute path — `C:\...\shims:C` parsed as one entry, so the
+/// shim injection silently did nothing *and* the first real entry was dropped.
+pub fn prepend_to_path(dir: &std::path::Path, original_path: &str) -> String {
+    let entries = std::iter::once(dir.to_path_buf())
+        .chain(std::env::split_paths(original_path))
+        .map(std::path::PathBuf::into_os_string);
+
+    std::env::join_paths(entries).map_or_else(
+        // join_paths only fails if an entry itself contains the separator, in
+        // which case there is no correct answer — fall back to the platform
+        // separator rather than dropping the injection entirely.
+        |_| {
+            let sep = if cfg!(windows) { ';' } else { ':' };
+            format!("{}{sep}{original_path}", dir.display())
+        },
+        |joined| joined.to_string_lossy().into_owned(),
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // --- prepend_to_path (#451) ---
+
+    /// The value must be readable by the `split_paths` that consumes it in
+    /// `runner::resolve_program`. Hard-coding `:` broke this on Windows, where
+    /// the separator is `;` and `:` occurs inside every absolute path.
+    #[test]
+    fn prepend_to_path_round_trips_through_split_paths() {
+        let original: Vec<std::path::PathBuf> =
+            std::env::split_paths(&std::env::join_paths(["/one/two", "/three"].iter()).unwrap())
+                .collect();
+        let original_str = std::env::join_paths(original.iter())
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+
+        let shims = std::path::Path::new("/shims/dir");
+        let joined = prepend_to_path(shims, &original_str);
+
+        let parsed: Vec<std::path::PathBuf> = std::env::split_paths(&joined).collect();
+        assert_eq!(
+            parsed.len(),
+            original.len() + 1,
+            "entry count must be preserved"
+        );
+        assert_eq!(parsed[0], shims, "shims dir must lead");
+        assert_eq!(
+            &parsed[1..],
+            &original[..],
+            "existing entries must survive intact"
+        );
+    }
+
+    /// The separator must be the platform's own, never a hard-coded `:`.
+    #[test]
+    fn prepend_to_path_uses_the_platform_separator() {
+        let sep = if cfg!(windows) { ';' } else { ':' };
+        let joined = prepend_to_path(std::path::Path::new("/shims"), "/existing");
+        assert!(
+            joined.contains(sep),
+            "expected {sep:?} to separate entries in {joined:?}"
+        );
+    }
+
+    /// An absolute Windows path contains a colon. Splitting on one would cut
+    /// `C:\\shims` into `C` and `\\shims`, which is the #451 bug.
+    ///
+    /// Windows-only by nature: on Unix `:` really is the separator, so the
+    /// same input correctly yields two entries there.
+    #[cfg(windows)]
+    #[test]
+    fn prepend_to_path_keeps_a_drive_letter_entry_whole() {
+        let dir = std::path::Path::new("C:/tokf/shims");
+        let joined = prepend_to_path(dir, "C:/existing/bin");
+        let parsed: Vec<std::path::PathBuf> = std::env::split_paths(&joined).collect();
+        assert_eq!(parsed[0], dir, "drive-lettered entry must survive whole");
+        assert_eq!(parsed.len(), 2, "must be exactly two entries, not four");
+    }
+}

--- a/crates/tokf-cli/src/resolve.rs
+++ b/crates/tokf-cli/src/resolve.rs
@@ -572,20 +572,35 @@ run = "pnpm test --reporter=dot {args}"
     #[test]
     fn build_inject_env_uses_original_path_when_nested() {
         // Simulate a nested invocation: TOKF_ORIGINAL_PATH is already set.
-        let rt = Runtime::builder().original_path("/usr/bin:/bin").build();
+        // Build the original value with the platform separator — hard-coding
+        // `:` is the #451 bug itself, and a test that assumes it cannot observe
+        // the fix.
+        let original = std::env::join_paths(["/usr/bin", "/bin"].iter())
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let rt = Runtime::builder().original_path(&original).build();
         let shims = rt.shims_dir().unwrap();
         std::fs::create_dir_all(&shims).unwrap();
 
         let cfg = config_with_inject(true);
         let env = build_inject_env(&rt, Some(&cfg));
 
-        // PATH should be shims:/usr/bin:/bin (not shims:shims:/usr/bin:/bin)
         assert_eq!(env[1].0, "TOKF_ORIGINAL_PATH");
-        assert_eq!(env[1].1, "/usr/bin:/bin");
-        assert!(
-            env[0]
-                .1
-                .starts_with(&format!("{}:/usr/bin:/bin", shims.display()))
+        assert_eq!(env[1].1, original);
+
+        // PATH must be shims + the original entries, and must not stack the
+        // shims dir twice on a nested invocation. Compare parsed entries rather
+        // than a formatted string so the assertion holds on either separator.
+        let entries: Vec<std::path::PathBuf> = std::env::split_paths(&env[0].1).collect();
+        assert_eq!(
+            entries,
+            vec![
+                shims,
+                std::path::PathBuf::from("/usr/bin"),
+                std::path::PathBuf::from("/bin"),
+            ],
+            "expected the shims dir once, then the original entries"
         );
     }
 
@@ -612,7 +627,9 @@ run = "pnpm test --reporter=dot {args}"
         )
         .unwrap();
 
-        assert_eq!(result.stdout.trim(), "substituted extra");
+        // PowerShell's `echo` is Write-Output, one line per argument; `sh`
+        // emits a single space-separated line. Both substituted both words.
+        assert_eq!(result.stdout.trim().replace('\n', " "), "substituted extra");
         assert_eq!(
             executed.as_deref(),
             // Args are shell-quoted: this is the literal line handed to `sh`.

--- a/crates/tokf-cli/src/resolve.rs
+++ b/crates/tokf-cli/src/resolve.rs
@@ -6,6 +6,8 @@ use tokf::tracking;
 
 use tokf::runtime::Runtime;
 
+use crate::path_env::prepend_to_path;
+
 /// Result of filter resolution, including any deferred output-pattern variants.
 pub struct FilterMatch {
     pub config: FilterConfig,
@@ -190,7 +192,7 @@ fn build_inject_env(rt: &Runtime, filter_cfg: Option<&FilterConfig>) -> Vec<(Str
         .map(std::borrow::ToOwned::to_owned)
         .or_else(|| std::env::var("PATH").ok())
         .unwrap_or_default();
-    let new_path = format!("{}:{}", shims.display(), original_path);
+    let new_path = prepend_to_path(&shims, &original_path);
     let tokf_exe = std::env::current_exe()
         .unwrap_or_else(|_| "tokf".into())
         .to_string_lossy()
@@ -292,15 +294,20 @@ pub fn run_command(
         }
         let result = runner::execute_shell_with_env(&run_cmd, remaining_args, &env_refs)?;
         Ok((result, Some(executed)))
-    } else if words_consumed > 0 {
-        let cmd_str = command_args[..words_consumed].join(" ");
-        Ok((
-            runner::execute_with_env(&cmd_str, remaining_args, &env_refs)?,
-            None,
-        ))
     } else {
+        // Pass argv straight through. This used to join the matched prefix with
+        // spaces and let the runner split it again, which tore apart any element
+        // containing one — `C:\Program Files\node.exe` became two arguments and
+        // the program was reported as not found.
+        //
+        // words_consumed is how many argv elements the filter's `command`
+        // pattern matched (0 when nothing matched); element 0 is the program
+        // either way, so the rest of the matched prefix simply leads the args.
+        let prefix_end = words_consumed.max(1);
+        let mut args = command_args[1..prefix_end].to_vec();
+        args.extend_from_slice(remaining_args);
         Ok((
-            runner::execute_with_env(&command_args[0], remaining_args, &env_refs)?,
+            runner::execute_with_env(&command_args[0], &args, &env_refs)?,
             None,
         ))
     }

--- a/crates/tokf-cli/src/runner.rs
+++ b/crates/tokf-cli/src/runner.rs
@@ -413,7 +413,15 @@ mod tests {
         // execute() uses Command::new (no shell), so special chars are passed literally
         let (program, args) = echo_program(&["hello world"]);
         let result = execute(program, &args).unwrap();
-        assert_eq!(result.stdout.trim(), "hello world");
+        // `cmd /C echo` prints the argument in the quoted form it received it
+        // in. Those quotes are the point: they show the space did not split it
+        // into two arguments, which is exactly what this test is about.
+        let expected = if cfg!(windows) {
+            "\"hello world\""
+        } else {
+            "hello world"
+        };
+        assert_eq!(result.stdout.trim(), expected);
         assert_eq!(result.exit_code, 0);
     }
 
@@ -477,7 +485,10 @@ mod tests {
     fn test_execute_shell_args_interpolation() {
         let args = vec!["a".to_string(), "b".to_string()];
         let result = execute_shell("echo {args}", &args).unwrap();
-        assert_eq!(result.stdout.trim(), "a b");
+        // PowerShell's `echo` is an alias for Write-Output, which emits one
+        // line per argument where `sh` emits one space-separated line. Both
+        // interpolated both arguments, which is what is under test.
+        assert_eq!(result.stdout.trim().replace('\n', " "), "a b");
     }
 
     #[test]
@@ -515,7 +526,7 @@ mod tests {
 
     #[test]
     fn test_execute_stderr() {
-        let result = execute_shell("echo err >&2", &[]).unwrap();
+        let result = execute_shell(&write_stderr("err"), &[]).unwrap();
         assert!(result.stderr.contains("err"));
         assert!(result.stdout.is_empty());
         assert_eq!(result.combined, "err");
@@ -662,7 +673,15 @@ mod tests {
     #[test]
     fn test_execute_shell_with_env_propagates_vars() {
         let env = vec![("TOKF_TEST_VAR2", "shell_env_val")];
-        let result = execute_shell_with_env("echo $TOKF_TEST_VAR2", &[], &env).unwrap();
+        // In PowerShell `$NAME` reads a shell variable; environment variables
+        // live in the `env:` drive, so the snippet differs by platform even
+        // though the behaviour under test does not.
+        let snippet = if cfg!(windows) {
+            "echo $env:TOKF_TEST_VAR2"
+        } else {
+            "echo $TOKF_TEST_VAR2"
+        };
+        let result = execute_shell_with_env(snippet, &[], &env).unwrap();
         assert_eq!(result.stdout.trim(), "shell_env_val");
     }
 

--- a/crates/tokf-cli/src/runner.rs
+++ b/crates/tokf-cli/src/runner.rs
@@ -101,15 +101,16 @@ fn run_interleaved(mut child: std::process::Child) -> anyhow::Result<CommandResu
 ///
 /// This is used when we're about to override `PATH` with a shims directory —
 /// we must resolve the original program first so it doesn't find our own shim.
+///
+/// Delegates to `which`, which applies the platform's own resolution rules.
+/// That matters on Windows, where a bare name is resolved through `PATHEXT`:
+/// a hand-rolled `dir.join(program)` loop had no success mode there. For `npm`
+/// it matched the extensionless POSIX shell script that ships next to
+/// `npm.cmd` — a file `CreateProcessW` cannot execute — and for a normal `.exe`
+/// such as `git` it found nothing at all, so the shim-avoidance this function
+/// exists for never happened.
 pub fn resolve_program(program: &str) -> Option<std::path::PathBuf> {
-    let path_var = std::env::var_os("PATH")?;
-    for dir in std::env::split_paths(&path_var) {
-        let candidate = dir.join(program);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
+    which::which(program).ok()
 }
 
 /// Build the system shell command for a shell snippet.
@@ -130,14 +131,20 @@ fn build_shell_command(command: &str) -> Command {
     }
 }
 
-fn spawn_command(mut cmd: Command, program: &str) -> anyhow::Result<std::process::Child> {
-    match cmd.spawn() {
-        Ok(child) => Ok(child),
-        Err(err) if err.kind() == ErrorKind::NotFound => {
-            Err(anyhow::anyhow!("program not found: {program}"))
-        }
-        Err(err) => Err(err.into()),
-    }
+/// Spawn a prepared command, leaving the `io::Error` intact.
+///
+/// The raw error kind is preserved so callers can distinguish `NotFound` and
+/// retry with a differently-resolved program path.
+fn spawn_command(mut cmd: Command) -> std::io::Result<std::process::Child> {
+    cmd.spawn()
+}
+
+/// Spawn a prepared command, reporting a missing program by name.
+fn spawn_named(cmd: Command, program: &str) -> anyhow::Result<std::process::Child> {
+    spawn_command(cmd).map_err(|err| match err.kind() {
+        ErrorKind::NotFound => anyhow::anyhow!("program not found: {program}"),
+        _ => err.into(),
+    })
 }
 
 /// Escape a string for safe inclusion in a shell command.
@@ -175,15 +182,13 @@ pub fn execute(command: &str, args: &[String]) -> anyhow::Result<CommandResult> 
 ///
 /// Returns an error if the command string is empty or the process fails to spawn.
 pub fn execute_with_env(
-    command: &str,
+    program: &str,
     args: &[String],
     extra_env: &[(&str, &str)],
 ) -> anyhow::Result<CommandResult> {
-    let mut parts = command.split_whitespace();
-    let program = parts
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("empty command"))?;
-    let base_args: Vec<&str> = parts.collect();
+    if program.is_empty() {
+        anyhow::bail!("empty command");
+    }
 
     let has_path_override = extra_env.iter().any(|(k, _)| *k == "PATH");
     let resolved = if has_path_override {
@@ -195,16 +200,41 @@ pub fn execute_with_env(
         .as_ref()
         .map_or(program, |p| p.to_str().unwrap_or(program));
 
-    let mut cmd = Command::new(actual_program);
-    cmd.args(&base_args)
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    match spawn_command(build_command(actual_program, args, extra_env)) {
+        Ok(child) => run_interleaved(child),
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            // Windows resolves a bare program name through CreateProcessW,
+            // which only ever appends `.exe`. Every other PATHEXT entry —
+            // `.cmd`, `.bat`, `.com`, … — is unreachable, so `npm` fails while
+            // `npm.cmd` works. `which` applies PATHEXT, so retry through it
+            // once before giving up. On Unix this second attempt simply finds
+            // nothing new and the original error stands.
+            let fallback = resolve_program(actual_program)
+                .filter(|p| p.as_os_str() != actual_program)
+                .ok_or_else(|| anyhow::anyhow!("program not found: {actual_program}"))?;
+
+            let child = spawn_named(
+                build_command(&fallback.to_string_lossy(), args, extra_env),
+                actual_program,
+            )?;
+            run_interleaved(child)
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Build the child process for `program`, without spawning it.
+///
+/// Separate from the spawn so a failed attempt can be rebuilt and retried with
+/// a different program path — `Command` does not allow changing it after the
+/// fact.
+fn build_command(program: &str, args: &[String], extra_env: &[(&str, &str)]) -> Command {
+    let mut cmd = Command::new(program);
+    cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
     for (k, v) in extra_env {
         cmd.env(k, v);
     }
-
-    run_interleaved(spawn_command(cmd, actual_program)?)
+    cmd
 }
 
 /// Execute a shell command with `{args}` interpolation.
@@ -259,7 +289,7 @@ pub fn execute_shell_with_env(
         cmd.env(k, v);
     }
 
-    run_interleaved(spawn_command(cmd, shell_program)?)
+    run_interleaved(spawn_named(cmd, shell_program)?)
 }
 
 #[cfg(test)]
@@ -271,11 +301,57 @@ pub fn execute_shell_with_env(
 mod tests {
     use super::*;
 
+    // --- cross-platform process helpers ---
+    //
+    // These tests spawn real processes, and the usual Unix stand-ins do not
+    // exist on Windows: `echo` and `false` are `cmd.exe` builtins with no
+    // executable behind them, so `Command::new("echo")` genuinely finds
+    // nothing. Routing through `cmd /C` keeps the same assertions meaningful on
+    // both platforms rather than compiling the coverage out on one of them.
+
+    /// Program + leading args that echo `words` back on the current platform.
+    fn echo_program(words: &[&str]) -> (&'static str, Vec<String>) {
+        let (program, mut args) = if cfg!(windows) {
+            ("cmd", vec!["/C".to_string(), "echo".to_string()])
+        } else {
+            ("echo", Vec::new())
+        };
+        args.extend(words.iter().map(|w| (*w).to_string()));
+        (program, args)
+    }
+
+    /// Program + args that exit non-zero without printing anything.
+    fn failing_program() -> (&'static str, Vec<String>) {
+        if cfg!(windows) {
+            ("cmd", vec!["/C".to_string(), "exit 1".to_string()])
+        } else {
+            ("false", Vec::new())
+        }
+    }
+
+    /// A shell snippet writing `msg` to stderr, in the platform shell's own
+    /// syntax — `execute_shell` uses `sh` on Unix and `powershell.exe` on
+    /// Windows, where `>&2` is not a redirection.
+    fn write_stderr(msg: &str) -> String {
+        if cfg!(windows) {
+            format!("[Console]::Error.WriteLine('{msg}')")
+        } else {
+            format!("echo {msg} >&2")
+        }
+    }
+
+    /// Join shell statements so they run in order. Windows PowerShell 5.1 — the
+    /// `powershell.exe` on the runners — has no `&&`.
+    fn shell_seq(parts: &[String]) -> String {
+        parts.join(if cfg!(windows) { "; " } else { " && " })
+    }
+
     // --- execute tests ---
 
     #[test]
     fn test_execute_echo() {
-        let result = execute("echo hello", &[]).unwrap();
+        let (program, args) = echo_program(&["hello"]);
+        let result = execute(program, &args).unwrap();
         assert_eq!(result.stdout.trim(), "hello");
         assert_eq!(result.exit_code, 0);
         assert!(result.stderr.is_empty());
@@ -283,21 +359,27 @@ mod tests {
 
     #[test]
     fn test_execute_with_args() {
-        let args = vec!["hello".to_string(), "world".to_string()];
-        let result = execute("echo", &args).unwrap();
+        let (program, args) = echo_program(&["hello", "world"]);
+        let result = execute(program, &args).unwrap();
         assert_eq!(result.stdout.trim(), "hello world");
     }
 
+    /// The first argument is a program, never a command line: it must reach
+    /// the OS whole. Splitting it on whitespace is what tore
+    /// `C:\Program Files\node.exe` in half and reported it as not found (#450).
     #[test]
-    fn test_execute_embedded_and_extra_args() {
-        let args = vec!["world".to_string()];
-        let result = execute("echo hello", &args).unwrap();
-        assert_eq!(result.stdout.trim(), "hello world");
+    fn execute_does_not_split_the_program_on_whitespace() {
+        let err = execute("echo hello", &[]).unwrap_err().to_string();
+        assert_eq!(
+            err, "program not found: echo hello",
+            "the whole string must be treated as one program name"
+        );
     }
 
     #[test]
     fn test_execute_failure() {
-        let result = execute("false", &[]).unwrap();
+        let (program, args) = failing_program();
+        let result = execute(program, &args).unwrap();
         assert_ne!(result.exit_code, 0);
     }
 
@@ -329,8 +411,8 @@ mod tests {
     #[test]
     fn test_execute_args_with_special_characters() {
         // execute() uses Command::new (no shell), so special chars are passed literally
-        let args = vec!["hello world".to_string()];
-        let result = execute("echo", &args).unwrap();
+        let (program, args) = echo_program(&["hello world"]);
+        let result = execute(program, &args).unwrap();
         assert_eq!(result.stdout.trim(), "hello world");
         assert_eq!(result.exit_code, 0);
     }
@@ -449,19 +531,21 @@ mod tests {
 
     #[test]
     fn test_combined_stdout_only() {
-        let result = execute("echo hello", &[]).unwrap();
+        let (program, args) = echo_program(&["hello"]);
+        let result = execute(program, &args).unwrap();
         assert_eq!(result.combined, "hello");
     }
 
     #[test]
     fn test_combined_stderr_only() {
-        let result = execute_shell("echo err >&2", &[]).unwrap();
+        let result = execute_shell(&write_stderr("err"), &[]).unwrap();
         assert_eq!(result.combined, "err");
     }
 
     #[test]
     fn test_combined_both_streams() {
-        let result = execute_shell("echo out && echo err >&2", &[]).unwrap();
+        let script = shell_seq(&["echo out".to_string(), write_stderr("err")]);
+        let result = execute_shell(&script, &[]).unwrap();
         // Both streams present in combined; exact order depends on scheduling
         assert!(result.combined.contains("out"));
         assert!(result.combined.contains("err"));
@@ -470,11 +554,13 @@ mod tests {
     #[test]
     fn test_combined_interleaving() {
         // Verify that stderr lines appear interleaved with stdout, not appended
-        let result = execute_shell(
-            "echo out1 && echo err1 >&2 && echo out2 && echo err2 >&2",
-            &[],
-        )
-        .unwrap();
+        let script = shell_seq(&[
+            "echo out1".to_string(),
+            write_stderr("err1"),
+            "echo out2".to_string(),
+            write_stderr("err2"),
+        ]);
+        let result = execute_shell(&script, &[]).unwrap();
         assert!(result.combined.contains("out1"));
         assert!(result.combined.contains("out2"));
         assert!(result.combined.contains("err1"));
@@ -487,10 +573,16 @@ mod tests {
 
     // --- resolve_program tests ---
 
+    /// A program every platform has, resolved by bare name.
+    ///
+    /// This failed on Windows before the switch to `which`: the old
+    /// `dir.join(program)` loop never appended an extension, so no `.exe` was
+    /// ever found by its bare name.
     #[test]
-    fn resolve_program_finds_sh() {
-        let result = resolve_program("sh");
-        assert!(result.is_some(), "sh should be on PATH");
+    fn resolve_program_finds_a_shell_by_bare_name() {
+        let name = if cfg!(windows) { "cmd" } else { "sh" };
+        let result = resolve_program(name);
+        assert!(result.is_some(), "{name} should be on PATH");
         assert!(result.unwrap().is_absolute());
     }
 
@@ -498,6 +590,56 @@ mod tests {
     fn resolve_program_returns_none_for_missing() {
         let result = resolve_program("nonexistent_program_xyz_abc_123");
         assert!(result.is_none());
+    }
+
+    /// Windows resolves a bare program name through `PATHEXT`, but
+    /// `CreateProcessW` only ever appends `.exe`. `which` applies the full
+    /// list, so a `.cmd` is reachable by a name that omits the extension.
+    ///
+    /// Uses an absolute path rather than mutating `PATH`, which is global
+    /// state — `CreateProcess` skips the `.exe` append for any name containing
+    /// a separator too, so this exercises the same gap. (#449)
+    #[cfg(windows)]
+    #[test]
+    fn execute_runs_a_cmd_shim_named_without_its_extension() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let script = dir.path().join("tokf_probe.cmd");
+        std::fs::write(&script, "@echo off\r\necho probe-ok\r\n").unwrap();
+
+        let extensionless = dir.path().join("tokf_probe");
+        let result = execute(&extensionless.to_string_lossy(), &[]).unwrap();
+
+        assert_eq!(result.stdout.trim(), "probe-ok");
+        assert_eq!(result.exit_code, 0);
+    }
+
+    /// A program whose *path* contains a space must reach the OS intact.
+    /// This is the #450 repro: `C:\Program Files\...` was cut at the space and
+    /// the leading half reported as the program.
+    #[test]
+    fn execute_runs_a_program_whose_path_contains_a_space() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let spaced = dir.path().join("probe dir");
+        std::fs::create_dir_all(&spaced).unwrap();
+
+        #[cfg(windows)]
+        let program = {
+            let p = spaced.join("probe.cmd");
+            std::fs::write(&p, "@echo off\r\necho probe-ok\r\n").unwrap();
+            p
+        };
+
+        #[cfg(unix)]
+        let program = {
+            use std::os::unix::fs::PermissionsExt;
+            let p = spaced.join("probe.sh");
+            std::fs::write(&p, "#!/bin/sh\necho probe-ok\n").unwrap();
+            std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+            p
+        };
+
+        let result = execute(&program.to_string_lossy(), &[]).unwrap();
+        assert_eq!(result.stdout.trim(), "probe-ok");
     }
 
     // --- execute_with_env tests ---
@@ -512,7 +654,8 @@ mod tests {
 
     #[test]
     fn test_execute_with_env_empty_env() {
-        let result = execute_with_env("echo", &["hi".into()], &[]).unwrap();
+        let (program, args) = echo_program(&["hi"]);
+        let result = execute_with_env(program, &args, &[]).unwrap();
         assert_eq!(result.stdout.trim(), "hi");
     }
 

--- a/crates/tokf-cli/tests/cli_hook_handle.rs
+++ b/crates/tokf-cli/tests/cli_hook_handle.rs
@@ -872,6 +872,9 @@ fn hook_log_unwritable_path_does_not_block_hook() {
     );
 }
 
+// Unix-only: the external engine is a `#!/bin/sh` script made executable with
+// a permission bit, neither of which exists on Windows.
+#[cfg(unix)]
 #[test]
 fn hook_log_records_ask_outcome() {
     // Wires the same external-engine harness as the existing #343 test

--- a/crates/tokf-cli/tests/cli_run.rs
+++ b/crates/tokf-cli/tests/cli_run.rs
@@ -4,6 +4,10 @@ mod common;
 
 use common::tokf;
 
+// Only the `nix develop -c` wrapper tests below use this, and they are
+// Unix-only — without the guard the import is dead on Windows and `-D warnings`
+// turns that into a build failure.
+#[cfg(unix)]
 use std::process::Command;
 
 // --- tokf run ---

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -276,3 +276,32 @@ after: |-
 Records are appended; nothing rotates or trims the file, so prune it yourself if it grows large. When the variable is unset (the default), nothing is written and the hook has zero filesystem overhead.
 
 This was added in response to issue #355, where stray `1echo` files in the agent's cwd turned out to come from a multi-line rewrite collapsing newlines into adjacent tokens — the kind of bug that's invisible in `tokf rewrite "..."` runs but obvious in a hook log.
+
+## Windows notes
+
+`tokf run` resolves a bare program name the way the platform does, which on
+Windows means consulting `PATHEXT`. That matters because most of the Node
+ecosystem ships as `.cmd` shims rather than `.exe` files:
+
+```console
+> tokf run npm --version
+11.11.0
+```
+
+Earlier versions could only find `.exe` programs, so `npm`, `npx`, `pnpm`,
+`tsc`, `eslint` and `gradlew` all failed with `program not found` unless you
+spelled out the extension (`npm.cmd`). If you added a `run =` line to a filter
+purely to work around that, it is no longer needed — though it is harmless.
+
+Two related fixes landed at the same time:
+
+- A program whose **path contains a space** — anything under
+  `C:\Program Files\` — is passed through whole. It used to be cut at the first
+  space, and the leading half reported as the program.
+- The **shims `PATH`** built for `inject_path = true` filters now uses `;`, the
+  Windows separator. With `:` the shims entry and the first real entry were both
+  lost, so shim injection silently did nothing.
+
+Still outstanding on Windows: filters that carry a `run =` line execute through
+`powershell.exe`, and a few built-ins assume POSIX shell syntax. Track that in
+[#360](https://github.com/mpecan/tokf/issues/360).

--- a/scripts/provision-windows-dev.ps1
+++ b/scripts/provision-windows-dev.ps1
@@ -1,0 +1,142 @@
+<#
+.SYNOPSIS
+    Provision a fresh Windows VM for building and testing tokf.
+
+.DESCRIPTION
+    Windows evaluation images expire after 90 days, so the VM is disposable by
+    design. This script exists so recreating one is a single command rather
+    than an afternoon: run it in a clean Windows 11 VM and it installs
+    everything needed to build the workspace and run the Windows test suite.
+
+    Installs: Git, rustup (honouring rust-toolchain.toml), Visual Studio Build
+    Tools with the C++ workload, CMake and NASM. The last four are not
+    optional — libsqlite3-sys, mlua-sys (Luau) and aws-lc-sys all compile C or
+    C++ and need a real MSVC toolchain plus a linker.
+
+.PARAMETER SkipBuildTools
+    Skip the Visual Studio Build Tools install. Use when the VM already has
+    them — it is by far the slowest step (several GB).
+
+.PARAMETER RepoUrl
+    Repository to clone. Defaults to the public tokf repo.
+
+.EXAMPLE
+    # In an elevated PowerShell in the fresh VM:
+    iwr -useb https://raw.githubusercontent.com/mpecan/tokf/main/scripts/provision-windows-dev.ps1 | iex
+
+.NOTES
+    Run as Administrator. Written for Windows 11 (x64 or ARM64) with winget
+    available, which is the default on current images.
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$SkipBuildTools,
+    [string]$RepoUrl = 'https://github.com/mpecan/tokf.git'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "`n=== $Message ===" -ForegroundColor Cyan
+}
+
+function Test-Admin {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+if (-not (Test-Admin)) {
+    throw 'Run this in an elevated PowerShell — the Build Tools install needs Administrator.'
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    throw 'winget not found. Install "App Installer" from the Microsoft Store, then re-run.'
+}
+
+# ARM64 hosts need the ARM64 compilers; x64 needs NASM for aws-lc-sys assembly.
+$arch = $env:PROCESSOR_ARCHITECTURE
+Write-Step "Detected architecture: $arch"
+
+function Install-Package {
+    param([string]$Id, [string]$Label)
+    Write-Host "Installing $Label ($Id)..."
+    # --accept-* keeps this non-interactive; a package already present is not an error.
+    winget install --id $Id --exact --silent --disable-interactivity `
+        --accept-package-agreements --accept-source-agreements
+    if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne -1978335189) {
+        throw "$Label failed to install (winget exit $LASTEXITCODE)"
+    }
+}
+
+Write-Step 'Core tools'
+Install-Package -Id 'Git.Git'        -Label 'Git'
+Install-Package -Id 'Kitware.CMake'  -Label 'CMake'      # aws-lc-sys
+Install-Package -Id 'Rustlang.Rustup' -Label 'rustup'
+
+if ($arch -eq 'AMD64') {
+    # aws-lc-sys assembles x86-64 sources with NASM. Not used on ARM64.
+    Install-Package -Id 'NASM.NASM' -Label 'NASM'
+    $nasm = 'C:\Program Files\NASM'
+    if (Test-Path $nasm) {
+        $env:PATH = "$nasm;$env:PATH"
+        [Environment]::SetEnvironmentVariable('PATH', "$nasm;$([Environment]::GetEnvironmentVariable('PATH','Machine'))", 'Machine')
+    }
+}
+
+if (-not $SkipBuildTools) {
+    Write-Step 'Visual Studio Build Tools (slow — several GB)'
+    # The C++ workload brings MSVC and the Windows SDK. On ARM64 the ARM64
+    # compilers are a separate component and are NOT in --includeRecommended.
+    $components = @(
+        '--add', 'Microsoft.VisualStudio.Workload.VCTools',
+        '--includeRecommended'
+    )
+    if ($arch -eq 'ARM64') {
+        $components += @('--add', 'Microsoft.VisualStudio.Component.VC.Tools.ARM64')
+    }
+    $override = ($components + @('--wait', '--quiet', '--norestart')) -join ' '
+
+    winget install --id 'Microsoft.VisualStudio.2022.BuildTools' --exact --silent `
+        --disable-interactivity --accept-package-agreements --accept-source-agreements `
+        --override $override
+    if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne -1978335189) {
+        throw "Build Tools failed to install (winget exit $LASTEXITCODE)"
+    }
+}
+
+# winget updates the machine PATH but not this session's.
+Write-Step 'Refreshing PATH for this session'
+$env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' +
+            [Environment]::GetEnvironmentVariable('PATH', 'User')
+
+Write-Step 'Cloning the repository'
+$repoDir = Join-Path $HOME 'tokf'
+if (Test-Path $repoDir) {
+    Write-Host "$repoDir already exists — pulling instead of cloning."
+    git -C $repoDir pull --ff-only
+} else {
+    git clone $RepoUrl $repoDir
+}
+Set-Location $repoDir
+
+# rustup reads rust-toolchain.toml here and installs the pinned toolchain,
+# so the VM matches CI without the version being duplicated in this script.
+Write-Step 'Installing the pinned Rust toolchain'
+rustup show
+
+Write-Step 'Done'
+Write-Host @"
+Provisioned. To run the same checks the Windows CI job runs:
+
+    cd $repoDir
+    cargo clippy --locked -p tokf --all-targets -- -D warnings
+    cargo test   --locked -p tokf --lib
+    cargo test   --locked -p tokf --bin tokf
+
+The first build compiles Luau, SQLite and aws-lc from source and will take a
+while. Snapshot the VM once this succeeds — that is the point you want to
+return to after the evaluation licence expires.
+"@ -ForegroundColor Green


### PR DESCRIPTION
Fixes #449, #450 and #451 together — they are three defects in one code path — and adds the `windows-latest` job that would have caught all three.

Credit to the reporter: all three issues arrived root-caused to the line, with patches verified in isolation on real hardware. This implements them.

## The three fixes

### #449 — `PATHEXT` is never consulted

`Command::new` reaches `CreateProcessW`, which only ever appends `.exe`. Every other `PATHEXT` entry — `.cmd`, `.bat`, `.com` — was unreachable, so `tokf run npm` failed while `tokf run npm.cmd` worked.

**With the hook installed this is an outright failure, not a missed optimisation**: the hook rewrites matched commands into `tokf run …`, so the agent receives `program not found: npm` instead of the command's output. 42 of 51 stdlib filters carry no `run =` line and take this path — `npm/run`, `npm/test`, `playwright`, `tsc`, `eslint`, `gradle/*`, `pnpm/*` and more.

`resolve_program` now delegates to `which` (already a dependency), and a spawn failing with `NotFound` retries through it once. The old `dir.join(program)` loop had *no success mode* on Windows: for `npm` it matched the extensionless POSIX script sitting beside `npm.cmd` — which `CreateProcessW` cannot execute — and for a real `.exe` like `git` it found nothing, so the shim-avoidance the function exists for never happened.

### #450 — argv torn apart at spaces

The runner joined argv with spaces then split it again on whitespace, so `C:\Program Files\node.exe` was reported as `program not found: C:\Program`.

Rather than make the splitter quote-aware, **the round-trip is gone**. Every caller already passed a single argv element; the one join site now passes the matched prefix through as args instead. `execute_with_env` takes a *program*, never a command line. That also removed a branch, since both call sites collapse into one.

### #451 — `PATH` built with `:`

`build_inject_env` hard-coded `:`. On Windows that is not the separator, and `:` occurs inside every absolute path — `C:\…\shims:C` parsed as one entry, so the shims entry *and* the first real entry were both lost. Now uses `env::join_paths`, matching the `split_paths` that reads it back.

Extracted to `path_env.rs`: `resolve.rs` went 22 lines over the 700-line hard limit with it inline.

## The Windows gate

New `windows-latest` job wired into the aggregate `Check` job. It runs clippy over all targets — which catches the *compile-time* class, and there was a live instance: `cli_hook_handle.rs` had an unguarded `std::os::unix` import and `cli_run.rs` an import left dead on Windows, so the crate did not build there at all — plus the unit and binary-crate tests.

**Scope is deliberate**: the job runs the `tokf` unit tests, not the whole workspace. Much of the integration suite shells out to `sh` and asserts POSIX semantics, which is #360 and a separate problem. A gate that cannot be green is not a gate, so this starts at a level that holds and can widen.

## On testing this without Windows

Where an invariant holds on every platform, the test asserts it everywhere rather than being cfg'd to Windows — the `PATH` round-trip through `split_paths` and the argv pass-through both fail on macOS if the fix regresses. Only genuinely platform-specific assertions (a drive letter surviving as one entry) are cfg-gated.

The process-spawning tests now route through `cmd /C` on Windows instead of being compiled out: `echo` and `false` are `cmd.exe` builtins with no executable behind them, so `Command::new("echo")` legitimately finds nothing there.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 2471 passed, 0 failed
- `scripts/check-file-sizes.sh` — passes (this is what forced the `path_env.rs` split)
- Windows behaviour: verified by the new CI job, not locally — see the PR discussion for why local Windows verification is not currently possible on an Apple Silicon host

## Docs

`docs/diagnostics.md` gains a Windows section with the before/after, a note that `run =` workarounds are no longer needed, and a pointer to #360 for what is still outstanding.

Closes #449, closes #450, closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)