### PR TITLE
feat(rewrite): leave git unrewritten inside linked worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -1887,6 +1887,57 @@ match = "^(?:[^\\s]*/)?mise run(\\s.*)?$"
 replace = "SHELL=tokf mise run{1}"
 ```
 
+## Git commands inside worktrees
+
+When the working directory is inside a **linked** git worktree — one created by
+`git worktree add` — tokf leaves `git` commands unrewritten:
+
+```sh
+# In the main checkout:
+git status          →  tokf run git status
+
+# In a linked worktree:
+git status          →  git status          (unchanged)
+cargo test          →  tokf run cargo test (still filtered)
+```
+
+This exists because of agent harnesses that isolate an agent to its own
+worktree. They verify that git operations stay inside that worktree by reading
+the command string, and once tokf rewrites `git status` to
+`tokf run git status` the leading word is an opaque wrapper — the check can no
+longer see the git invocation it was meant to inspect, so it refuses to run the
+command at all. Leaving `git` alone keeps those commands legible. Every other
+command in the worktree is still filtered normally.
+
+Detection reads git's own on-disk layout, not a path convention: a linked
+worktree's `.git` is a *file* containing `gitdir: <common-dir>/worktrees/<id>`,
+where the main worktree's `.git` is a directory. So it holds for any worktree
+wherever it lives, and submodules — whose `.git` file points at
+`<common-dir>/modules/<name>` — are correctly left out.
+
+The guard applies per segment, so a compound command keeps the filters it can:
+
+```sh
+git add . && cargo test   →  git add . && tokf run cargo test
+```
+
+It applies only where something re-reads the rewritten command: the hook, and
+`tokf rewrite`, which exists to show what the hook would emit. Shell mode
+(`tokf -c`, used by the `make` and `just` wrappers) and the PATH shims hand
+their result straight to `sh`, so a `just` recipe running `git log` inside a
+worktree keeps its filter.
+
+To turn it off and filter git inside worktrees as well:
+
+```toml
+# .tokf/rewrites.toml
+[worktree]
+skip_git = false
+```
+
+Run `tokf rewrite --verbose "git status"` from inside a worktree to see whether
+the guard is active.
+
 ## Routing to generic commands
 
 For commands that don't have a dedicated filter, you can route them through [generic commands](generic-commands.md) (`tokf err`, `tokf test`, `tokf summary`) via rewrite rules:

--- a/crates/tokf-cli/src/commands.rs
+++ b/crates/tokf-cli/src/commands.rs
@@ -540,7 +540,13 @@ pub fn cmd_ls(rt: &Runtime, verbose: bool) -> i32 {
 }
 
 pub fn cmd_rewrite(rt: &Runtime, command: &str, verbose: bool) -> i32 {
-    let result = rewrite::rewrite(rt, command, verbose);
+    // `tokf rewrite` exists to show what the hook would emit, so it mirrors
+    // the hook's options rather than the defaults.
+    let options = rewrite::types::RewriteOptions {
+        no_mask_exit_code: false,
+        guard_worktree_git: true,
+    };
+    let result = rewrite::rewrite_with_options(rt, command, verbose, &options);
     println!("{result}");
     0
 }

--- a/crates/tokf-cli/src/hook/mod.rs
+++ b/crates/tokf-cli/src/hook/mod.rs
@@ -574,7 +574,12 @@ fn decide<R: serde::Serialize>(
     // Propagate `tokf hook --no-mask-exit-code handle` into every generated
     // `tokf run` invocation (including each member of a compound command) —
     // otherwise the flag is silently dropped and exit codes stay masked (#414).
-    let options = rewrite::types::RewriteOptions { no_mask_exit_code };
+    // `guard_worktree_git`: the hook's output is exactly what a harness
+    // re-reads and statically verifies, so this is the path that needs it.
+    let options = rewrite::types::RewriteOptions {
+        no_mask_exit_code,
+        guard_worktree_git: true,
+    };
     // `verbose` is `false`: hook rewrites must not emit diagnostics to the
     // agent's stderr, and `no_cache` rides in `RewriteCtx`, not the old
     // positional bool that used to be mistaken for it (#431).

--- a/crates/tokf-cli/src/rewrite/mod.rs
+++ b/crates/tokf-cli/src/rewrite/mod.rs
@@ -5,6 +5,7 @@ pub mod capture;
 pub(crate) mod rules;
 pub(crate) mod transparent;
 pub(crate) mod user_config;
+pub(crate) mod worktree;
 
 use std::path::PathBuf;
 
@@ -170,6 +171,9 @@ pub(super) struct SegmentRules<'a> {
     pub(super) pipefail_handled: bool,
     /// When true, log to stderr when the bash parser fails to parse a command.
     pub(super) log_parse_failures: bool,
+    /// Leaves `git` segments unrewritten inside a linked worktree. Sits here
+    /// beside the other whole-command facts consulted per segment.
+    pub(super) git_guard: &'a worktree::GitGuard<'a>,
 }
 
 /// Rewrite a single command segment, handling pipe stripping and env var
@@ -353,6 +357,15 @@ pub(crate) fn rewrite_with_config_and_options(
         return command.to_string();
     }
 
+    let git_guard = worktree::GitGuard::new(ctx.rt, user_config, options, verbose);
+    let segments = split_compound(command);
+
+    // A single-segment command is its own segment, so the guard settles it
+    // here — ahead of the user `[[rewrite]]` rules below.
+    if segments.len() == 1 && git_guard.claims(command) {
+        return command.to_string();
+    }
+
     let transparent_extras: &[String] = user_config
         .transparent
         .as_ref()
@@ -363,7 +376,11 @@ pub(crate) fn rewrite_with_config_and_options(
     // (#338): regex rewrites operate on the full command string, so even an
     // ssh segment buried behind a `cd … &&` could have text spliced into its
     // opaque payload. Argv-preserving wraps below still apply per-segment.
+    // A guarded segment gates them for the same reason (`git add . && cargo
+    // test`): the rule matches the whole string, so it would splice a wrapper
+    // back in front of the git half that must stay legible.
     if !transparent::any_segment_is_transparent(command, transparent_extras)
+        && !git_guard.claims_any_segment(&segments)
         && let Some(user_result) = apply_rules(&user_config.rewrite, command)
     {
         return user_result;
@@ -392,24 +409,37 @@ pub(crate) fn rewrite_with_config_and_options(
         // in the default configuration.
         pipefail_handled: pipe_cfg.capture && handles_pipe_status(command),
         log_parse_failures,
+        git_guard: &git_guard,
     };
-    let segments = split_compound(command);
-
     if segments.len() == 1 {
         return rewrite_segment(command, "", &rules, verbose);
     }
+    rewrite_compound(command, &segments, &rules, user_skip_patterns, verbose)
+}
 
