### PR TITLE
chore(deps): consolidate the three open dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: "1.97.1"
+          toolchain: "1.98.0"
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
@@ -116,7 +116,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: "1.97.1"
+          toolchain: "1.98.0"
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
@@ -208,7 +208,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: "1.97.1"
+          toolchain: "1.98.0"
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
@@ -241,7 +241,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: "1.97.1"
+          toolchain: "1.98.0"
           components: clippy
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3981,7 +3981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4253,9 +4253,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4289,9 +4289,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]

--- a/crates/crdb-test-macro/Cargo.toml
+++ b/crates/crdb-test-macro/Cargo.toml
@@ -10,7 +10,7 @@ proc-macro = true
 
 [dependencies]
 quote = "1"
-syn = { version = "2", features = ["full"] }
+syn = { version = "3", features = ["full"] }
 proc-macro2 = "1"
 
 [lints]

--- a/crates/tokf-cli/src/config/mod.rs
+++ b/crates/tokf-cli/src/config/mod.rs
@@ -192,11 +192,7 @@ pub fn pattern_matches_prefix(pattern: &str, words: &[&str]) -> Option<usize> {
                 word_idx += 1;
             } else if pat_idx > 0 {
                 // Between pattern words, try to skip over global flag tokens.
-                if let Some(advance) = skip_flags_to_match(&words[word_idx..], pword) {
-                    word_idx += advance;
-                } else {
-                    return None;
-                }
+                word_idx += skip_flags_to_match(&words[word_idx..], pword)?;
             } else {
                 return None;
             }

--- a/crates/tokf-cli/src/config/tests_matching.rs
+++ b/crates/tokf-cli/src/config/tests_matching.rs
@@ -29,7 +29,7 @@ fn specificity_all_wildcards() {
 fn specificity_ordering() {
     // "git push" more specific than "git *" more specific than "* push"
     assert!(pattern_specificity("git push") > pattern_specificity("git *"));
-    assert!(pattern_specificity("git *") == pattern_specificity("* push"));
+    assert_eq!(pattern_specificity("git *"), pattern_specificity("* push"));
 }
 
 // --- pattern_matches_prefix ---

--- a/crates/tokf-cli/tests/config_resolution.rs
+++ b/crates/tokf-cli/tests/config_resolution.rs
@@ -255,7 +255,10 @@ fn test_pattern_matches_prefix_basic() {
 #[test]
 fn test_pattern_specificity_ordering() {
     assert!(config::pattern_specificity("git push") > config::pattern_specificity("git *"));
-    assert!(config::pattern_specificity("git *") == config::pattern_specificity("* push"));
+    assert_eq!(
+        config::pattern_specificity("git *"),
+        config::pattern_specificity("* push")
+    );
     assert_eq!(config::pattern_specificity("git push"), 2);
     assert_eq!(config::pattern_specificity("git *"), 1);
 }

--- a/crates/tokf-common/Cargo.toml
+++ b/crates/tokf-common/Cargo.toml
@@ -18,7 +18,7 @@ sha2 = "0.11"
 # emission (escape choices, float formatting, key ordering) silently changes
 # every published hash. Per ADR-0002, version bumps must be gated by the
 # frozen v1 corpus; if the corpus drifts, either stay pinned or ship v2.
-toml = "=1.1.3"
+toml = "=1.1.4"
 regex = { version = "1", optional = true }
 unicode-normalization = "0.1"
 # Calibration-only, OFF by default (`tokenizer` feature). Fully offline:

--- a/crates/tokf-filter/src/filter/template/mod.rs
+++ b/crates/tokf-filter/src/filter/template/mod.rs
@@ -84,7 +84,7 @@ fn find_expressions(template: &str) -> Vec<(usize, usize)> {
 }
 
 /// Find the matching `}` for an opening `{` at `start`, respecting nesting and quotes.
-fn find_matching_close(bytes: &[u8], start: usize) -> Option<usize> {
+const fn find_matching_close(bytes: &[u8], start: usize) -> Option<usize> {
     let mut depth = 0;
     let mut in_quote = false;
     let mut i = start;

--- a/crates/tokf-server/src/routes/ip.rs
+++ b/crates/tokf-server/src/routes/ip.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::net::SocketAddr;
 
 use axum::extract::ConnectInfo;
@@ -15,12 +16,17 @@ pub struct PeerIp(pub Option<String>);
 impl<S: Send + Sync> axum::extract::FromRequestParts<S> for PeerIp {
     type Rejection = std::convert::Infallible;
 
-    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+    // Not an `async fn`: there is nothing to await, and returning a ready
+    // future avoids generating an async state machine for a plain lookup.
+    fn from_request_parts(
+        parts: &mut Parts,
+        _state: &S,
+    ) -> impl Future<Output = Result<Self, Self::Rejection>> {
         let ip = parts
             .extensions
             .get::<ConnectInfo<SocketAddr>>()
             .map(|ci| ci.0.ip().to_string());
-        Ok(Self(ip))
+        std::future::ready(Ok(Self(ip)))
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.98.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Replaces #458, #459 and #461 — all three are currently unmergeable. Closes them if merged.

## Why they can't merge as-is

| PR | Update | Failing | Cause |
|---|---|---|---|
| #458 | rust 1.96.0 → 1.98.0 | Supply chain, **Lint**, **Windows** | stale base + new 1.98 clippy lints |
| #459 | toml =1.1.3 → =1.1.4 | Supply chain, `renovate/artifacts` | stale base + renovate could not update the lockfile |
| #461 | syn 2 → 3 | Supply chain | stale base only |

Every one fails **Supply chain** for the same reason: they predate the h2/chacha20 fix in #463. So all three needed a rebase regardless, and doing it once is cheaper than three times. They also all touch `Cargo.lock`, so merging any one would conflict the other two.

#459's lockfile wasn't reusable in any case — its `renovate/artifacts` step failed, and its 242-line diff was churn accumulated from a much older base. Regenerating from the manifest change touches **12 lines**.

## A pin that had drifted

`rust-toolchain.toml` said `1.96.0` while `ci.yml` pinned `1.97.1` in four places. rustup honours the file, so CI was installing one toolchain and building with another — #457 evidently updated one side only. Both now say `1.98.0`, which is also why #458's failure didn't look like a toolchain problem.

## Four new lints in 1.98, all genuine

CI reported only the first: clippy aborts `tokf-filter` before reaching the rest, so #458 looked like a one-line fix when it wasn't.

- **`missing_const_for_fn`** — `find_matching_close` is pure byte arithmetic, so it's simply `const fn` now. (the one CI showed)
- **`question_mark`** — an `if let … else { return None }` in `pattern_matches_prefix`.
- **`manual_assert_eq`** — two `assert!(a == b)` in specificity tests.
- **`unused_async_trait_impl`** — the `PeerIp` axum extractor awaits nothing. Returns a ready future instead, per clippy's own suggestion; that also drops an async state machine from what is a plain extension lookup. No `#[allow]` needed.

## Verification

Run locally against **1.98.0** (installed via the updated `rust-toolchain.toml`, so this is the toolchain CI will use):

- 2539 tests pass, 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean
- `cargo deny check advisories bans sources` → `advisories ok, bans ok, sources ok`

Windows I can't run locally, but its failure on #458 was the same `find_matching_close` lint as Lint, so it should clear with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