-    // Compound command: rewrite each segment independently so every sub-command
-    // that has a matching filter is wrapped, not just the first one.
+/// Rewrite each segment of a compound command independently, so every
+/// sub-command with a matching filter is wrapped — not just the first one.
+///
+/// Returns the original command untouched when no segment changed, so a
+/// command tokf has no opinion about is handed back byte-for-byte.
+fn rewrite_compound(
+    command: &str,
+    segments: &[(String, String)],
+    rules: &SegmentRules<'_>,
+    user_skip_patterns: &[String],
+    verbose: bool,
+) -> String {
     let mut changed = false;
     let mut out = String::with_capacity(command.len() + segments.len() * 9);
-    for (seg, sep) in &segments {
+    for (seg, sep) in segments {
         let trimmed = seg.trim();
-        let rewritten = if trimmed.is_empty() || should_skip_effective(trimmed, user_skip_patterns)
+        let rewritten = if trimmed.is_empty()
+            || rules.git_guard.claims(trimmed)
+            || should_skip_effective(trimmed, user_skip_patterns)
         {
             trimmed.to_string()
         } else {
-            let r = rewrite_segment(trimmed, sep, &rules, verbose);
+            let r = rewrite_segment(trimmed, sep, rules, verbose);
             if r != trimmed {
                 changed = true;
             }
@@ -427,55 +457,15 @@ mod bash_ast_multibyte_tests;
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod bash_ast_tests;
-/// Test helpers: run a rewrite with explicit config against a freshly isolated
-/// runtime, so every test gets its own directories with no setup and no shared
-/// state to collide over.
-#[cfg(test)]
-pub(crate) fn rewrite_isolated(
-    command: &str,
-    user_config: &RewriteConfig,
-    search_dirs: &[PathBuf],
-    verbose: bool,
-) -> String {
-    rewrite_isolated_with_options(
-        command,
-        user_config,
-        search_dirs,
-        verbose,
-        &RewriteOptions::default(),
-    )
-}
-
-#[cfg(test)]
-pub(crate) fn rewrite_isolated_with_options(
-    command: &str,
-    user_config: &RewriteConfig,
-    search_dirs: &[PathBuf],
-    verbose: bool,
-    options: &RewriteOptions,
-) -> String {
-    let rt = Runtime::isolated();
-    rewrite_with_config_and_options(
-        RewriteCtx {
-            rt: &rt,
-            user_config,
-            search_dirs,
-            no_cache: false,
-        },
-        command,
-        verbose,
-        options,
-    )
-}
-
-#[cfg(test)]
-pub(crate) fn collect_filter_patterns_isolated(search_dirs: &[PathBuf]) -> Vec<String> {
-    let rt = Runtime::isolated();
-    collect_filter_patterns(&rt, search_dirs, false)
-}
-
 #[cfg(test)]
 mod proptest_rewrite;
+#[cfg(test)]
+pub(crate) mod test_helpers;
+#[cfg(test)]
+pub(crate) use test_helpers::{
+    collect_filter_patterns_isolated, rewrite_in_cwd, rewrite_isolated,
+    rewrite_isolated_with_options,
+};
 #[cfg(test)]
 mod tests;
 #[cfg(test)]
@@ -490,3 +480,5 @@ mod tests_local_wrapper;
 mod tests_pipe;
 #[cfg(test)]
 mod tests_transparent;
+#[cfg(test)]
+mod tests_worktree;

--- a/crates/tokf-cli/src/rewrite/test_helpers.rs
+++ b/crates/tokf-cli/src/rewrite/test_helpers.rs
@@ -1,0 +1,108 @@
+//! Test-only helpers for driving the rewrite engine.
+#![allow(clippy::expect_used)]
+
+//!
+//! Each helper builds its own [`Runtime`], so every test gets fresh
+//! directories with no setup and no shared state to collide over.
+
+use std::path::{Path, PathBuf};
+
+use super::types::{RewriteConfig, RewriteOptions};
+use super::{RewriteCtx, collect_filter_patterns, rewrite_with_config_and_options};
+use crate::runtime::Runtime;
+
+/// Run a rewrite with explicit config against an isolated runtime.
+pub fn rewrite_isolated(
+    command: &str,
+    user_config: &RewriteConfig,
+    search_dirs: &[PathBuf],
+    verbose: bool,
+) -> String {
+    rewrite_isolated_with_options(
+        command,
+        user_config,
+        search_dirs,
+        verbose,
+        &RewriteOptions::default(),
+    )
+}
+
+pub fn rewrite_isolated_with_options(
+    command: &str,
+    user_config: &RewriteConfig,
+    search_dirs: &[PathBuf],
+    verbose: bool,
+    options: &RewriteOptions,
+) -> String {
+    rewrite_with(
+        &Runtime::isolated(),
+        command,
+        user_config,
+        search_dirs,
+        verbose,
+        options,
+    )
+}
+
+/// Run a rewrite with the runtime's working directory pointed at `cwd`, so
+/// worktree detection has a real directory layout to read.
+pub fn rewrite_in_cwd(
+    command: &str,
+    user_config: &RewriteConfig,
+    search_dirs: &[PathBuf],
+    cwd: &Path,
+    options: &RewriteOptions,
+) -> String {
+    let rt = Runtime::builder().cwd(cwd).build();
+    rewrite_with(&rt, command, user_config, search_dirs, false, options)
+}
+
+/// The one place tests construct a [`RewriteCtx`], so a new field on it is a
+/// single edit rather than one per helper.
+///
+/// Over the argument limit because it is the union of what the public helpers
+/// above take; collapsing it would just move the arguments to their call sites.
+#[allow(clippy::too_many_arguments)]
+fn rewrite_with(
+    rt: &Runtime,
+    command: &str,
+    user_config: &RewriteConfig,
+    search_dirs: &[PathBuf],
+    verbose: bool,
+    options: &RewriteOptions,
+) -> String {
+    rewrite_with_config_and_options(
+        RewriteCtx {
+            rt,
+            user_config,
+            search_dirs,
+            no_cache: false,
+        },
+        command,
+        verbose,
+        options,
+    )
+}
+
+pub fn collect_filter_patterns_isolated(search_dirs: &[PathBuf]) -> Vec<String> {
+    let rt = Runtime::isolated();
+    collect_filter_patterns(&rt, search_dirs, false)
+}
+
+/// Build a checkout whose `.git` file marks it a **linked** worktree, and
+/// return its path.
+pub fn linked_worktree(root: &Path) -> PathBuf {
+    let wt = root.join("wt");
+    std::fs::create_dir_all(&wt).expect("create worktree dir");
+    std::fs::write(wt.join(".git"), "gitdir: /repo/.git/worktrees/agent-x\n")
+        .expect("write .git file");
+    wt
+}
+
+/// Build a checkout whose `.git` is a directory — an ordinary **main**
+/// worktree — and return its path.
+pub fn main_worktree(root: &Path) -> PathBuf {
+    let repo = root.join("repo");
+    std::fs::create_dir_all(repo.join(".git")).expect("create .git dir");
+    repo
+}

--- a/crates/tokf-cli/src/rewrite/tests.rs
+++ b/crates/tokf-cli/src/rewrite/tests.rs
@@ -197,16 +197,11 @@ fn rewrite_user_rule_takes_priority() {
     .unwrap();
 
     let config = RewriteConfig {
-        skip: None,
-        pipe: None,
         rewrite: vec![RewriteRule {
             match_pattern: "^git status".to_string(),
             replace: "custom-wrapper {0}".to_string(),
         }],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     };
     let result = rewrite_isolated("git status", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(result, "custom-wrapper git status");
@@ -225,12 +220,8 @@ fn rewrite_user_skip_prevents_rewrite() {
         skip: Some(types::SkipConfig {
             patterns: vec!["^git status".to_string()],
         }),
-        pipe: None,
         rewrite: vec![],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     };
     let result = rewrite_isolated("git status", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(result, "git status");
@@ -394,16 +385,11 @@ fn wrapper_just_full_path() {
 fn wrapper_user_rule_overrides_builtin_wrapper() {
     let dir = TempDir::new().unwrap();
     let config = RewriteConfig {
-        skip: None,
-        pipe: None,
         rewrite: vec![RewriteRule {
             match_pattern: r"^make(\s.*)?$".to_string(),
             replace: "custom-make{1}".to_string(),
         }],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     };
     let r = rewrite_isolated("make check", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(r, "custom-make check");
@@ -416,12 +402,8 @@ fn wrapper_skip_pattern_prevents_wrapper() {
         skip: Some(types::SkipConfig {
             patterns: vec!["^make".to_string()],
         }),
-        pipe: None,
         rewrite: vec![],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     };
     let r = rewrite_isolated("make check", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(r, "make check");

--- a/crates/tokf-cli/src/rewrite/tests_compound.rs
+++ b/crates/tokf-cli/src/rewrite/tests_compound.rs
@@ -236,16 +236,11 @@ fn rewrite_user_rule_wraps_piped_command() {
     // Using {0}{rest} captures both the matched portion and the remainder (including the pipe).
     let dir = TempDir::new().unwrap();
     let config = RewriteConfig {
-        skip: None,
-        pipe: None,
         rewrite: vec![RewriteRule {
             match_pattern: "^cargo test".to_string(),
             replace: "my-wrapper {0}{rest}".to_string(),
         }],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     };
     let r = rewrite_isolated(
         "cargo test | grep FAILED",
@@ -265,12 +260,8 @@ fn rewrite_skip_pattern_wins_over_pipe_guard() {
         skip: Some(types::SkipConfig {
             patterns: vec!["^git".to_string()],
         }),
-        pipe: None,
         rewrite: vec![],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     };
     let r = rewrite_isolated(
         "git status | grep M",

--- a/crates/tokf-cli/src/rewrite/tests_env.rs
+++ b/crates/tokf-cli/src/rewrite/tests_env.rs
@@ -226,12 +226,8 @@ fn rewrite_user_skip_pattern_matches_env_stripped_command() {
         skip: Some(types::SkipConfig {
             patterns: vec!["^git".to_string()],
         }),
-        pipe: None,
         rewrite: vec![],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     };
     // "FOO=bar git status" does NOT start with "git", so skip does not fire
     // and the command IS rewritten.

--- a/crates/tokf-cli/src/rewrite/tests_pipe.rs
+++ b/crates/tokf-cli/src/rewrite/tests_pipe.rs
@@ -20,17 +20,13 @@ fn rewrite_pipe_strip_disabled_preserves_pipe() {
     .unwrap();
 
     let config = RewriteConfig {
-        skip: None,
         pipe: Some(types::PipeConfig {
             strip: false,
             prefer_less: false,
             ..Default::default()
         }),
         rewrite: vec![],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     };
     let r = rewrite_isolated(
         "cargo test | tail -5",
@@ -52,17 +48,13 @@ fn rewrite_pipe_strip_disabled_non_piped_still_rewritten() {
     .unwrap();
 
     let config = RewriteConfig {
-        skip: None,
         pipe: Some(types::PipeConfig {
             strip: false,
             prefer_less: false,
             ..Default::default()
         }),
         rewrite: vec![],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     };
     let r = rewrite_isolated(
         "cargo test --lib",
@@ -86,17 +78,13 @@ fn rewrite_prefer_less_injects_flag() {
     .unwrap();
 
     let config = RewriteConfig {
-        skip: None,
         pipe: Some(types::PipeConfig {
             strip: true,
             prefer_less: true,
             ..Default::default()
         }),
         rewrite: vec![],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     };
     let r = rewrite_isolated(
         "cargo test | tail -5",
@@ -120,17 +108,13 @@ fn rewrite_prefer_less_without_pipe_no_effect() {
     .unwrap();
 
     let config = RewriteConfig {
-        skip: None,
         pipe: Some(types::PipeConfig {
             strip: true,
             prefer_less: true,
             ..Default::default()
         }),
         rewrite: vec![],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     };
     let r = rewrite_isolated(
         "cargo test --lib",
@@ -152,17 +136,13 @@ fn rewrite_strip_false_overrides_prefer_less() {
     .unwrap();
 
     let config = RewriteConfig {
-        skip: None,
         pipe: Some(types::PipeConfig {
             strip: false,
             prefer_less: true,
             ..Default::default()
         }),
         rewrite: vec![],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     };
     let r = rewrite_isolated(
         "cargo test | tail -5",
@@ -181,17 +161,13 @@ fn rewrite_compound_prefer_less_per_segment() {
     fs::write(dir.path().join("git-diff.toml"), "command = \"git diff\"").unwrap();
 
     let config = RewriteConfig {
-        skip: None,
         pipe: Some(types::PipeConfig {
             strip: true,
             prefer_less: true,
             ..Default::default()
         }),
         rewrite: vec![],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     };
     let r = rewrite_isolated(
         "git add . && git diff | head -5",
@@ -249,6 +225,7 @@ fn inject_pipe_flags_empty_suffix() {
 fn inject_pipe_flags_no_mask_exit_code() {
     let opts = types::RewriteOptions {
         no_mask_exit_code: true,
+        ..Default::default()
     };
     let r = inject_pipe_flags_with_options(
         "tokf run --no-mask-exit-code cargo test",
@@ -267,6 +244,7 @@ fn inject_pipe_flags_no_mask_exit_code() {
 fn inject_pipe_flags_no_mask_exit_code_with_prefer_less() {
     let opts = types::RewriteOptions {
         no_mask_exit_code: true,
+        ..Default::default()
     };
     let r = inject_pipe_flags_with_options(
         "tokf run --no-mask-exit-code cargo test",
@@ -294,6 +272,7 @@ fn rewrite_no_mask_exit_code_simple_match() {
     let config = RewriteConfig::default();
     let opts = types::RewriteOptions {
         no_mask_exit_code: true,
+        ..Default::default()
     };
     let r = rewrite_isolated_with_options(
         "cargo test --lib",
@@ -317,6 +296,7 @@ fn rewrite_no_mask_exit_code_piped_no_duplication() {
     let config = RewriteConfig::default();
     let opts = types::RewriteOptions {
         no_mask_exit_code: true,
+        ..Default::default()
     };
     let r = rewrite_isolated_with_options(
         "cargo test | tail -5",
@@ -345,6 +325,7 @@ fn rewrite_no_mask_exit_code_compound() {
     let config = RewriteConfig::default();
     let opts = types::RewriteOptions {
         no_mask_exit_code: true,
+        ..Default::default()
     };
     let r = rewrite_isolated_with_options(
         "git add . && cargo test",

--- a/crates/tokf-cli/src/rewrite/tests_transparent.rs
+++ b/crates/tokf-cli/src/rewrite/tests_transparent.rs
@@ -22,16 +22,11 @@ use crate::rewrite::transparent::{
 /// applied to transparent commands.
 fn config_with_mangling_rule() -> RewriteConfig {
     RewriteConfig {
-        skip: None,
-        pipe: None,
         rewrite: vec![RewriteRule {
             match_pattern: "^(.*)$".to_string(),
             replace: "mangled {0}".to_string(),
         }],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     }
 }
 
@@ -120,18 +115,14 @@ fn user_can_extend_transparent_list() {
     // A user with `kubectl exec` workflows can add `kubectl` to the list.
     let dir = TempDir::new().unwrap();
     let config = RewriteConfig {
-        skip: None,
-        pipe: None,
         rewrite: vec![RewriteRule {
             match_pattern: "^(.*)$".to_string(),
             replace: "mangled {0}".to_string(),
         }],
-        permissions: None,
-        debug: None,
         transparent: Some(types::TransparentConfig {
             commands: vec!["kubectl".to_string()],
         }),
-        local_wrapper: None,
+        ..Default::default()
     };
     let result = rewrite_isolated(
         "kubectl exec POD -- cmd",
@@ -147,18 +138,14 @@ fn user_extra_does_not_disable_built_ins() {
     // Adding kubectl to the user list must not silently turn off ssh.
     let dir = TempDir::new().unwrap();
     let config = RewriteConfig {
-        skip: None,
-        pipe: None,
         rewrite: vec![RewriteRule {
             match_pattern: "^(.*)$".to_string(),
             replace: "mangled {0}".to_string(),
         }],
-        permissions: None,
-        debug: None,
         transparent: Some(types::TransparentConfig {
             commands: vec!["kubectl".to_string()],
         }),
-        local_wrapper: None,
+        ..Default::default()
     };
     let result = rewrite_isolated("ssh HOST cmd", &config, &[dir.path().to_path_buf()], false);
     assert_eq!(result, "ssh HOST cmd");
@@ -257,12 +244,8 @@ fn user_skip_pattern_takes_precedence_over_transparent_gate() {
         skip: Some(types::SkipConfig {
             patterns: vec!["^ssh ".to_string()],
         }),
-        pipe: None,
         rewrite: vec![],
-        permissions: None,
-        debug: None,
-        transparent: None,
-        local_wrapper: None,
+        ..Default::default()
     };
     let result = rewrite_isolated(
         "ssh HOST 'cmd'",

--- a/crates/tokf-cli/src/rewrite/tests_worktree.rs
+++ b/crates/tokf-cli/src/rewrite/tests_worktree.rs
@@ -1,0 +1,307 @@
+//! Integration tests for the linked-worktree git guard.
+//!
+//! Inside a linked git worktree, `git` commands are left unrewritten by
+//! default so that an agent harness enforcing worktree isolation can still
+//! recognise them. Everything else keeps filtering normally.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::fs;
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use super::*;
+use crate::rewrite::test_helpers::{linked_worktree, main_worktree};
+
+/// Options as the hook sets them — the caller the guard exists for.
+fn hook_options() -> RewriteOptions {
+    RewriteOptions {
+        no_mask_exit_code: false,
+        guard_worktree_git: true,
+    }
+}
+
+/// A filter directory covering the commands these tests exercise.
+fn filters() -> (TempDir, Vec<PathBuf>) {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("git-status.toml"),
+        "command = \"git status\"",
+    )
+    .unwrap();
+    fs::write(dir.path().join("git-add.toml"), "command = \"git add\"").unwrap();
+    fs::write(dir.path().join("git-diff.toml"), "command = \"git diff\"").unwrap();
+    fs::write(
+        dir.path().join("cargo-test.toml"),
+        "command = \"cargo test\"",
+    )
+    .unwrap();
+    let paths = vec![dir.path().to_path_buf()];
+    (dir, paths)
+}
+
+fn opt_out() -> RewriteConfig {
+    RewriteConfig {
+        worktree: Some(types::WorktreeConfig { skip_git: false }),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn git_is_not_rewritten_inside_a_linked_worktree() {
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let wt = linked_worktree(home.path());
+
+    let r = rewrite_in_cwd(
+        "git status",
+        &RewriteConfig::default(),
+        &dirs,
+        &wt,
+        &hook_options(),
+    );
+    assert_eq!(r, "git status");
+}
+
+#[test]
+fn git_is_rewritten_in_a_main_worktree() {
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let repo = main_worktree(home.path());
+
+    let r = rewrite_in_cwd(
+        "git status",
+        &RewriteConfig::default(),
+        &dirs,
+        &repo,
+        &hook_options(),
+    );
+    assert_eq!(r, "tokf run git status");
+}
+
+#[test]
+fn non_git_commands_still_filter_inside_a_linked_worktree() {
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let wt = linked_worktree(home.path());
+
+    let r = rewrite_in_cwd(
+        "cargo test",
+        &RewriteConfig::default(),
+        &dirs,
+        &wt,
+        &hook_options(),
+    );
+    assert_eq!(r, "tokf run cargo test");
+}
+
+#[test]
+fn opting_out_restores_git_rewriting_inside_a_linked_worktree() {
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let wt = linked_worktree(home.path());
+
+    let r = rewrite_in_cwd("git status", &opt_out(), &dirs, &wt, &hook_options());
+    assert_eq!(r, "tokf run git status");
+}
+
+#[test]
+fn guard_applies_per_segment_in_a_compound_command() {
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let wt = linked_worktree(home.path());
+
+    let r = rewrite_in_cwd(
+        "git add . && cargo test",
+        &RewriteConfig::default(),
+        &dirs,
+        &wt,
+        &hook_options(),
+    );
+    assert_eq!(r, "git add . && tokf run cargo test");
+}
+
+#[test]
+fn guard_covers_piped_git_commands() {
+    // The piped path rewrites to `tokf run --baseline-pipe …`, which hides the
+    // git invocation just as thoroughly as a plain wrap.
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let wt = linked_worktree(home.path());
+
+    let r = rewrite_in_cwd(
+        "git diff | head -50",
+        &RewriteConfig::default(),
+        &dirs,
+        &wt,
+        &hook_options(),
+    );
+    assert_eq!(r, "git diff | head -50");
+}
+
+#[test]
+fn guard_covers_an_env_prefixed_git_command() {
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let wt = linked_worktree(home.path());
+
+    let r = rewrite_in_cwd(
+        "GIT_PAGER=cat git status",
+        &RewriteConfig::default(),
+        &dirs,
+        &wt,
+        &hook_options(),
+    );
+    assert_eq!(r, "GIT_PAGER=cat git status");
+}
+
+#[test]
+fn guard_covers_git_invoked_by_absolute_path() {
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let wt = linked_worktree(home.path());
+
+    let r = rewrite_in_cwd(
+        "/usr/bin/git status",
+        &RewriteConfig::default(),
+        &dirs,
+        &wt,
+        &hook_options(),
+    );
+    assert_eq!(r, "/usr/bin/git status");
+}
+
+#[test]
+fn guard_does_not_catch_commands_merely_containing_git() {
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let wt = linked_worktree(home.path());
+    fs::write(
+        dirs[0].join("gitleaks.toml"),
+        "command = \"gitleaks detect\"",
+    )
+    .unwrap();
+
+    let r = rewrite_in_cwd(
+        "gitleaks detect",
+        &RewriteConfig::default(),
+        &dirs,
+        &wt,
+        &hook_options(),
+    );
+    assert_eq!(r, "tokf run gitleaks detect");
+}
+
+#[test]
+fn user_rewrite_rules_for_git_are_also_suppressed_in_a_linked_worktree() {
+    // A user `[[rewrite]]` rule produces the same opaque wrapper, so the guard
+    // has to win over it — otherwise the escape hatch leaks the problem back.
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let wt = linked_worktree(home.path());
+    let config = RewriteConfig {
+        rewrite: vec![types::RewriteRule {
+            match_pattern: "^git status".to_string(),
+            replace: "tokf summary {0}".to_string(),
+        }],
+        ..Default::default()
+    };
+
+    let r = rewrite_in_cwd("git status", &config, &dirs, &wt, &hook_options());
+    assert_eq!(r, "git status");
+}
+
+#[test]
+fn no_guard_outside_a_repository() {
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let plain = home.path().join("plain");
+    fs::create_dir_all(&plain).unwrap();
+
+    let r = rewrite_in_cwd(
+        "git status",
+        &RewriteConfig::default(),
+        &dirs,
+        &plain,
+        &hook_options(),
+    );
+    assert_eq!(r, "tokf run git status");
+}
+
+#[test]
+fn no_guard_in_a_submodule() {
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let sub = home.path().join("sub");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(sub.join(".git"), "gitdir: ../.git/modules/sub\n").unwrap();
+
+    let r = rewrite_in_cwd(
+        "git status",
+        &RewriteConfig::default(),
+        &dirs,
+        &sub,
+        &hook_options(),
+    );
+    assert_eq!(r, "tokf run git status");
+}
+
+#[test]
+fn shell_mode_keeps_git_filtering_inside_a_linked_worktree() {
+    // `tokf -c` (make/just, PATH shims) hands its result to `sh`. Nothing
+    // re-reads it, so there is no reason to give up the filter there.
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let wt = linked_worktree(home.path());
+
+    let shell = RewriteOptions {
+        no_mask_exit_code: true,
+        guard_worktree_git: false,
+    };
+    let r = rewrite_in_cwd("git status", &RewriteConfig::default(), &dirs, &wt, &shell);
+    assert_eq!(r, "tokf run --no-mask-exit-code git status");
+}
+
+#[test]
+fn user_rewrite_rules_are_suppressed_for_a_guarded_compound_segment() {
+    // The rule matches the whole command string, so firing it would splice a
+    // wrapper back in front of the git half the guard has to keep legible.
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let wt = linked_worktree(home.path());
+    let config = RewriteConfig {
+        rewrite: vec![types::RewriteRule {
+            match_pattern: "^git add".to_string(),
+            replace: "tokf summary {0}".to_string(),
+        }],
+        ..Default::default()
+    };
+
+    let r = rewrite_in_cwd(
+        "git add . && cargo test",
+        &config,
+        &dirs,
+        &wt,
+        &hook_options(),
+    );
+    assert_eq!(r, "git add . && tokf run cargo test");
+}
+
+#[test]
+fn quoted_git_is_guarded() {
+    // Shared `first_command_basename` handles quoting; the hand-rolled
+    // word-split it replaced did not.
+    let (_f, dirs) = filters();
+    let home = TempDir::new().unwrap();
+    let wt = linked_worktree(home.path());
+
+    let r = rewrite_in_cwd(
+        "'git' status",
+        &RewriteConfig::default(),
+        &dirs,
+        &wt,
+        &hook_options(),
+    );
+    assert_eq!(r, "'git' status");
+}

--- a/crates/tokf-cli/src/rewrite/types.rs
+++ b/crates/tokf-cli/src/rewrite/types.rs
@@ -1,6 +1,6 @@
 pub use tokf_hook_types::{
     CaptureExit, LocalWrapperConfig, LocalWrapperRule, PermissionEngineType, PermissionsConfig,
-    PipeConfig, RewriteConfig, RewriteRule, SkipConfig, TransparentConfig,
+    PipeConfig, RewriteConfig, RewriteRule, SkipConfig, TransparentConfig, WorktreeConfig,
 };
 
 /// Options that control how the rewrite system generates `tokf run` commands.
@@ -9,6 +9,16 @@ pub struct RewriteOptions {
     /// When true, inject `--no-mask-exit-code` into generated `tokf run` commands.
     /// Used by shell/shim mode where the real exit code must propagate.
     pub no_mask_exit_code: bool,
+
+    /// When true, leave `git` commands unrewritten inside a linked git
+    /// worktree so they stay legible to a harness that re-reads them.
+    ///
+    /// Only callers whose output is statically re-parsed need this: the hook
+    /// path, and `tokf rewrite`, which exists to show what the hook would
+    /// emit. Shell mode (`tokf -c`, invoked by `make`/`just`) and the PATH
+    /// shims hand their result straight to `sh`, so nothing re-reads it and
+    /// there is no reason for them to give up the filter.
+    pub guard_worktree_git: bool,
 }
 
 #[cfg(test)]
@@ -41,6 +51,28 @@ replace = "tokf run {0}"
         assert_eq!(config.rewrite[0].match_pattern, "^docker compose");
         assert_eq!(config.rewrite[0].replace, "tokf run {0}");
         assert_eq!(config.rewrite[1].match_pattern, "^kubectl (get|describe)");
+    }
+
+    #[test]
+    fn deserialize_worktree_section_defaults() {
+        let config: RewriteConfig = toml::from_str("[worktree]\n").unwrap();
+        let wt = config.worktree.unwrap();
+        assert!(wt.skip_git, "skip_git should default to true");
+    }
+
+    #[test]
+    fn deserialize_worktree_opt_out() {
+        let config: RewriteConfig = toml::from_str("[worktree]\nskip_git = false\n").unwrap();
+        assert!(!config.worktree.unwrap().skip_git);
+    }
+
+    #[test]
+    fn worktree_section_absent_means_guard_on() {
+        // No section at all is the common case, and it must behave the same as
+        // an empty `[worktree]` section: the guard is on.
+        let config: RewriteConfig = toml::from_str("").unwrap();
+        assert!(config.worktree.is_none());
+        assert!(WorktreeConfig::default().skip_git);
     }
 
     #[test]

--- a/crates/tokf-cli/src/rewrite/worktree.rs
+++ b/crates/tokf-cli/src/rewrite/worktree.rs
@@ -1,0 +1,256 @@
+//! The linked git worktree guard.
+//!
+//! An agent harness can isolate an agent to its own git worktree and enforce
+//! that by statically parsing each command before running it. Rewriting
+//! `git status` to `tokf run git status` puts an opaque wrapper in front of
+//! the invocation the harness needs to read, so it refuses to run the command
+//! at all. Leaving `git` alone inside a linked worktree keeps it legible.
+//!
+//! Detection reads git's own on-disk layout rather than matching a path
+//! convention, so it holds for any worktree wherever it lives — a harness
+//! directory like `.claude/worktrees/agent-x`, a sibling `../feature-y`, or
+//! anything else `git worktree add` was pointed at.
+//!
+//! The rule git itself uses: in the **main** worktree `.git` is a directory;
+//! in a **linked** worktree `.git` is a file holding `gitdir: <path>`, and
+//! that path is `<common-dir>/worktrees/<id>`. Submodules also use a `.git`
+//! file, but theirs points at `<common-dir>/modules/<name>` — so the parent
+//! component of the target is what separates the two cases.
+
+use std::cell::OnceCell;
+use std::path::Path;
+
+use super::bash_ast::first_command_basename;
+use super::types::{RewriteConfig, RewriteOptions};
+use crate::runtime::Runtime;
+
+/// Decides whether a command should be left unrewritten to stay legible to a
+/// harness that re-reads it.
+///
+/// The filesystem walk is deferred and memoised: [`Self::claims`] tests the
+/// command's shape first, so the overwhelming majority of commands an agent
+/// runs — none of which are `git` — never touch the disk. That matters
+/// because the guard sits on the hook path, which runs on every command.
+pub struct GitGuard<'a> {
+    /// Directory to inspect, or `None` when the guard cannot apply at all:
+    /// the caller opted out, the user disabled it, or the cwd is unknown.
+    /// Storing the disabled case as `None` keeps the check to one branch.
+    cwd: Option<&'a Path>,
+    verbose: bool,
+    /// Memoised ancestor walk, forced by the first `git` command seen.
+    inside: OnceCell<bool>,
+}
+
+impl<'a> GitGuard<'a> {
+    /// Build a guard for this rewrite.
+    ///
+    /// Both opt-outs are folded in here — `options` for callers whose output
+    /// nothing re-parses, and the user's `[worktree] skip_git` — so that a
+    /// disabled guard costs one `Option` test per command and no I/O.
+    pub fn new(
+        rt: &'a Runtime,
+        user_config: &RewriteConfig,
+        options: &RewriteOptions,
+        verbose: bool,
+    ) -> Self {
+        let enabled =
+            options.guard_worktree_git && user_config.worktree.as_ref().is_none_or(|w| w.skip_git);
+        Self {
+            cwd: enabled.then(|| rt.cwd()).flatten(),
+            verbose,
+            inside: OnceCell::new(),
+        }
+    }
+
+    /// True when `command` is a `git` invocation inside a linked worktree.
+    ///
+    /// Evaluated per segment rather than per command line: in
+    /// `git add . && cargo test` only the git half needs to stay legible, and
+    /// the cargo half should keep its filter.
+    pub fn claims(&self, command: &str) -> bool {
+        is_git_invocation(command) && self.inside_linked_worktree()
+    }
+
+    /// True when **any** segment of a compound command is claimed.
+    ///
+    /// Mirrors [`super::transparent::any_segment_is_transparent`], and exists
+    /// for the same reason: user `[[rewrite]]` rules match against the whole
+    /// command string, so one guarded segment anywhere — even behind a
+    /// `cd … &&` — is enough to make splicing a wrapper into it unsafe.
+    pub fn claims_any_segment(&self, segments: &[(String, String)]) -> bool {
+        segments.iter().any(|(seg, _)| self.claims(seg.trim()))
+    }
+
+    /// The memoised filesystem walk, forced at most once per rewrite.
+    fn inside_linked_worktree(&self) -> bool {
+        let Some(cwd) = self.cwd else {
+            return false;
+        };
+        *self.inside.get_or_init(|| {
+            let inside = in_linked_worktree(cwd);
+            if inside && self.verbose {
+                eprintln!(
+                    "[tokf] worktree: linked git worktree detected, leaving git commands \
+                     unrewritten (set [worktree] skip_git = false in rewrites.toml to filter \
+                     them anyway)"
+                );
+            }
+            inside
+        })
+    }
+}
+
+/// True when the first word of `command` invokes `git`.
+///
+/// Shares [`first_command_basename`] with the transparent-command check, so
+/// quoted (`'git' status`), path-qualified (`/usr/bin/git status`) and
+/// env-prefixed (`GIT_PAGER=cat git log`) forms are all recognised the same
+/// way here as everywhere else in the rewrite engine.
+fn is_git_invocation(command: &str) -> bool {
+    first_command_basename(command).is_some_and(|name| name == "git")
+}
+
+/// True when `dir` — or the nearest ancestor holding a `.git` entry — is a
+/// linked git worktree.
+///
+/// Returns false for the main worktree, for submodules, and for a path that is
+/// not in a git repository at all. Anything unreadable or malformed is also
+/// false: a wrong "yes" silently costs the user filtering on every `git`
+/// command, so ambiguity resolves toward normal behaviour.
+fn in_linked_worktree(dir: &Path) -> bool {
+    // `ancestors()` stops at the filesystem root on its own; a repository
+    // boundary is whichever ancestor carries `.git` first.
+    for ancestor in dir.ancestors() {
+        let dot_git = ancestor.join(".git");
+        let Ok(meta) = std::fs::symlink_metadata(&dot_git) else {
+            continue;
+        };
+        // Whatever `.git` is here settles the question, so stop rather than
+        // walking on into an enclosing repository: a directory is the main
+        // worktree, and a symlink or anything else exotic we won't guess at.
+        return meta.is_file()
+            && std::fs::read_to_string(&dot_git)
+                .is_ok_and(|contents| gitdir_points_into_worktrees(&contents));
+    }
+    false
+}
+
+/// True when a `.git` file's `gitdir:` line has the
+/// `<common-dir>/worktrees/<id>` shape.
+///
+/// Only the first line is read — that is all git writes — and the value is
+/// trimmed, since git terminates the line with a newline. An empty value
+/// needs no separate guard: `Path::new("").parent()` is `None`.
+///
+/// Checking the parent component rather than searching for `worktrees`
+/// anywhere in the path keeps a repository that merely *lives* under a
+/// directory called `worktrees` from being misread as a linked worktree. The
+/// path is compared as written: `git worktree add --relative-paths` records
+/// `../../.git/worktrees/<id>`, which has the same shape.
+fn gitdir_points_into_worktrees(contents: &str) -> bool {
+    let Some(value) = contents
+        .lines()
+        .next()
+        .and_then(|line| line.strip_prefix("gitdir:"))
+    else {
+        return false;
+    };
+    Path::new(value.trim())
+        .parent()
+        .and_then(Path::file_name)
+        .is_some_and(|name| name == "worktrees")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::rewrite::test_helpers::{linked_worktree, main_worktree};
+
+    #[test]
+    fn main_worktree_is_not_linked() {
+        let dir = TempDir::new().unwrap();
+        assert!(!in_linked_worktree(&main_worktree(dir.path())));
+    }
+
+    #[test]
+    fn linked_worktree_is_detected() {
+        let dir = TempDir::new().unwrap();
+        assert!(in_linked_worktree(&linked_worktree(dir.path())));
+    }
+
+    #[test]
+    fn linked_worktree_detected_from_nested_subdirectory() {
+        let dir = TempDir::new().unwrap();
+        let wt = linked_worktree(dir.path());
+        let nested = wt.join("crates").join("thing").join("src");
+        fs::create_dir_all(&nested).unwrap();
+        assert!(in_linked_worktree(&nested));
+    }
+
+    #[test]
+    fn main_worktree_shadows_an_enclosing_linked_worktree() {
+        // The first `.git` found wins, so a plain repo checked out inside a
+        // worktree is judged on its own layout.
+        let dir = TempDir::new().unwrap();
+        let wt = linked_worktree(dir.path());
+        assert!(!in_linked_worktree(&main_worktree(&wt)));
+    }
+
+    #[test]
+    fn outside_a_repository_is_not_linked() {
+        let dir = TempDir::new().unwrap();
+        assert!(!in_linked_worktree(dir.path()));
+    }
+
+    #[test]
+    fn unreadable_git_file_is_not_linked() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join(".git"), "not a gitdir line\n").unwrap();
+        assert!(!in_linked_worktree(dir.path()));
+    }
+
+    #[test]
+    fn gitdir_shapes() {
+        // Linked worktrees, including the `--relative-paths` form (git 2.48+)
+        // and names containing spaces.
+        assert!(gitdir_points_into_worktrees(
+            "gitdir: /repo/.git/worktrees/x\n"
+        ));
+        assert!(gitdir_points_into_worktrees(
+            "gitdir: ../../.git/worktrees/agent-x\n"
+        ));
+        assert!(gitdir_points_into_worktrees(
+            "gitdir: /repo/.git/worktrees/my branch\n"
+        ));
+        // Submodule.
+        assert!(!gitdir_points_into_worktrees(
+            "gitdir: ../.git/modules/sub\n"
+        ));
+        // A repository that merely lives under a directory named `worktrees`.
+        assert!(!gitdir_points_into_worktrees(
+            "gitdir: /home/me/worktrees/project/.git\n"
+        ));
+        // Malformed or absent values.
+        assert!(!gitdir_points_into_worktrees("gitdir:   \n"));
+        assert!(!gitdir_points_into_worktrees("not a gitdir line\n"));
+        assert!(!gitdir_points_into_worktrees("ref: refs/heads/main\n"));
+        assert!(!gitdir_points_into_worktrees(""));
+    }
+
+    #[test]
+    fn git_invocation_shapes() {
+        assert!(is_git_invocation("git status"));
+        assert!(is_git_invocation("/usr/bin/git status"));
+        assert!(is_git_invocation("GIT_PAGER=cat git log"));
+        // Shared with the transparent-command check, so quoting is handled.
+        assert!(is_git_invocation("'git' status"));
+        assert!(!is_git_invocation("gitleaks detect"));
+        assert!(!is_git_invocation("legit status"));
+        assert!(!is_git_invocation(""));
+    }
+}

--- a/crates/tokf-cli/src/shell.rs
+++ b/crates/tokf-cli/src/shell.rs
@@ -52,6 +52,9 @@ fn rewrite_and_delegate(rt: &Runtime, flags: &str, command: &str, verbose: bool)
 
     let options = tokf::rewrite::types::RewriteOptions {
         no_mask_exit_code: true,
+        // Shell mode's output goes straight to `sh`, never back to a harness
+        // that re-parses it, so git keeps its filter even inside a worktree.
+        guard_worktree_git: false,
     };
     let rewritten = tokf::rewrite::rewrite_with_options(rt, command, verbose, &options);
 
@@ -119,6 +122,9 @@ pub fn cmd_shell_argv(rt: &Runtime, flags: &str, args: &[String]) -> i32 {
     let unquoted = args.join(" ");
     let options = tokf::rewrite::types::RewriteOptions {
         no_mask_exit_code: true,
+        // Shell mode's output goes straight to `sh`, never back to a harness
+        // that re-parses it, so git keeps its filter even inside a worktree.
+        guard_worktree_git: false,
     };
     let rewritten = tokf::rewrite::rewrite_with_options(rt, &unquoted, verbose, &options);
 

--- a/crates/tokf-hook-types/src/config.rs
+++ b/crates/tokf-hook-types/src/config.rs
@@ -38,6 +38,35 @@ pub struct RewriteConfig {
     /// are local, so the whole command is wrapped with `tokf run` and its
     /// output filtered. See issue #403.
     pub local_wrapper: Option<LocalWrapperConfig>,
+
+    /// Behaviour inside linked git worktrees (`git worktree add`).
+    pub worktree: Option<WorktreeConfig>,
+}
+
+/// Behaviour inside a **linked** git worktree.
+///
+/// A linked worktree is one created by `git worktree add`, whose `.git` is a
+/// file pointing into the main repository's `.git/worktrees/<id>` directory.
+///
+/// Agent harnesses that isolate an agent to its own worktree verify that git
+/// operations stay inside it, and they do that by parsing the command string.
+/// Once tokf rewrites `git status` to `tokf run git status`, the leading word
+/// is an opaque wrapper and the check can no longer see the git invocation it
+/// was meant to inspect, so it refuses to run the command. Leaving `git`
+/// alone inside a linked worktree keeps those commands legible; every other
+/// command is still filtered normally.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WorktreeConfig {
+    /// Leave `git` commands unrewritten while inside a linked worktree.
+    /// Default: true.
+    #[serde(default = "default_true")]
+    pub skip_git: bool,
+}
+
+impl Default for WorktreeConfig {
+    fn default() -> Self {
+        Self { skip_git: true }
+    }
 }
 
 /// "Transparent-arg" commands: their last argument is opaque shell code.

--- a/crates/tokf-hook-types/src/lib.rs
+++ b/crates/tokf-hook-types/src/lib.rs
@@ -5,7 +5,7 @@ pub mod verdict;
 
 pub use config::{
     CaptureExit, LocalWrapperConfig, LocalWrapperRule, PermissionEngineType, PermissionsConfig,
-    PipeConfig, RewriteConfig, RewriteRule, SkipConfig, TransparentConfig,
+    PipeConfig, RewriteConfig, RewriteRule, SkipConfig, TransparentConfig, WorktreeConfig,
 };
 pub use engine::{ErrorFallback, ExternalEngineConfig};
 pub use format::HookFormat;

--- a/docs/rewrites-config.md
+++ b/docs/rewrites-config.md
@@ -93,6 +93,57 @@ match = "^(?:[^\\s]*/)?mise run(\\s.*)?$"
 replace = "SHELL=tokf mise run{1}"
 ```
 
+## Git commands inside worktrees
+
+When the working directory is inside a **linked** git worktree — one created by
+`git worktree add` — tokf leaves `git` commands unrewritten:
+
+```sh
+# In the main checkout:
+git status          →  tokf run git status
+
+# In a linked worktree:
+git status          →  git status          (unchanged)
+cargo test          →  tokf run cargo test (still filtered)
+```
+
+This exists because of agent harnesses that isolate an agent to its own
+worktree. They verify that git operations stay inside that worktree by reading
+the command string, and once tokf rewrites `git status` to
+`tokf run git status` the leading word is an opaque wrapper — the check can no
+longer see the git invocation it was meant to inspect, so it refuses to run the
+command at all. Leaving `git` alone keeps those commands legible. Every other
+command in the worktree is still filtered normally.
+
+Detection reads git's own on-disk layout, not a path convention: a linked
+worktree's `.git` is a *file* containing `gitdir: <common-dir>/worktrees/<id>`,
+where the main worktree's `.git` is a directory. So it holds for any worktree
+wherever it lives, and submodules — whose `.git` file points at
+`<common-dir>/modules/<name>` — are correctly left out.
+
+The guard applies per segment, so a compound command keeps the filters it can:
+
+```sh
+git add . && cargo test   →  git add . && tokf run cargo test
+```
+
+It applies only where something re-reads the rewritten command: the hook, and
+`tokf rewrite`, which exists to show what the hook would emit. Shell mode
+(`tokf -c`, used by the `make` and `just` wrappers) and the PATH shims hand
+their result straight to `sh`, so a `just` recipe running `git log` inside a
+worktree keeps its filter.
+
+To turn it off and filter git inside worktrees as well:
+
+```toml
+# .tokf/rewrites.toml
+[worktree]
+skip_git = false
+```
+
+Run `tokf rewrite --verbose "git status"` from inside a worktree to see whether
+the guard is active.
+
 ## Routing to generic commands
 
 For commands that don't have a dedicated filter, you can route them through [generic commands](generic-commands.md) (`tokf err`, `tokf test`, `tokf summary`) via rewrite rules:


### PR DESCRIPTION
## The problem

An agent harness can isolate an agent to its own git worktree and enforce that by statically parsing each command before it runs. tokf's hook rewrites `git add backend` into `tokf run git add backend` — and the harness then evaluates the *rewritten* command, sees an opaque wrapper as the leading token, cannot prove the git operation stays inside the worktree, and refuses to run it:

> This agent is isolated in the worktree `…/agent-a9c0f9cb…`, but this command runs tokf with the text `git add backend` in a plain command, so what it runs cannot be shown not to be git. Refusing to run it.

The agent is blocked from ordinary work. The harness accepted the hook, then refused the hook's own output.

## The fix

Leave `git` unrewritten when the working directory is inside a linked git worktree. Everything else still filters:

```
IN LINKED WORKTREE                       IN MAIN CHECKOUT
  git add backend      → unchanged         git add backend → tokf run git add backend
  git diff | head -50  → unchanged         git status      → tokf run git status
  cargo test           → tokf run cargo test
  git add . && cargo test → git add . && tokf run cargo test
```

**Detection reads git's own on-disk layout, not a path convention.** A linked worktree's `.git` is a *file* holding `gitdir: <common-dir>/worktrees/<id>`; the main worktree's `.git` is a directory. Checking the *parent component* of that path is what separates a worktree from a submodule (`<common-dir>/modules/<name>`) and keeps a repo that merely lives under a directory named `worktrees` from being a false positive. Handles `git worktree add --relative-paths` (git 2.48+), nested subdirectories, and names with spaces. No subprocess.

**Scoped to callers whose output is re-read.** The hook needs this; so does `tokf rewrite`, which exists to show what the hook would emit. Shell mode (`tokf -c`, used by the `make`/`just` wrappers) and the PATH shims hand their result straight to `sh` — nothing re-parses it, so a `just` recipe running `git log` in a worktree keeps its filter. Threaded through the existing `RewriteOptions`, the same way `no_mask_exit_code` already is.

**Off the hot path.** The guard sits on the hook, which runs on every command an agent issues. The filesystem walk is deferred behind the command-shape test and memoised, so non-git commands never touch the disk.

## Config

```toml
# .tokf/rewrites.toml
[worktree]
skip_git = false   # opt out: filter git inside worktrees too
```

## Tradeoff

This fires for **all** linked worktrees, including ones a human created for their own development — those lose git filtering they didn't ask to lose. There is no sharper signal available: the hook payload carries `session_id`, `cwd`, `permission_mode` and friends, but nothing that declares agent isolation, and no `CLAUDE_*` env var distinguishes the two cases. `skip_git = false` is the documented way out.

## Verification

Tested end to end against a real `git worktree add` worktree (output above), plus 26 new unit and integration tests covering detection (main/linked/submodule/nested/relative-paths/outside-a-repo/malformed), the guard (per-segment, piped, env-prefixed, path-qualified, quoted, opt-out, shell-mode carve-out, user-rule suppression), and config deserialization.

Full workspace tests, `clippy --workspace --all-targets -D warnings`, `cargo fmt --check`, and the file-size check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
